### PR TITLE
Compound addon_author with maintainer attribution

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -32,7 +32,7 @@ addon_info = AddonInfo(
 		"Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
 	),
 	# Author(s)
-	addon_author="Musharraf Omer <ibnomer2011@hotmail.com>",
+	addon_author="Musharraf Omer (original) <ibnomer2011@hotmail.com>, Ali Ustek (maintainer) <13117393+austek@users.noreply.github.com>",
 	# URL for the add-on documentation support
 	addon_url="https://github.com/austek/sonata-nvda",
 	# URL for the add-on repository where the source code can be found


### PR DESCRIPTION
## Summary

Switch `addon_author` from `"Musharraf Omer <ibnomer2011@hotmail.com>"` to a compound string that preserves mush42's original attribution while adding the active fork maintainer.

```diff
-addon_author="Musharraf Omer <ibnomer2011@hotmail.com>",
+addon_author="Musharraf Omer (original) <ibnomer2011@hotmail.com>, Ali Ustek (maintainer) <13117393+austek@users.noreply.github.com>",
```

NVDA's addon manager shows `addon_author` as the contact. Since the upstream developer is no longer acting on this project (per the [NVDA Add-ons announcement](https://nvda-addons.groups.io/g/nvda-addons/message/27636)), users hitting bugs in `v3.2.0+` need a route to the active maintainer.

GitHub noreply email is used so the address isn't a routable spam target — all real contact goes through GitHub Issues.

## Notes

- v3.2.0 was published just before this change; the compound author ships in v3.2.1+.
- Passes `tests/test_buildvars.py` — the existing tests use `re.search(r"<([^>]+)>", author)` which captures the first email block (mush42's), validates `@` is present.

Apply `chore` label.