### PR TITLE
Fall back to config metadata when voice archive filename is non-standard (closes #10)

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
@@ -477,6 +477,52 @@ class PiperRTVoiceDownloader:
             done_callback(result)
 
 
+def _voice_key_from_filename(stem):
+    """Derive a voice_key from a filename stem like 'en_US-lessac-medium'.
+
+    Returns the voice_key or None if the stem doesn't match the expected
+    <language>-<name>-<quality> form.
+    """
+    m = VOICE_INFO_REGEX.match(stem)
+    if m is None:
+        return None
+    info = m.groupdict()
+    return "-".join([
+        normalizeLanguage(info["language"]),
+        info["name"].replace("-", "_"),
+        info["quality"].replace("-", "_"),
+    ])
+
+
+def _voice_key_from_config(config):
+    """Derive a voice_key from a Piper voice config dict.
+
+    Used as a fallback when the filename doesn't follow the
+    <language>-<name>-<quality> convention. Modern Piper configs carry
+    `language.code`, `dataset`, and `audio.quality` — enough to construct
+    a unique key without relying on the filename.
+
+    Raises ValueError if the config is missing any required field.
+    """
+    try:
+        language = config["language"]["code"]
+        dataset = config["dataset"]
+        quality = config["audio"]["quality"]
+    except (KeyError, TypeError):
+        raise ValueError(
+            "Voice config is missing required fields (language.code, dataset, "
+            "audio.quality). The archive filename also didn't follow the "
+            "<language>-<name>-<quality> convention. Either rename the .onnx "
+            "file to follow that convention, or ensure the bundled config "
+            "JSON carries those fields."
+        )
+    return "-".join([
+        normalizeLanguage(language),
+        str(dataset).replace("-", "_"),
+        str(quality).replace("-", "_"),
+    ])
+
+
 def install_voice_from_tar_archive(tar_path, voices_dir):
     tar = tarfile.open(tar_path)
     filenames = {f.name: f for f in tar.getmembers()}
@@ -491,17 +537,12 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
     if not (onnx_files and config_files):
         raise FileNotFoundError("Required files not found in archive")
     if len(onnx_files) == 1:
-        voice_info = VOICE_INFO_REGEX.match(Path(onnx_files[0]).stem)
+        voice_key = _voice_key_from_filename(Path(onnx_files[0]).stem)
     else:
-        voice_info = VOICE_INFO_REGEX.match(Path(tar_path).stem[:-4])
-    if voice_info is None:
-        raise FileNotFoundError("Required files not found in archive")
-    info = voice_info.groupdict()
-    voice_key = "-".join([
-        normalizeLanguage(info["language"]),
-        info["name"].replace("-", "_"),
-        info["quality"].replace("-", "_"),
-    ])
+        voice_key = _voice_key_from_filename(Path(tar_path).stem[:-4])
+    if voice_key is None:
+        config = json.loads(tar.extractfile(filenames[config_files[0]]).read().decode("utf-8"))
+        voice_key = _voice_key_from_config(config)
     voice_folder_name = Path(voices_dir).joinpath(voice_key)
     voice_folder_name.mkdir(parents=True, exist_ok=True)
     voice_folder_name = os.fspath(voice_folder_name)

--- a/tests/test_voice_key_helpers.py
+++ b/tests/test_voice_key_helpers.py
@@ -1,0 +1,134 @@
+# coding: utf-8
+"""
+Tests for the voice-key derivation helpers in voice_download.py:
+
+  - _voice_key_from_filename(stem)  -> str | None
+  - _voice_key_from_config(config)  -> str  (raises ValueError on missing fields)
+
+These helpers feed `install_voice_from_tar_archive` — the filename path is the
+fast path; the config path is the fallback used when a user provides an
+archive whose .onnx file doesn't follow the
+<language>-<name>-<quality> naming convention (upstream bug
+mush42/sonata-nvda#47).
+
+The helpers are extracted from voice_download.py as text rather than imported
+because voice_download depends on NVDA-only modules. `normalizeLanguage` is
+stubbed as identity for the exec namespace.
+"""
+
+import os
+import re
+
+import pytest
+
+
+_VOICE_DOWNLOAD_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "addon",
+    "globalPlugins",
+    "sonata_tts_global_plugin",
+    "voice_download.py",
+)
+
+
+def _load_helpers():
+    """Extract VOICE_INFO_REGEX + the two helpers and exec them in a clean
+    namespace with a stubbed normalizeLanguage."""
+    with open(_VOICE_DOWNLOAD_PATH, encoding="utf-8") as f:
+        src = f.read()
+
+    regex_match = re.search(
+        r"VOICE_INFO_REGEX\s*=\s*re\.compile\(\s*(.*?)\)\s*\n",
+        src,
+        re.DOTALL,
+    )
+    assert regex_match, "VOICE_INFO_REGEX not found"
+
+    fn_match = re.search(
+        r"def _voice_key_from_filename\(stem\):.*?(?=\ndef )",
+        src,
+        re.DOTALL,
+    )
+    assert fn_match, "_voice_key_from_filename not found"
+
+    cfg_match = re.search(
+        r"def _voice_key_from_config\(config\):.*?(?=\ndef )",
+        src,
+        re.DOTALL,
+    )
+    assert cfg_match, "_voice_key_from_config not found"
+
+    ns = {"re": re, "normalizeLanguage": lambda x: x}
+    exec(f"VOICE_INFO_REGEX = re.compile({regex_match.group(1)})", ns)
+    exec(fn_match.group(0), ns)
+    exec(cfg_match.group(0), ns)
+    return ns["_voice_key_from_filename"], ns["_voice_key_from_config"]
+
+
+_voice_key_from_filename, _voice_key_from_config = _load_helpers()
+
+
+class TestVoiceKeyFromFilename:
+    @pytest.mark.parametrize("stem,expected", [
+        ("en_US-lessac-medium", "en_US-lessac-medium"),
+        ("en_GB-southern_english_female-low", "en_GB-southern_english_female-low"),
+        ("pl_PL-mls_6892-low", "pl_PL-mls_6892-low"),
+        ("vi_VN-vivos-x_low", "vi_VN-vivos-x_low"),
+        ("en_US-amy+RT-medium", "en_US-amy+RT-medium"),
+    ])
+    def test_parses_canonical(self, stem, expected):
+        assert _voice_key_from_filename(stem) == expected
+
+    @pytest.mark.parametrize("stem", [
+        "aivars",              # the case from upstream #47 — no separators at all
+        "voice",                # single word
+        "aivars-medium",       # missing language part
+        "en-foo-banana",       # quality not in {high,medium,low,x-low,x_low}
+    ])
+    def test_returns_none_on_mismatch(self, stem):
+        assert _voice_key_from_filename(stem) is None
+
+
+class TestVoiceKeyFromConfig:
+    """Modern Piper configs have language.code, dataset, audio.quality —
+    enough to construct a voice_key even when the filename is non-standard.
+    """
+
+    @pytest.mark.parametrize("config,expected", [
+        (
+            {"language": {"code": "en_US"}, "dataset": "lessac", "audio": {"quality": "medium"}},
+            "en_US-lessac-medium",
+        ),
+        (
+            {"language": {"code": "lv_LV"}, "dataset": "aivars", "audio": {"quality": "medium"}},
+            "lv_LV-aivars-medium",
+        ),
+        (
+            {"language": {"code": "pl_PL"}, "dataset": "mls_6892", "audio": {"quality": "low"}},
+            "pl_PL-mls_6892-low",
+        ),
+    ])
+    def test_derives_key(self, config, expected):
+        assert _voice_key_from_config(config) == expected
+
+    def test_replaces_dashes_in_dataset(self):
+        """Dashes inside dataset/quality would break the X-Y-Z structure of voice_key."""
+        config = {"language": {"code": "en_US"}, "dataset": "my-dataset", "audio": {"quality": "medium"}}
+        assert _voice_key_from_config(config) == "en_US-my_dataset-medium"
+
+    def test_replaces_dashes_in_quality(self):
+        config = {"language": {"code": "en_US"}, "dataset": "foo", "audio": {"quality": "x-low"}}
+        assert _voice_key_from_config(config) == "en_US-foo-x_low"
+
+    @pytest.mark.parametrize("config", [
+        {},                                                                  # totally empty
+        {"language": {"code": "en_US"}},                                      # no dataset
+        {"language": {"code": "en_US"}, "dataset": "x"},                      # no audio
+        {"dataset": "x", "audio": {"quality": "medium"}},                     # no language
+        {"language": {}, "dataset": "x", "audio": {"quality": "medium"}},     # language without code
+        {"language": "en_US", "dataset": "x", "audio": {"quality": "medium"}},# language as str, not dict
+    ])
+    def test_missing_field_raises(self, config):
+        with pytest.raises(ValueError, match="missing required fields"):
+            _voice_key_from_config(config)


