### PR TITLE
Improve install-from-local-file UX: broader wildcard + surface error detail

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
@@ -182,7 +182,12 @@ class InstalledSonataVoicesPanel(SizedPanel):
             # Translators: title for a dialog for opening a file
             message=_("Choose voice archive file "),
             defaultDir=wx.GetUserHome(),
-            wildcard="Tar archives *.tar.gz | *.tar.gz",
+            wildcard=(
+                # Translators: file dialog filter for tar archives
+                _("Tar archives (*.tar.gz, *.tgz)") + "|*.tar.gz;*.tgz|"
+                # Translators: file dialog filter for all files
+                + _("All files") + "|*.*"
+            ),
             style=wx.FD_OPEN,
         )
         gui.runScriptModalDialog(
@@ -200,15 +205,17 @@ class InstalledSonataVoicesPanel(SizedPanel):
             voice_key = voice_download.install_voice_from_tar_archive(
                 filepath, SONATA_VOICES_DIR
             )
-        except:
+        except Exception as exc:
             log.error("Failed to install voice from archive", exc_info=True)
             gui.messageBox(
                 # Translators: message telling the user that installing the voice has failed
                 _(
-                    "Failed to install voice from archive. See NVDA's log for more details."
-                ),
+                    "Failed to install voice from archive.\n\n{detail}\n\n"
+                    "See NVDA's log for more details."
+                ).format(detail=str(exc) or type(exc).__name__),
                 _("Voice installation failed"),
                 style=wx.ICON_ERROR,
+                parent=gui.mainFrame,
             )
         else:
             gui.messageBox(


### PR DESCRIPTION
Closes #8.

## Summary

Two ergonomic improvements to the install-from-local-file flow, addressing the user-visible complaints in [upstream mush42/sonata-nvda#67](https://github.com/mush42/sonata-nvda/issues/67) by @Violet-Iolite (2025-10).

## Changes

**1. Broader file picker wildcard**

Was:
```python
wildcard="Tar archives *.tar.gz | *.tar.gz"
```

Now:
```python
wildcard=(
    _("Tar archives (*.tar.gz, *.tgz)") + "|*.tar.gz;*.tgz|"
    + _("All files") + "|*.*"
)
```

The reporter described seeing "an empty folder" in the picker despite the files being present — likely the strict `*.tar.gz` filter hiding archives saved with non-standard extensions. The new wildcard accepts `.tgz` as well and offers "All files" as a fallback.

**2. Surface the actual exception message**

The install-failure messageBox previously read:
> Failed to install voice from archive. See NVDA's log for more details.

Now it reads (e.g.):
> Failed to install voice from archive.
>
> Voice config is missing required fields (language.code, dataset, audio.quality)…
>
> See NVDA's log for more details.

Users can self-diagnose without digging through the log. Also adds `parent=gui.mainFrame` to the messageBox call, consistent with the earlier parent-guard work (#3, #18).

## Related

The underlying `.onnx`-filename naming requirement that historically caused this exact failure mode is also now relaxed by PR #17 (config-metadata fallback). With that merged, any properly-built Piper voice archive should install regardless of how the files inside are named.

## Test plan

- [x] Syntax check passes.
- [ ] CI build + test green.
- [ ] Manual verification on NVDA 2026 after next release:
  - File picker shows .tgz files in addition to .tar.gz.
  - "All files" filter switches to showing everything.
  - Install failure on a malformed archive shows the actual error text in the dialog.