### PR TITLE
Add issue/PR templates and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Something in the add-on isn't behaving the way it should.
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. The fields below help me reproduce and diagnose the problem quickly — please fill in as much as you can.
+
+  - type: input
+    id: addon-version
+    attributes:
+      label: Sonata Neural Voices version
+      description: From the add-on store, or the version number embedded in the file you installed.
+      placeholder: e.g. 3.2.0 / v3.2-beta.4
+    validations:
+      required: true
+
+  - type: input
+    id: nvda-version
+    attributes:
+      label: NVDA version
+      description: NVDA menu → Help → About NVDA.
+      placeholder: e.g. 2026.1
+    validations:
+      required: true
+
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows version
+      description: Settings → System → About, or `winver`.
+      placeholder: e.g. Windows 11 24H2 (x64)
+    validations:
+      required: true
+
+  - type: input
+    id: voice
+    attributes:
+      label: Voice / variant tested
+      description: Which Sonata voice was active when the bug happened. Skip if the bug isn't tied to a specific voice.
+      placeholder: e.g. en_US-lessac-medium (standard) / fr_FR-mls_1840-low (fast)
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What did you do, step by step? The more specific, the faster I can reproduce.
+      placeholder: |
+        1. Open voice manager
+        2. Click Download on a voice
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What you thought would happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What actually happened. Include any error dialog text verbatim.
+    validations:
+      required: true
+
+  - type: textarea
+    id: nvda-log
+    attributes:
+      label: NVDA log slice
+      description: |
+        NVDA menu → Tools → View log → copy the relevant lines (the few lines around the error).
+        For best signal: set NVDA log level to "debug" (Preferences → General → Logging level), reproduce, then grab the log.
+      render: text
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Workarounds you tried, related issues, screenshots, voice config file contents, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Installation help / general usage
+    url: https://github.com/austek/sonata-nvda/blob/main/readme.md
+    about: Start here for how to install the add-on and download voices.
+  - name: NVDA add-ons community list
+    url: https://nvda-addons.groups.io/g/nvda-addons
+    about: General NVDA add-on discussion, announcements, and user-to-user help.
+  - name: Upstream sonata-nvda (read-only)
+    url: https://github.com/mush42/sonata-nvda
+    about: The original repository. No longer actively maintained — this fork is the active maintenance source.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a new capability or an improvement to existing behavior.
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. A bit of context helps me decide whether and how to prioritize it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the underlying pain point or scenario, not just the proposed feature. This often suggests alternative approaches.
+      placeholder: e.g. "When I want to preview many voices in a row, the modal blocks me from navigating the list..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should change? If you have a specific UI/API in mind, describe it; if not, just sketch the desired outcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, or existing workarounds.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, screenshots, links to similar features elsewhere, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+Closes #<!-- issue number, or remove this line if no issue -->.
+
+## Summary
+
+<!-- 1-3 sentences on what this PR does and why. -->
+
+## Changes
+
+<!-- Concrete list of changes. File paths and line refs help reviewers. -->
+
+## Test plan
+
+- [ ] Syntax check passes.
+- [ ] CI build + test green.
+- [ ] <!-- Add any manual verification steps relevant to the change. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to Sonata Neural Voices (maintenance fork)
+
+This is a maintenance fork of [mush42/sonata-nvda](https://github.com/mush42/sonata-nvda). The upstream author can no longer maintain the project ([announcement](https://nvda-addons.groups.io/g/nvda-addons/message/27636)); this fork carries compatibility fixes and minor improvements so the add-on keeps working on current NVDA releases.
+
+Contributions are welcome.
+
+## Reporting a bug
+
+Use the **Bug report** template at <https://github.com/austek/sonata-nvda/issues/new/choose>. The template asks for NVDA version, add-on version, OS, voice tested, steps to reproduce, and an NVDA log slice — please fill in as much as you can. Bugs filed without that info almost always end up labelled `needs-reproducer` until they have it.
+
+For installation questions or general usage help, check the [readme](readme.md) first and then ask on the [NVDA add-ons community list](https://nvda-addons.groups.io/g/nvda-addons).
+
+## Suggesting a feature
+
+Use the **Feature request** template. Describe the *problem* you're trying to solve, not just the proposed feature — that often suggests cleaner alternatives.
+
+## Development setup
+
+The add-on is built with [SCons](https://scons.org/) targeting Python 3.13 (the version embedded in NVDA 2026.1+). On Windows or any platform with Python 3.13:
+
+```bash
+python -m pip install --upgrade pip wheel
+pip install scons markdown pytest
+```
+
+## Building the add-on
+
+From the repo root:
+
+```bash
+scons
+```
+
+The build produces a `.nvda-addon` file in the repo root. Install it by opening the file in NVDA (NVDA menu → Tools → Manage add-ons → Install from external source).
+
+To rebuild the translation template (`.pot`):
+
+```bash
+scons pot
+```
+
+## Running tests
+
+```bash
+pytest
+```
+
+The test suite (under `tests/`) covers add-on metadata, build helpers, the TTS system, and several pure-Python parsers extracted from the synth driver. Tests stub NVDA-only modules in `tests/conftest.py` so they can run outside the NVDA runtime.
+
+## Refreshing the bundled binaries
+
+The add-on bundles three native dependencies built for Python 3.13 / Windows x64:
+
+```bash
+python update_grpc.py        # gRPC + protobuf
+python update_miniaudio.py   # audio decoding
+python update_cffi.py        # C FFI runtime
+```
+
+Each script fetches the matching `cp313-win_amd64` wheel from PyPI and swaps the contents under `addon/synthDrivers/sonata_neural_voices/lib/`.
+
+## Submitting a PR
+
+Use the pull request template. Link the issue with `Closes #N` in the PR body — GitHub will auto-close the issue when the PR merges.
+
+Conventions used in this fork:
+
+- **Commit messages**: short imperative subject, blank line, then a body that explains *why*. Reference the relevant issue or upstream report (e.g. "Closes #5", "mirrored from upstream mush42/sonata-nvda#30").
+- **PR titles**: same conventional-commits style as the lead commit (`fix:`, `feat:`, `chore:`, `docs:`).
+- **Branch naming**: `fix/<short-slug>`, `feat/<short-slug>`, `chore/<short-slug>`.
+- **No `Co-Authored-By` trailers.**
+
+## Cutting a release
+
+Releases are tag-driven. Push an annotated tag from `main`:
+
+```bash
+git tag -a v3.2-beta.N -m "v3.2-beta.N: <summary>"
+git push origin v3.2-beta.N
+```
+
+CI builds on Ubuntu, runs pytest on `windows-latest`, and publishes a GitHub Release with the `.nvda-addon`, the `.pot`, and an auto-generated `changelog.md` containing the SHA256.
+
+Note: `addon_version` in `buildVars.py` must remain strict three-part semver (e.g. `3.2.0`) — there's a test enforcing it. The `-beta.N` signal lives only in the git tag.


### PR DESCRIPTION
## Summary

Repo hygiene to reduce the friction we ran into while clearing the legacy bug backlog. No code changes — just GitHub plumbing and docs.

## Changes

- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — YAML form pre-collecting the fields I kept having to ask for on the legacy issues we triaged: NVDA version, addon version, OS, voice tested, steps to reproduce, expected vs. actual behavior, NVDA log slice. Auto-applies the `bug` label.
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — structured form that prompts the *problem* first, not just the proposed feature. Auto-applies `enhancement`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues, routes installation/usage questions to the readme and the NVDA add-ons list, and links to the upstream repo with a clear "no longer maintained" framing.
- **`.github/pull_request_template.md`** — codifies the `Closes #N` + summary + test-plan pattern that's emerged across recent PRs.
- **`CONTRIBUTING.md`** — covers fork context, dev setup, `scons` build, `pytest`, the `update_grpc.py` / `update_miniaudio.py` / `update_cffi.py` refresh scripts, branch/commit conventions, and the tag-driven release flow including the strict-semver constraint on `addon_version`.

## Test plan

- [x] YAML parses for all three issue templates.
- [ ] After merge: confirm "New issue" on the repo shows the chooser with the three options.
- [ ] After merge: confirm opening a new PR pre-populates the body with the template.