### PR TITLE
Release Drafter: prefix tags with v

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,8 +3,8 @@
 # (e.g. v3.2-beta.5 — note that addon_version in buildVars.py stays strict
 # semver while -beta.N lives only in the tag; see project memory), and publish.
 
-name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 template: |
   $CHANGES
 


### PR DESCRIPTION
## Summary

The `tag-template` / `name-template` in `.github/release-drafter.yml` was `\$RESOLVED_VERSION` (no `v` prefix), but real release tags on this fork are `v3.2-beta.N` (with `v`). Release Drafter couldn't anchor against existing releases, so its first run created a draft tagged `0.1.0` and bucketed every historical PR back to #2 into it.

## Fix

```diff
-name-template: '\$RESOLVED_VERSION'
-tag-template: '\$RESOLVED_VERSION'
+name-template: 'v\$RESOLVED_VERSION'
+tag-template: 'v\$RESOLVED_VERSION'
```

## Test plan

- [x] YAML parses.
- [ ] CI green.
- [ ] After merge: confirm Release Drafter creates a new draft, the tag uses the `v` prefix, and only PRs merged after `v3.2-beta.4` appear in the body.