### PR TITLE
Graduate to v3.2.0 stable

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -26,7 +26,11 @@ addon_info = AddonInfo(
 	addon_version="3.2.0",
 	# Brief changelog for this version
 	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=None,
+	addon_changelog=_(
+		"First stable release of the maintenance fork. "
+		"Adds NVDA 2026.1 compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, miniaudio, and cffi binaries. "
+		"Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
+	),
 	# Author(s)
 	addon_author="Musharraf Omer <ibnomer2011@hotmail.com>",
 	# URL for the add-on documentation support
@@ -42,7 +46,7 @@ addon_info = AddonInfo(
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!
-	addon_updateChannel="beta",
+	addon_updateChannel=None,
 	# Add-on license such as GPL 2
 	addon_license="GPL 2",
 	# URL for the license document the ad-on is licensed under


### PR DESCRIPTION
## Summary

After confirmed installs on real NVDA 2026.1 (see [techexplorers123's report on upstream #72](https://github.com/mush42/sonata-nvda/pull/72#issuecomment-4565109800)) and the bug-fix backlog cleared in PRs #15–#20, the maintenance fork is ready to leave beta.

## Changes

- `buildVars.py`:
  - `addon_updateChannel`: `"beta"` → `None` (stable)
  - `addon_changelog`: populated with a user-facing summary of what this release delivers since the last upstream stable (`v3.1.0`)

`addon_version` stays at `3.2.0` — already the right value per `tests/test_buildvars.py`'s strict-semver test.

## After merge

1. Tag `v3.2.0` from `main`. CI publishes a GitHub Release with `.nvda-addon` + SHA256.
2. Edit the Release Drafter draft body to keep only the PRs merged since `v3.2-beta.4` (i.e. #21, #22, #23, #24, and this one). Past PRs are already in the published `v3.2-beta.4`.
3. Publish.
4. After publication, future Release Drafter drafts will anchor on `v3.2.0` correctly and only show PRs merged after it — bootstrapping the standard-semver scheme.

## What this unlocks

- NVDA Add-on Store submission becomes a credible next step (upstream #19 and #37 both asked for this).
- Update Channel in NVDA reports the addon as stable instead of beta.

## Test plan

- [x] Syntax check + buildvars tests pass on inspection (no version format change).
- [ ] CI green on this PR.
- [ ] After merge: tag `v3.2.0`, monitor CI to publish release, verify Release Drafter recognizes the new tag.

Apply `chore` label.