### PR TITLE
Rebrand as maintenance fork

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -29,9 +29,9 @@ addon_info = {
 	# Author(s)
 	"addon_author": "Musharraf Omer <ibnomer2011@hotmail.com>",
 	# URL for the add-on documentation support
-	"addon_url": None,
+	"addon_url": "https://github.com/austek/sonata-nvda",
 	# URL for the add-on repository where the source code can be found
-	"addon_sourceURL": "https://github.com/mush42/sonata-nvda",
+	"addon_sourceURL": "https://github.com/austek/sonata-nvda",
 	# Documentation file name
 	"addon_docFileName": "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # Sonata neural voices for NVDA
 
+> **Maintenance fork notice**
+>
+> The original author, Musharraf Omer ([@mush42](https://github.com/mush42)), [announced on the NVDA Add-ons list](https://nvda-addons.groups.io/g/nvda-addons/message/27636) that commercial contract conflicts prevent him from continuing to maintain this open-source add-on. This fork continues the project to keep the add-on working on current NVDA releases (2026.1+). All credit for the original work belongs to Musharraf Omer; this fork only carries minimal compatibility fixes.
+
 This add-on implements a speech synthesizer driver for NVDA using neural TTS models. It supports [Piper](https://github.com/rhasspy/piper).
 
 [Piper](https://github.com/rhasspy/piper) is a fast, local neural text to speech system that sounds great and is optimized for low-end devices such as the Raspberry Pi.
@@ -13,7 +17,11 @@ This add-on uses [Sonata: A cross-platform Rust engine for neural TTS models](ht
 
 ## Downloading the add-on
 
-You can find the add-on package under the assets section of the [release page](https://github.com/mush42/sonata-nvda/releases/latest)
+You can find the add-on package under the assets section of the [release page](https://github.com/austek/sonata-nvda/releases/latest).
+
+## Reporting issues
+
+Please report bugs and feature requests on the [issue tracker for this fork](https://github.com/austek/sonata-nvda/issues).
 
 ## Adding voices
 


### PR DESCRIPTION
## Summary

The original author, Musharraf Omer (@mush42), [announced on the NVDA Add-ons list](https://nvda-addons.groups.io/g/nvda-addons/message/27636) that commercial contract conflicts prevent him from maintaining the upstream project. This PR repositions this fork as the active maintenance source.

Scope is intentionally minimal: just the rebrand metadata. NVDA 2026.1 compatibility work and code fixes will land in a separate follow-up PR.

## Changes

- `readme.md` — banner crediting Musharraf Omer for the original work and linking to the announcement, install instructions point at this fork's releases, pointer to this fork's issue tracker.
- `buildVars.py` — `addon_url` and `addon_sourceURL` switched to this fork. `addon_author` left as Musharraf Omer — this fork carries minimal compatibility fixes, original authorship is intact.

Repository setting change (already applied, not in the diff): issues are now enabled on this fork.

## Test plan

- [ ] CI green on the PR.
- [ ] Confirm README banner renders correctly on GitHub.