### PR TITLE
Fix voice list not refreshing after download (closes #5)

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
@@ -95,11 +95,6 @@ class InstalledSonataVoicesPanel(SizedPanel):
 
     def invalidate_cache(self):
         self.__already_populated.clear()
-        if "sonata" in synthDriverHandler.getSynth().name.lower():
-            if invalidate_synth_voices_cache:
-                synth = synthDriverHandler.getSynth()
-                synth.terminate()
-                synth.__init__()
 
     def _get_installed_voice_name(self, voice):
         return f"{voice.name} ({voice.variant})"


### PR DESCRIPTION
Closes #5.

## Summary

After a successful voice download, the "Download" tab in the voice manager keeps showing the just-installed voice instead of dropping it. Root cause is a `NameError` in `InstalledSonataVoicesPanel.invalidate_cache()` that aborts the panel-iteration loop before reaching the Online panel.

Originally reported as upstream [mush42/sonata-nvda#30](https://github.com/mush42/sonata-nvda/issues/30) by @Turkrosoft in 2023-11. Mirrored on this fork as #5.

## Diagnosis

`voice_manager.py:96-102`:

```python
def invalidate_cache(self):
    self.__already_populated.clear()
    if "sonata" in synthDriverHandler.getSynth().name.lower():
        if invalidate_synth_voices_cache:   # NameError — not in scope here
            synth = synthDriverHandler.getSynth()
            synth.terminate()
            synth.__init__()
```

`invalidate_synth_voices_cache` is a parameter of `update_voices_list(self, set_focus=False, invalidate_synth_voices_cache=False)` further up in the same class — it was copy-pasted into `invalidate_cache` but the parameter never propagates here, so when the active synth is Sonata the method raises `NameError`.

Cascade:
1. Download completes → `success_callback` → `_invalidate_pages_voice_cache()`.
2. That iterates panels in notebook order; "Installed" is added first, so its `invalidate_cache` runs first.
3. `NameError` aborts the loop. `OnlineSonataVoicesPanel.invalidate_cache` never runs → its `__already_populated` flag stays set.
4. `wx.CallAfter(self.populate_list)` returns early because the flag is set → list doesn't refresh.

## Fix

Drop the broken `if`-block. `update_voices_list` already handles the synth-restart from its explicit callers (`update_voices_list(invalidate_synth_voices_cache=True)` at `voice_manager.py:182,227`).

```diff
     def invalidate_cache(self):
         self.__already_populated.clear()
-        if "sonata" in synthDriverHandler.getSynth().name.lower():
-            if invalidate_synth_voices_cache:
-                synth = synthDriverHandler.getSynth()
-                synth.terminate()
-                synth.__init__()
```

The block was dead code anyway — the `NameError` made the inner statements unreachable on every invocation. No regression risk.

## Test plan

- [x] AST parses (`python3 -c "import ast; ast.parse(...)"`).
- [ ] CI green (`build` + `test`).
- [ ] Manual verification on NVDA 2026 once next release is cut: download a voice, observe the Download tab drops it immediately and the Installed tab shows it after a tab switch.