### PR DESCRIPTION
Closes #10.

## Summary

`install_voice_from_tar_archive` raised the misleading `Required files not found in archive` error whenever the `.onnx` filename didn't match the `<language>-<name>-<quality>` regex — even though the `.onnx` and `.onnx.json` files were actually present. The user just had to know the exact naming convention.

Reported as upstream [mush42/sonata-nvda#47](https://github.com/mush42/sonata-nvda/issues/47) by @BlindDeveloper in 2024-05. Mirrored on this fork as #10.

## Fix

Refactor the voice-key derivation into two small helpers, and fall back to the config when the filename doesn't conform:

- `_voice_key_from_filename(stem) -> str | None` — fast path; preserves existing behavior for canonically-named files.
- `_voice_key_from_config(config) -> str` — fallback; reads `language.code`, `dataset`, and `audio.quality` from the bundled Piper config JSON. Raises `ValueError` with an actionable message if any field is missing.

`install_voice_from_tar_archive` tries the filename path first, then falls back to reading the config. Either route produces the same `voice_key` shape.

Modern Piper voice configs always carry the three required fields (verified against `rhasspy/piper-voices` voices). So in practice, any properly-built Piper voice archive should now install regardless of how the files are named.

## Test plan

- [x] New `tests/test_voice_key_helpers.py` covers:
  - `_voice_key_from_filename` happy paths (canonical names, MLS-digit names, RT variants) + None on mismatch (`"aivars"`, `"voice"`, `"aivars-medium"`, etc.)
  - `_voice_key_from_config` derivation across language/dataset/quality combinations + dash replacement
  - `ValueError` raised for every shape of missing-field
- [x] Helpers extracted via the same text-exec pattern as `test_voice_archive_regex.py` — no NVDA stubs needed.
- [x] Manually validated each parametrized case with plain Python (pytest not available in my dev env).
- [ ] CI green (build + windows-latest pytest).