### PR TITLE
Add stale-issue bot and Release Drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+# Release Drafter config. Maintains a draft release on GitHub that auto-updates
+# as PRs merge into main. At release time, open the draft, set the actual tag
+# (e.g. v3.2-beta.5 — note that addon_version in buildVars.py stays strict
+# semver while -beta.N lives only in the tag; see project memory), and publish.
+
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+template: |
+  $CHANGES
+
+categories:
+  - title: '🐛 Fixes'
+    labels:
+      - bug
+  - title: '✨ Features'
+    labels:
+      - enhancement
+  - title: '📚 Documentation'
+    labels:
+      - documentation
+  - title: '🧹 Maintenance'
+    labels:
+      - chore
+      - dependencies
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+# We tag manually, so don't try to auto-bump versions based on labels.
+# Leave $RESOLVED_VERSION as a placeholder the maintainer overrides at
+# release time.
+version-resolver:
+  default: patch
+
+# Exclude PRs by label — uncategorized noise (e.g. nvda-2026 historical work)
+# shouldn't pollute the release notes.
+exclude-labels:
+  - skip-changelog
+
+# If a PR has no recognized category label, surface it in a "Other Changes"
+# section so it isn't silently dropped.
+include-labels: []

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,26 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  # Re-run when a PR is opened/edited so label changes are reflected without
+  # waiting for the next merge.
+  pull_request:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: Mark stale issues
+
+on:
+  schedule:
+    # Daily at 06:00 UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Only touch issues that have been parked pending a reproducer.
+          # Everything else (active bugs, feature requests, etc.) stays open
+          # until someone explicitly acts on it.
+          only-issue-labels: needs-reproducer
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          # PRs are not subject to this workflow.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: stale
+          remove-stale-when-updated: true
+          close-issue-reason: not_planned
+          stale-issue-message: |
+            This issue has been waiting on a reproducer for 30 days with no activity, so it's been marked as `stale`.
+
+            If you can still reproduce on the latest [release](https://github.com/austek/sonata-nvda/releases/latest), please reply with:
+            - The exact NVDA version and add-on version
+            - A minimal reproducer (steps, expected vs. actual behavior)
+            - The relevant NVDA log slice
+
+            …and the `stale` and `needs-reproducer` labels will be removed.
+
+            Otherwise this issue will close in 14 days. Closing isn't a verdict — it just means we don't have enough information to act on it.
+          close-issue-message: |
+            Closing as stale — no reproducer was received in 44 days.
+
+            If you hit this on a recent release, please open a fresh issue using the [bug report template](https://github.com/austek/sonata-nvda/issues/new/choose), which collects the diagnostic info up-front. Thanks for the original report regardless.


### PR DESCRIPTION
## Summary

Two GitHub Actions to reduce ongoing maintenance overhead. No code changes.

## Changes

### Stale-issue bot (`.github/workflows/stale.yml`)

- Daily cron at 06:00 UTC, runs `actions/stale@v9`.
- **Only** touches issues labeled `needs-reproducer` (the four currently open ones — #4, #11, #12, #13 — and any future ones tagged the same way). Everything else stays open indefinitely.
- 30 days no activity → warning comment + `stale` label.
- 14 more days → close with `not_planned` reason, pointing at the bug report template.
- PRs are explicitly excluded.

### Release Drafter (`.github/workflows/release-drafter.yml` + `.github/release-drafter.yml`)

- Runs on every push to `main` and on PR open/edit/label.
- Maintains a draft GitHub Release whose body auto-updates as PRs merge.
- PRs bucketed by label into Fixes / Features / Documentation / Maintenance.
- `skip-changelog` label excludes a PR from the notes (label created in this PR).
- At release time: open the draft, set the actual tag (e.g. `v3.2-beta.5`), publish. `addon_version` in `buildVars.py` still needs to be bumped manually since it must stay strict semver.

### Supporting labels

Created `chore`, `dependencies`, `skip-changelog` so the drafter's categorization works from day 1. Existing `bug`, `enhancement`, `documentation`, `needs-reproducer` are reused.

## Test plan

- [x] YAML parses for all three files.
- [ ] CI green on this PR.
- [ ] After merge: confirm the Release Drafter workflow runs on the merge and creates/updates a draft release.
- [ ] Verify stale workflow appears in the Actions tab (won't actually fire today since no issue has been inactive for 30 days yet).