### PR TITLE
Switch tag scheme to standard semver

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Sonata Neural Voices version
       description: From the add-on store, or the version number embedded in the file you installed.
-      placeholder: e.g. 3.2.0 / v3.2-beta.4
+      placeholder: e.g. 3.2.0 / v3.2.0-beta.5
     validations:
       required: true
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,9 @@
 # Release Drafter config. Maintains a draft release on GitHub that auto-updates
-# as PRs merge into main. At release time, open the draft, set the actual tag
-# (e.g. v3.2-beta.5 — note that addon_version in buildVars.py stays strict
-# semver while -beta.N lives only in the tag; see project memory), and publish.
+# as PRs merge into main. At release time, open the draft, confirm the
+# auto-resolved tag (e.g. v3.2.0-beta.5 for a beta, v3.2.0 for a stable cut),
+# and publish. addon_version in buildVars.py stays strict 3-part semver while
+# the -beta.N pre-release tag lives only in the git tag — see CONTRIBUTING.md
+# and the project_release_workflow memory.
 
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,10 +75,12 @@ Conventions used in this fork:
 Releases are tag-driven. Push an annotated tag from `main`:
 
 ```bash
-git tag -a v3.2-beta.N -m "v3.2-beta.N: <summary>"
-git push origin v3.2-beta.N
+git tag -a v3.2.0-beta.N -m "v3.2.0-beta.N: <summary>"
+git push origin v3.2.0-beta.N
 ```
 
-CI builds on Ubuntu, runs pytest on `windows-latest`, and publishes a GitHub Release with the `.nvda-addon`, the `.pot`, and an auto-generated `changelog.md` containing the SHA256.
+CI builds on Ubuntu, runs pytest on `windows-latest`, and publishes a GitHub Release with the `.nvda-addon`, the `.pot`, and an auto-generated `changelog.md` containing the SHA256. Release Drafter maintains a draft release on every push to `main` — open the draft, set the actual tag, then publish.
 
-Note: `addon_version` in `buildVars.py` must remain strict three-part semver (e.g. `3.2.0`) — there's a test enforcing it. The `-beta.N` signal lives only in the git tag.
+Tag scheme: standard semver `vMAJOR.MINOR.PATCH(-prerelease)`, e.g. `v3.2.0-beta.5` for a beta or `v3.2.0` for a stable cut. The `-beta.N` portion stays in the git tag only; `addon_version` in `buildVars.py` must remain strict three-part semver (e.g. `3.2.0`) per `tests/test_buildvars.py`.
+
+Historical tags `v3.2-beta.1` through `v3.2-beta.4` used a non-standard two-part scheme (no `.0` patch component). They're left as-is — already published, already linked — but new tags use the standard form so Release Drafter can anchor against them correctly.


### PR DESCRIPTION
Closes — no issue; follow-up from #23.

## Summary

The current tag scheme `v3.2-beta.N` (two-part, no `.0` patch component) isn't standard semver and Release Drafter can't parse it as a valid anchor. After #23 fixed the `v` prefix, the draft body still includes every historical PR because Release Drafter sees no parseable previous release.

Switch documentation + tooling examples to standard semver: `v3.2.0-beta.N` for betas, `v3.2.0` for stable. Existing `v3.2-beta.{1..4}` tags stay as-is (already published).

## Changes

- `CONTRIBUTING.md` release section: tag example + new paragraph explaining the scheme and the historical-tag carveout.
- `.github/release-drafter.yml` config header comment.
- `.github/ISSUE_TEMPLATE/bug_report.yml` version placeholder.

## What doesn't change

- `addon_version` in `buildVars.py` stays `3.2.0` — already matches strict 3-part-integer semver enforced by `tests/test_buildvars.py`.
- No code changes.
- No tags get moved or deleted.

## Test plan

- [x] YAML + diff verified.
- [ ] CI green.
- [ ] After merge, next tag I push will be `v3.2.0-beta.5` (or `v3.2.0` for stable). Release Drafter should then recognize it and limit the *following* draft to PRs merged since that tag.

## Aside

Apply the `chore` label.