### PR TITLE
fix: resolve NVDA profile reload crash by ensuring idempotent aio lifecycle

### DIFF
--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -187,8 +187,10 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def __init__(self):
         super().__init__()
+        aio.ensure_running()
+        grpc_init_fut = grpc_client.initialize()
         try:
-            _GRPC_IS_INIT.result()
+            grpc_init_fut.result(timeout=10)
         except Exception:
             log.exception(
                 "Failed to initialize Sonata services. Synthesizer will not be available.",
@@ -196,7 +198,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             )
             return
         try:
-            sonata_grpc_server_version = grpc_client.check_grpc_server().result()
+            sonata_grpc_server_version = grpc_client.check_grpc_server().result(timeout=10)
         except Exception:
             log.exception(
                 "Failed to connect to sonata GRPC server. Synthesizer will not be available.",
@@ -237,11 +239,12 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def terminate(self):
         self.cancel()
-        self.tts.shutdown()
+        if hasattr(self, "tts") and self.tts is not None:
+            self.tts.shutdown()
         for player in self._players.values():
             player.close()
         self._players.clear()
-        aio.terminate()
+
 
     def speak(self, speechSequence):
         with self.tts.create_synthesis_context():

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -33,7 +33,6 @@ from . import grpc_client
 from ._config import SonataConfig
 from .helpers import update_displaied_params_on_voice_change
 from .aio import (
-    ASYNCIO_EVENT_LOOP,
     CancelledError,
     asyncio,
     asyncio_cancel_task,
@@ -149,7 +148,7 @@ async def _process_speech_sequence(speech_seq):
 @asyncio_coroutine_to_concurrent_future
 async def process_speech(speech_seq):
     speech_task = _process_speech_sequence(speech_seq)
-    return ASYNCIO_EVENT_LOOP.create_task(speech_task)
+    return asyncio.get_running_loop().create_task(speech_task)
 
 
 

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -29,6 +29,7 @@ from synthDriverHandler import (
     synthIndexReached,
 )
 
+from . import aio
 from . import grpc_client
 from ._config import SonataConfig
 from .helpers import update_displaied_params_on_voice_change
@@ -48,10 +49,6 @@ from .tts_system import (
 import addonHandler
 
 addonHandler.initTranslation()
-
-
-aio.initialize()
-_GRPC_IS_INIT = grpc_client.initialize()
 
 
 class DoneSpeakingTask:
@@ -186,10 +183,17 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def __init__(self):
         super().__init__()
+        # Set before any early return below so terminate() stays safe when
+        # initialization bails out.
+        self._current_task = None
+        self._rateBoost = False
+        self.tts = None
+        self._player = None
+        self._players = {}
         aio.ensure_running()
         grpc_init_fut = grpc_client.initialize()
         try:
-            grpc_init_fut.result(timeout=10)
+            grpc_init_fut.result(timeout=grpc_client.STARTUP_TIMEOUT)
         except Exception:
             log.exception(
                 "Failed to initialize Sonata services. Synthesizer will not be available.",
@@ -197,7 +201,9 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             )
             return
         try:
-            sonata_grpc_server_version = grpc_client.check_grpc_server().result(timeout=10)
+            sonata_grpc_server_version = grpc_client.check_grpc_server().result(
+                timeout=grpc_client.STARTUP_TIMEOUT
+            )
         except Exception:
             log.exception(
                 "Failed to connect to sonata GRPC server. Synthesizer will not be available.",
@@ -212,8 +218,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
                 "No installed voices were found for Sonata. Synthesizer will not be available."
             )
             return
-        self._current_task = None
-        self._rateBoost = False
         self.voices = SonataTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
         try:
             voice_key = config.conf["speech"]["sonata_neural_voices"]["voice"]
@@ -226,7 +230,6 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         self.tts = SonataTextToSpeechSystem(
             self.voices, speech_options=init_speech_options
         )
-        self._players = {}
         self._player = self._get_or_create_player(
             self.tts.speech_options.voice.sample_rate
         )
@@ -238,12 +241,11 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def terminate(self):
         self.cancel()
-        if hasattr(self, "tts") and self.tts is not None:
+        if self.tts is not None:
             self.tts.shutdown()
         for player in self._players.values():
             player.close()
         self._players.clear()
-
 
     def speak(self, speechSequence):
         with self.tts.create_synthesis_context():
@@ -312,10 +314,12 @@ class SynthDriver(synthDriverHandler.SynthDriver):
     def cancel(self):
         if self._current_task is not None:
             asyncio_cancel_task(self._current_task)
-        self._player.stop()
+        if self._player is not None:
+            self._player.stop()
 
     def pause(self, switch):
-        self._player.pause(switch)
+        if self._player is not None:
+            self._player.pause(switch)
 
     def _on_index_reached(self, index):
         if index is not None:

--- a/addon/synthDrivers/sonata_neural_voices/aio.py
+++ b/addon/synthDrivers/sonata_neural_voices/aio.py
@@ -12,58 +12,81 @@ from .helpers import import_bundled_library
 
 
 THREADED_EXECUTOR = None
-ASYNCIO_EVENT_LOOP = asyncio.new_event_loop()
+ASYNCIO_EVENT_LOOP = None
 ASYNCIO_LOOP_THREAD = None
 
 
 def initialize():
     global THREADED_EXECUTOR, ASYNCIO_EVENT_LOOP, ASYNCIO_LOOP_THREAD
 
-    THREADED_EXECUTOR = ThreadPoolExecutor(
-        max_workers=os.cpu_count() // 2, thread_name_prefix="piper4nvda_executor"
-    )
-
-    if ASYNCIO_LOOP_THREAD:
-        log.warning(
-            "Attempted to start the asyncio eventloop while it is already running"
+    if THREADED_EXECUTOR is None or getattr(THREADED_EXECUTOR, "_shutdown", False):
+        max_workers = max(1, (os.cpu_count() or 2) // 2)
+        THREADED_EXECUTOR = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="piper4nvda_executor"
         )
-        return
 
-    def _thread_target():
+    if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
+        if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
+            return
+        ASYNCIO_LOOP_THREAD.join(timeout=2)
+
+    ASYNCIO_EVENT_LOOP = asyncio.new_event_loop()
+
+    def _thread_target(loop):
         log.info("Starting asyncio event loop")
-        asyncio.set_event_loop(ASYNCIO_EVENT_LOOP)
-        ASYNCIO_EVENT_LOOP.run_forever()
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
 
     ASYNCIO_LOOP_THREAD = threading.Thread(
-        target=_thread_target, daemon=True, name="piper4nvda_asyncio"
+        target=_thread_target, args=(ASYNCIO_EVENT_LOOP,), daemon=True, name="piper4nvda_asyncio"
     )
     ASYNCIO_LOOP_THREAD.start()
+
+
+def ensure_running():
+    if (
+        THREADED_EXECUTOR is None
+        or getattr(THREADED_EXECUTOR, "_shutdown", False)
+        or ASYNCIO_LOOP_THREAD is None
+        or not ASYNCIO_LOOP_THREAD.is_alive()
+        or ASYNCIO_EVENT_LOOP is None
+        or not ASYNCIO_EVENT_LOOP.is_running()
+    ):
+        initialize()
 
 
 def terminate():
     global THREADED_EXECUTOR, ASYNCIO_LOOP_THREAD, ASYNCIO_EVENT_LOOP
     log.info("Shutting down the thread pool executor")
-    THREADED_EXECUTOR.shutdown()
-    THREADED_EXECUTOR = None
-    if ASYNCIO_LOOP_THREAD:
+    if THREADED_EXECUTOR is not None:
+        THREADED_EXECUTOR.shutdown(wait=False)
+        THREADED_EXECUTOR = None
+    if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
         log.info("Shutting down asyncio event loop")
-        ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.stop)
+        loop_thread = ASYNCIO_LOOP_THREAD
         ASYNCIO_LOOP_THREAD = None
+        if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
+            ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.stop)
+        loop_thread.join(timeout=2)
+
 
 
 def asyncio_create_task(coro):
+    ensure_running()
     return ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.create_task, coro)
 
 
 def asyncio_cancel_task(task):
-    ASYNCIO_EVENT_LOOP.call_soon_threadsafe(task.cancel)
+    if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
+        ASYNCIO_EVENT_LOOP.call_soon_threadsafe(task.cancel)
 
 
 def asyncio_coroutine_to_concurrent_future(async_func):
-    """Returns a concurrent.futures.Future that wrapps the decorated async function."""
+    """Returns a concurrent.futures.Future that wraps the decorated async function."""
 
     @wraps(async_func)
     def wrapper(*args, **kwargs):
+        ensure_running()
         return asyncio.run_coroutine_threadsafe(
             async_func(*args, **kwargs), loop=ASYNCIO_EVENT_LOOP
         )
@@ -79,6 +102,7 @@ def call_threaded(func: t.Callable[..., None]) -> t.Callable[..., "Future"]:
 
     @wraps(func)
     def wrapper(*args, **kwargs):
+        ensure_running()
         try:
             return THREADED_EXECUTOR.submit(func, *args, **kwargs)
         except RuntimeError:
@@ -88,5 +112,6 @@ def call_threaded(func: t.Callable[..., None]) -> t.Callable[..., "Future"]:
 
 
 def run_in_executor(func, *args, **kwargs):
+    ensure_running()
     bound_func = partial(func, *args, **kwargs)
     return ASYNCIO_EVENT_LOOP.run_in_executor(THREADED_EXECUTOR, bound_func)

--- a/addon/synthDrivers/sonata_neural_voices/aio.py
+++ b/addon/synthDrivers/sonata_neural_voices/aio.py
@@ -16,6 +16,15 @@ ASYNCIO_EVENT_LOOP = None
 ASYNCIO_LOOP_THREAD = None
 
 
+def _close_loop(loop):
+    if loop is None or loop.is_closed() or loop.is_running():
+        return
+    try:
+        loop.close()
+    except RuntimeError:
+        log.debug("Failed to close the asyncio event loop", exc_info=True)
+
+
 def initialize():
     global THREADED_EXECUTOR, ASYNCIO_EVENT_LOOP, ASYNCIO_LOOP_THREAD
 
@@ -30,6 +39,7 @@ def initialize():
             return
         ASYNCIO_LOOP_THREAD.join(timeout=2)
 
+    _close_loop(ASYNCIO_EVENT_LOOP)
     ASYNCIO_EVENT_LOOP = asyncio.new_event_loop()
 
     def _thread_target(loop):
@@ -68,7 +78,8 @@ def terminate():
         if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
             ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.stop)
         loop_thread.join(timeout=2)
-
+    _close_loop(ASYNCIO_EVENT_LOOP)
+    ASYNCIO_EVENT_LOOP = None
 
 
 def asyncio_create_task(coro):

--- a/addon/synthDrivers/sonata_neural_voices/aio.py
+++ b/addon/synthDrivers/sonata_neural_voices/aio.py
@@ -14,6 +14,13 @@ from .helpers import import_bundled_library
 THREADED_EXECUTOR = None
 ASYNCIO_EVENT_LOOP = None
 ASYNCIO_LOOP_THREAD = None
+EXECUTOR_IS_SHUTDOWN = False
+
+LOOP_STARTUP_TIMEOUT = 5
+LOOP_SHUTDOWN_TIMEOUT = 2
+
+_LIFECYCLE_LOCK = threading.RLock()
+_LOOP_RUNNING = threading.Event()
 
 
 def _close_loop(loop):
@@ -25,61 +32,88 @@ def _close_loop(loop):
         log.debug("Failed to close the asyncio event loop", exc_info=True)
 
 
+def _is_running():
+    return (
+        THREADED_EXECUTOR is not None
+        and not EXECUTOR_IS_SHUTDOWN
+        and ASYNCIO_LOOP_THREAD is not None
+        and ASYNCIO_LOOP_THREAD.is_alive()
+        and ASYNCIO_EVENT_LOOP is not None
+        and ASYNCIO_EVENT_LOOP.is_running()
+    )
+
+
 def initialize():
     global THREADED_EXECUTOR, ASYNCIO_EVENT_LOOP, ASYNCIO_LOOP_THREAD
+    global EXECUTOR_IS_SHUTDOWN
 
-    if THREADED_EXECUTOR is None or getattr(THREADED_EXECUTOR, "_shutdown", False):
-        max_workers = max(1, (os.cpu_count() or 2) // 2)
-        THREADED_EXECUTOR = ThreadPoolExecutor(
-            max_workers=max_workers, thread_name_prefix="piper4nvda_executor"
+    with _LIFECYCLE_LOCK:
+        if THREADED_EXECUTOR is None or EXECUTOR_IS_SHUTDOWN:
+            max_workers = max(1, (os.cpu_count() or 2) // 2)
+            THREADED_EXECUTOR = ThreadPoolExecutor(
+                max_workers=max_workers, thread_name_prefix="piper4nvda_executor"
+            )
+            EXECUTOR_IS_SHUTDOWN = False
+
+        if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
+            # The thread is started before run_forever() marks the loop running,
+            # so wait on the handshake rather than sampling is_running().
+            if _LOOP_RUNNING.wait(timeout=LOOP_SHUTDOWN_TIMEOUT) and _is_running():
+                return
+            ASYNCIO_LOOP_THREAD.join(timeout=LOOP_SHUTDOWN_TIMEOUT)
+
+        _close_loop(ASYNCIO_EVENT_LOOP)
+        ASYNCIO_EVENT_LOOP = asyncio.new_event_loop()
+        _LOOP_RUNNING.clear()
+
+        def _thread_target(loop):
+            log.info("Starting asyncio event loop")
+            asyncio.set_event_loop(loop)
+            loop.call_soon(_LOOP_RUNNING.set)
+            try:
+                loop.run_forever()
+            finally:
+                _LOOP_RUNNING.clear()
+
+        ASYNCIO_LOOP_THREAD = threading.Thread(
+            target=_thread_target,
+            args=(ASYNCIO_EVENT_LOOP,),
+            daemon=True,
+            name="piper4nvda_asyncio",
         )
-
-    if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
-        if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
-            return
-        ASYNCIO_LOOP_THREAD.join(timeout=2)
-
-    _close_loop(ASYNCIO_EVENT_LOOP)
-    ASYNCIO_EVENT_LOOP = asyncio.new_event_loop()
-
-    def _thread_target(loop):
-        log.info("Starting asyncio event loop")
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    ASYNCIO_LOOP_THREAD = threading.Thread(
-        target=_thread_target, args=(ASYNCIO_EVENT_LOOP,), daemon=True, name="piper4nvda_asyncio"
-    )
-    ASYNCIO_LOOP_THREAD.start()
+        ASYNCIO_LOOP_THREAD.start()
+        if not _LOOP_RUNNING.wait(timeout=LOOP_STARTUP_TIMEOUT):
+            log.error("Timed out waiting for the asyncio event loop to start")
 
 
 def ensure_running():
-    if (
-        THREADED_EXECUTOR is None
-        or getattr(THREADED_EXECUTOR, "_shutdown", False)
-        or ASYNCIO_LOOP_THREAD is None
-        or not ASYNCIO_LOOP_THREAD.is_alive()
-        or ASYNCIO_EVENT_LOOP is None
-        or not ASYNCIO_EVENT_LOOP.is_running()
-    ):
-        initialize()
+    if _is_running():
+        return
+    with _LIFECYCLE_LOCK:
+        if not _is_running():
+            initialize()
 
 
 def terminate():
     global THREADED_EXECUTOR, ASYNCIO_LOOP_THREAD, ASYNCIO_EVENT_LOOP
-    log.info("Shutting down the thread pool executor")
-    if THREADED_EXECUTOR is not None:
-        THREADED_EXECUTOR.shutdown(wait=False)
-        THREADED_EXECUTOR = None
-    if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
-        log.info("Shutting down asyncio event loop")
-        loop_thread = ASYNCIO_LOOP_THREAD
-        ASYNCIO_LOOP_THREAD = None
-        if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
-            ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.stop)
-        loop_thread.join(timeout=2)
-    _close_loop(ASYNCIO_EVENT_LOOP)
-    ASYNCIO_EVENT_LOOP = None
+    global EXECUTOR_IS_SHUTDOWN
+
+    with _LIFECYCLE_LOCK:
+        log.info("Shutting down the thread pool executor")
+        if THREADED_EXECUTOR is not None:
+            THREADED_EXECUTOR.shutdown(wait=False)
+            THREADED_EXECUTOR = None
+        EXECUTOR_IS_SHUTDOWN = True
+        if ASYNCIO_LOOP_THREAD is not None and ASYNCIO_LOOP_THREAD.is_alive():
+            log.info("Shutting down asyncio event loop")
+            loop_thread = ASYNCIO_LOOP_THREAD
+            ASYNCIO_LOOP_THREAD = None
+            if ASYNCIO_EVENT_LOOP is not None and ASYNCIO_EVENT_LOOP.is_running():
+                ASYNCIO_EVENT_LOOP.call_soon_threadsafe(ASYNCIO_EVENT_LOOP.stop)
+            loop_thread.join(timeout=LOOP_SHUTDOWN_TIMEOUT)
+        _LOOP_RUNNING.clear()
+        _close_loop(ASYNCIO_EVENT_LOOP)
+        ASYNCIO_EVENT_LOOP = None
 
 
 def asyncio_create_task(coro):

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -74,6 +74,10 @@ GRPC_SERVER_PROCESS = None
 CHANNEL = None
 SONATA_GRPC_SERVICE = None
 SERVER_CHECK_TIMEOUT = 15
+# Outer bound on the startup futures; must exceed SERVER_CHECK_TIMEOUT so the
+# coroutine's own error surfaces instead of a bare future timeout.
+STARTUP_TIMEOUT = SERVER_CHECK_TIMEOUT + 5
+CALL_TIMEOUT = 10
 
 
 def start_grpc_server():
@@ -137,20 +141,21 @@ async def initialize():
     start_grpc_server()
     if CHANNEL is not None:
         try:
+            # grpc.aio binds a channel to the loop that created it, so a channel
+            # outliving its loop has to be replaced rather than reused.
             channel_loop = getattr(CHANNEL, "_loop", None)
             if channel_loop is aio.ASYNCIO_EVENT_LOOP and aio.ASYNCIO_EVENT_LOOP.is_running():
                 return
         except Exception:
-            pass
+            log.debug("Failed to inspect the existing GRPC channel", exc_info=True)
         try:
             await CHANNEL.close()
         except Exception:
-            pass
+            log.debug("Failed to close the stale GRPC channel", exc_info=True)
         CHANNEL = None
     port = SONATA_GRPC_SERVER_PORT
     CHANNEL = grpc.aio.insecure_channel(f"localhost:{port}")
     SONATA_GRPC_SERVICE = sonata_grpcStub(CHANNEL)
-
 
 
 @atexit.register

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -136,11 +136,21 @@ async def initialize():
     global CHANNEL, SONATA_GRPC_SERVICE, SONATA_GRPC_SERVER_PORT
     start_grpc_server()
     if CHANNEL is not None:
-        log.warning("Attempted to re-initialize an already initialized GRPC connection")
-        return
+        try:
+            channel_loop = getattr(CHANNEL, "_loop", None)
+            if channel_loop is aio.ASYNCIO_EVENT_LOOP and aio.ASYNCIO_EVENT_LOOP.is_running():
+                return
+        except Exception:
+            pass
+        try:
+            await CHANNEL.close()
+        except Exception:
+            pass
+        CHANNEL = None
     port = SONATA_GRPC_SERVER_PORT
     CHANNEL = grpc.aio.insecure_channel(f"localhost:{port}")
     SONATA_GRPC_SERVICE = sonata_grpcStub(CHANNEL)
+
 
 
 @atexit.register

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -78,6 +78,7 @@ SERVER_CHECK_TIMEOUT = 15
 # coroutine's own error surfaces instead of a bare future timeout.
 STARTUP_TIMEOUT = SERVER_CHECK_TIMEOUT + 5
 CALL_TIMEOUT = 10
+CHANNEL_CLOSE_TIMEOUT = 5
 
 
 def start_grpc_server():
@@ -158,14 +159,35 @@ async def initialize():
     SONATA_GRPC_SERVICE = sonata_grpcStub(CHANNEL)
 
 
+def close_channel():
+    """Close the aio channel on the loop that owns it.
+
+    Channel.close() is a coroutine whose internals walk the running loop's
+    task set, so it cannot be driven from another thread or a stopped loop.
+    """
+    global CHANNEL
+    if CHANNEL is None:
+        return
+    channel, CHANNEL = CHANNEL, None
+    loop = aio.ASYNCIO_EVENT_LOOP
+    if loop is None or not loop.is_running():
+        log.debug("Discarding the GRPC channel: its event loop is gone")
+        channel.close().close()
+        return
+    try:
+        asyncio.run_coroutine_threadsafe(channel.close(), loop).result(
+            timeout=CHANNEL_CLOSE_TIMEOUT
+        )
+    except Exception:
+        log.debug("Failed to close the GRPC channel cleanly", exc_info=True)
+
+
 @atexit.register
 def terminate():
-    global CHANNEL, GRPC_SERVER_PROCESS, SONATA_GRPC_SERVER_PORT
+    global GRPC_SERVER_PROCESS, SONATA_GRPC_SERVER_PORT
     SONATA_GRPC_SERVER_PORT = None
+    close_channel()
     aio.terminate()
-    if CHANNEL is not None:
-        CHANNEL.close()
-        CHANNEL = None
     if GRPC_SERVER_PROCESS is not None:
         GRPC_SERVER_PROCESS.terminate()
         GRPC_SERVER_PROCESS = None

--- a/addon/synthDrivers/sonata_neural_voices/tts_system.py
+++ b/addon/synthDrivers/sonata_neural_voices/tts_system.py
@@ -114,7 +114,7 @@ class SonataVoice:
             )
         voice_info = grpc_client.load_voice(
             os.fspath(self.config_path)
-        ).result(timeout=10)
+        ).result(timeout=grpc_client.CALL_TIMEOUT)
         self.remote_id = voice_info.voice_id
         self.supports_streaming_output = voice_info.supports_streaming_output
         default_synth_options = voice_info.synth_options
@@ -132,41 +132,51 @@ class SonataVoice:
         else:
             self.default_speaker = None
 
+    def _get_synth_option(self, name):
+        options = grpc_client.get_synth_options(self.remote_id).result(
+            timeout=grpc_client.CALL_TIMEOUT
+        )
+        return getattr(options, name)
+
+    def _set_synth_option(self, **kwargs):
+        grpc_client.set_synth_options(self.remote_id, **kwargs).result(
+            timeout=grpc_client.CALL_TIMEOUT
+        )
+
     @property
     def speaker(self):
         if self.is_multi_speaker:
-            return grpc_client.get_synth_options(self.remote_id).result(timeout=10).speaker
+            return self._get_synth_option("speaker")
         return FALLBACK_SPEAKER_NAME
 
     @speaker.setter
     def speaker(self, value):
         if self.is_multi_speaker:
-            grpc_client.set_synth_options(self.remote_id, speaker=value).result(timeout=10)
+            self._set_synth_option(speaker=value)
 
     @property
     def noise_scale(self):
-        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).noise_scale
+        return self._get_synth_option("noise_scale")
 
     @noise_scale.setter
     def noise_scale(self, value):
-        grpc_client.set_synth_options(self.remote_id, noise_scale=value).result(timeout=10)
+        self._set_synth_option(noise_scale=value)
 
     @property
     def length_scale(self):
-        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).length_scale
+        return self._get_synth_option("length_scale")
 
     @length_scale.setter
     def length_scale(self, value):
-        grpc_client.set_synth_options(self.remote_id, length_scale=value).result(timeout=10)
+        self._set_synth_option(length_scale=value)
 
     @property
     def noise_w(self):
-        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).noise_w
+        return self._get_synth_option("noise_w")
 
     @noise_w.setter
     def noise_w(self, value):
-        grpc_client.set_synth_options(self.remote_id, noise_w=value).result(timeout=10)
-
+        self._set_synth_option(noise_w=value)
 
     @property
     def is_fast(self):

--- a/addon/synthDrivers/sonata_neural_voices/tts_system.py
+++ b/addon/synthDrivers/sonata_neural_voices/tts_system.py
@@ -114,7 +114,7 @@ class SonataVoice:
             )
         voice_info = grpc_client.load_voice(
             os.fspath(self.config_path)
-        ).result()
+        ).result(timeout=10)
         self.remote_id = voice_info.voice_id
         self.supports_streaming_output = voice_info.supports_streaming_output
         default_synth_options = voice_info.synth_options
@@ -135,37 +135,38 @@ class SonataVoice:
     @property
     def speaker(self):
         if self.is_multi_speaker:
-            return grpc_client.get_synth_options(self.remote_id).result().speaker
+            return grpc_client.get_synth_options(self.remote_id).result(timeout=10).speaker
         return FALLBACK_SPEAKER_NAME
 
     @speaker.setter
     def speaker(self, value):
         if self.is_multi_speaker:
-            grpc_client.set_synth_options(self.remote_id, speaker=value).result()
+            grpc_client.set_synth_options(self.remote_id, speaker=value).result(timeout=10)
 
     @property
     def noise_scale(self):
-        return grpc_client.get_synth_options(self.remote_id).result().noise_scale
+        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).noise_scale
 
     @noise_scale.setter
     def noise_scale(self, value):
-        grpc_client.set_synth_options(self.remote_id, noise_scale=value).result()
+        grpc_client.set_synth_options(self.remote_id, noise_scale=value).result(timeout=10)
 
     @property
     def length_scale(self):
-        return grpc_client.get_synth_options(self.remote_id).result().length_scale
+        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).length_scale
 
     @length_scale.setter
     def length_scale(self, value):
-        grpc_client.set_synth_options(self.remote_id, length_scale=value).result()
+        grpc_client.set_synth_options(self.remote_id, length_scale=value).result(timeout=10)
 
     @property
     def noise_w(self):
-        return grpc_client.get_synth_options(self.remote_id).result().noise_w
+        return grpc_client.get_synth_options(self.remote_id).result(timeout=10).noise_w
 
     @noise_w.setter
     def noise_w(self, value):
-        grpc_client.set_synth_options(self.remote_id, noise_w=value).result()
+        grpc_client.set_synth_options(self.remote_id, noise_w=value).result(timeout=10)
+
 
     @property
     def is_fast(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -243,6 +243,9 @@ _grpc_client.get_synth_options = MagicMock(
 )
 _grpc_client.set_synth_options = MagicMock(return_value=_make_ready_future(None))
 _grpc_client.SONATA_GRPC_SERVER_PORT = 50051
+_grpc_client.SERVER_CHECK_TIMEOUT = 15
+_grpc_client.STARTUP_TIMEOUT = 20
+_grpc_client.CALL_TIMEOUT = 10
 
 # aio — starts real threads/event loops; stub completely
 _aio = _stub_module("sonata_neural_voices.aio")

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -1,0 +1,76 @@
+# coding: utf-8
+"""
+Tests for aio module lifecycle resilience and re-initialization behavior.
+"""
+
+import os
+import importlib.util
+import pytest
+
+_TESTS_DIR = os.path.dirname(__file__)
+_AIO_PATH = os.path.join(
+    _TESTS_DIR, "..", "addon", "synthDrivers", "sonata_neural_voices", "aio.py"
+)
+
+
+def _load_real_aio():
+    spec = importlib.util.spec_from_file_location(
+        "sonata_neural_voices.aio_real", _AIO_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+aio = _load_real_aio()
+
+
+class TestAioLifecycle:
+
+    def setup_method(self):
+        aio.initialize()
+
+    def teardown_method(self):
+        aio.terminate()
+
+    def test_initialize_is_idempotent(self):
+        aio.initialize()
+        aio.initialize()
+        assert aio.ASYNCIO_EVENT_LOOP is not None
+        assert aio.ASYNCIO_EVENT_LOOP.is_running()
+        assert aio.THREADED_EXECUTOR is not None
+
+    def test_reinitialization_after_terminate(self):
+        # Shutdown loop and executor
+        aio.terminate()
+        assert aio.THREADED_EXECUTOR is None
+
+        # Re-initialize
+        aio.initialize()
+        assert aio.ASYNCIO_EVENT_LOOP is not None
+        assert aio.ASYNCIO_EVENT_LOOP.is_running()
+        assert aio.THREADED_EXECUTOR is not None
+
+    def test_asyncio_coroutine_to_concurrent_future_resurrects_stopped_loop(self):
+        aio.terminate()
+
+        @aio.asyncio_coroutine_to_concurrent_future
+        async def dummy_coro():
+            return 42
+
+        fut = dummy_coro()
+        assert fut.result(timeout=5) == 42
+
+    def test_run_in_executor_resurrects_stopped_loop(self):
+        aio.terminate()
+
+        def sync_fn(val):
+            return val * 2
+
+        @aio.asyncio_coroutine_to_concurrent_future
+        async def run_test():
+            return await aio.run_in_executor(sync_fn, 21)
+
+        fut = run_test()
+        assert fut.result(timeout=5) == 42
+

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -4,10 +4,14 @@ Tests for aio module lifecycle resilience and re-initialization behavior.
 """
 
 import ast
+import asyncio
+import gc
 import os
 import glob
 import threading
 import time
+import types
+import warnings
 import importlib.util
 
 _STRESS_THREADS = 8
@@ -18,8 +22,42 @@ _PKG_DIR = os.path.join(
     _TESTS_DIR, "..", "addon", "synthDrivers", "sonata_neural_voices"
 )
 _AIO_PATH = os.path.join(_PKG_DIR, "aio.py")
+_GRPC_CLIENT_PATH = os.path.join(_PKG_DIR, "grpc_client", "__init__.py")
 
 _LOOP_THREAD_NAME = "piper4nvda_asyncio"
+
+
+def _load_module_function(path, name, namespace):
+    """Exec a single top-level function against a stubbed namespace.
+
+    grpc_client imports grpc and NVDA globals, so it cannot be imported here.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        source = f.read()
+    for node in ast.parse(source, filename=path).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            exec(ast.get_source_segment(source, node), namespace)
+            return namespace[name]
+    raise LookupError(f"{name} not found in {path}")
+
+
+class _FakeAioChannel:
+    """Stands in for grpc.aio.Channel, whose close() is a coroutine."""
+
+    def __init__(self):
+        self.close_awaited = False
+        self.closed_on_loop = None
+
+    async def _close(self):
+        self.close_awaited = True
+        self.closed_on_loop = asyncio.get_running_loop()
+
+    def close(self):
+        return self._close()
+
+
+def _never_awaited_warnings(caught):
+    return [w for w in caught if "never awaited" in str(w.message)]
 
 
 def _load_real_aio():
@@ -205,6 +243,60 @@ class TestAioGlobalsAreNotAliased:
             "aio.initialize() rebinds the loop. Reference aio.ASYNCIO_EVENT_LOOP or "
             "asyncio.get_running_loop() instead."
         )
+
+
+class TestGrpcChannelTeardown:
+
+    def setup_method(self):
+        aio.initialize()
+
+    def teardown_method(self):
+        aio.terminate()
+
+    def _close_channel_with(self, channel):
+        namespace = {
+            "asyncio": asyncio,
+            "aio": aio,
+            "log": types.SimpleNamespace(debug=lambda *a, **k: None),
+            "CHANNEL": channel,
+            "CHANNEL_CLOSE_TIMEOUT": 5,
+        }
+        close_channel = _load_module_function(
+            _GRPC_CLIENT_PATH, "close_channel", namespace
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            close_channel()
+            gc.collect()
+        return namespace, caught
+
+    def test_dropping_the_close_coroutine_is_detectable(self):
+        """Self-check: the assertions below are only meaningful if this warns."""
+        channel = _FakeAioChannel()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            channel.close()
+            gc.collect()
+
+        assert _never_awaited_warnings(caught)
+
+    def test_close_channel_awaits_close_on_the_owning_loop(self):
+        channel = _FakeAioChannel()
+        namespace, caught = self._close_channel_with(channel)
+
+        assert channel.close_awaited
+        assert channel.closed_on_loop is aio.ASYNCIO_EVENT_LOOP
+        assert namespace["CHANNEL"] is None
+        assert _never_awaited_warnings(caught) == []
+
+    def test_close_channel_discards_coroutine_when_loop_is_gone(self):
+        aio.terminate()
+        channel = _FakeAioChannel()
+        namespace, caught = self._close_channel_with(channel)
+
+        assert not channel.close_awaited
+        assert namespace["CHANNEL"] is None
+        assert _never_awaited_warnings(caught) == []
 
 
 class TestCrossModuleAttributesResolve:

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -3,14 +3,19 @@
 Tests for aio module lifecycle resilience and re-initialization behavior.
 """
 
+import ast
 import os
+import glob
+import threading
 import importlib.util
-import pytest
 
 _TESTS_DIR = os.path.dirname(__file__)
-_AIO_PATH = os.path.join(
-    _TESTS_DIR, "..", "addon", "synthDrivers", "sonata_neural_voices", "aio.py"
+_PKG_DIR = os.path.join(
+    _TESTS_DIR, "..", "addon", "synthDrivers", "sonata_neural_voices"
 )
+_AIO_PATH = os.path.join(_PKG_DIR, "aio.py")
+
+_LOOP_THREAD_NAME = "piper4nvda_asyncio"
 
 
 def _load_real_aio():
@@ -73,4 +78,61 @@ class TestAioLifecycle:
 
         fut = run_test()
         assert fut.result(timeout=5) == 42
+
+    def test_task_creation_resolves_the_live_loop_after_reinitialization(self):
+        aio.terminate()
+
+        async def spoken():
+            return "spoken"
+
+        @aio.asyncio_coroutine_to_concurrent_future
+        async def create_task_like_process_speech():
+            loop = aio.asyncio.get_running_loop()
+            assert loop is aio.ASYNCIO_EVENT_LOOP
+            return await loop.create_task(spoken())
+
+        assert create_task_like_process_speech().result(timeout=5) == "spoken"
+
+    def test_terminate_closes_and_clears_the_loop(self):
+        loop = aio.ASYNCIO_EVENT_LOOP
+        assert loop is not None
+
+        aio.terminate()
+
+        assert loop.is_closed()
+        assert aio.ASYNCIO_EVENT_LOOP is None
+
+    def test_repeated_cycles_do_not_accumulate_loop_threads(self):
+        for _ in range(10):
+            aio.terminate()
+            aio.initialize()
+
+        live = [t for t in threading.enumerate() if t.name == _LOOP_THREAD_NAME]
+        assert len(live) == 1
+
+
+class TestAioGlobalsAreNotAliased:
+    """Guards against re-introducing a stale by-value import of a mutable aio global."""
+
+    def test_no_module_imports_the_event_loop_by_value(self):
+        offenders = []
+        for path in glob.glob(os.path.join(_PKG_DIR, "**", "*.py"), recursive=True):
+            if f"{os.sep}lib{os.sep}" in path:
+                continue
+            with open(path, "r", encoding="utf-8") as f:
+                tree = ast.parse(f.read(), filename=path)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ImportFrom) or node.level == 0:
+                    continue
+                if (node.module or "").split(".")[-1] != "aio":
+                    continue
+                for alias in node.names:
+                    if alias.name == "ASYNCIO_EVENT_LOOP":
+                        offenders.append(os.path.basename(path))
+
+        assert offenders == [], (
+            f"{offenders} import ASYNCIO_EVENT_LOOP by value; the alias goes stale once "
+            "aio.initialize() rebinds the loop. Reference aio.ASYNCIO_EVENT_LOOP or "
+            "asyncio.get_running_loop() instead."
+        )
 

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -7,7 +7,11 @@ import ast
 import os
 import glob
 import threading
+import time
 import importlib.util
+
+_STRESS_THREADS = 8
+_STRESS_ITERATIONS = 40
 
 _TESTS_DIR = os.path.dirname(__file__)
 _PKG_DIR = os.path.join(
@@ -27,7 +31,48 @@ def _load_real_aio():
     return mod
 
 
+def _package_sources():
+    """(path, AST) for every first-party module, skipping vendored libraries."""
+    for path in sorted(glob.glob(os.path.join(_PKG_DIR, "**", "*.py"), recursive=True)):
+        if f"{os.sep}lib{os.sep}" in path:
+            continue
+        with open(path, "r", encoding="utf-8") as f:
+            yield path, ast.parse(f.read(), filename=path)
+
+
+def _top_level_names(tree):
+    names = set()
+    body = list(tree.body)
+    for node in tree.body:
+        if isinstance(node, ast.With):
+            body.extend(node.body)
+    for node in body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(a.asname or a.name.split(".")[0] for a in node.names)
+        elif isinstance(node, ast.Assign):
+            names.update(
+                t.id for t in node.targets if isinstance(t, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return names
+
+
 aio = _load_real_aio()
+
+
+def _settled_loop_thread_count(timeout=2):
+    """Loop-thread count once stopped threads have had a chance to exit."""
+    deadline = time.monotonic() + timeout
+    while True:
+        count = len(
+            [t for t in threading.enumerate() if t.name == _LOOP_THREAD_NAME]
+        )
+        if count <= 1 or time.monotonic() > deadline:
+            return count
+        time.sleep(0.05)
 
 
 class TestAioLifecycle:
@@ -107,8 +152,37 @@ class TestAioLifecycle:
             aio.terminate()
             aio.initialize()
 
-        live = [t for t in threading.enumerate() if t.name == _LOOP_THREAD_NAME]
-        assert len(live) == 1
+        assert _settled_loop_thread_count() == 1
+
+    def test_concurrent_ensure_running_does_not_orphan_loops(self):
+        errors = []
+        barrier = threading.Barrier(_STRESS_THREADS + 1)
+
+        def worker():
+            barrier.wait()
+            for _ in range(_STRESS_ITERATIONS):
+                try:
+                    aio.ensure_running()
+                except Exception as exc:
+                    errors.append(repr(exc))
+                    continue
+                if aio.ASYNCIO_EVENT_LOOP is None:
+                    errors.append("ensure_running() left ASYNCIO_EVENT_LOOP unset")
+
+        threads = [threading.Thread(target=worker) for _ in range(_STRESS_THREADS)]
+        for thread in threads:
+            thread.start()
+
+        barrier.wait()
+        for _ in range(15):
+            aio.terminate()
+            time.sleep(0.01)
+        for thread in threads:
+            thread.join()
+
+        aio.ensure_running()
+        assert errors == []
+        assert _settled_loop_thread_count() == 1
 
 
 class TestAioGlobalsAreNotAliased:
@@ -116,11 +190,7 @@ class TestAioGlobalsAreNotAliased:
 
     def test_no_module_imports_the_event_loop_by_value(self):
         offenders = []
-        for path in glob.glob(os.path.join(_PKG_DIR, "**", "*.py"), recursive=True):
-            if f"{os.sep}lib{os.sep}" in path:
-                continue
-            with open(path, "r", encoding="utf-8") as f:
-                tree = ast.parse(f.read(), filename=path)
+        for path, tree in _package_sources():
             for node in ast.walk(tree):
                 if not isinstance(node, ast.ImportFrom) or node.level == 0:
                     continue
@@ -134,5 +204,34 @@ class TestAioGlobalsAreNotAliased:
             f"{offenders} import ASYNCIO_EVENT_LOOP by value; the alias goes stale once "
             "aio.initialize() rebinds the loop. Reference aio.ASYNCIO_EVENT_LOOP or "
             "asyncio.get_running_loop() instead."
+        )
+
+
+class TestCrossModuleAttributesResolve:
+    """__init__.py cannot be imported without NVDA, so check its references statically."""
+
+    def test_grpc_client_attribute_references_are_defined(self):
+        sources = dict(_package_sources())
+        grpc_client_path = os.path.join(_PKG_DIR, "grpc_client", "__init__.py")
+        defined = _top_level_names(sources[grpc_client_path])
+
+        unresolved = []
+        for path, tree in sources.items():
+            if path == grpc_client_path:
+                continue
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Attribute)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == "grpc_client"
+                    and node.attr not in defined
+                ):
+                    unresolved.append(
+                        f"{os.path.basename(path)}:{node.lineno} grpc_client.{node.attr}"
+                    )
+
+        assert unresolved == [], (
+            f"{unresolved} reference names that grpc_client does not define at module "
+            "level; these fail at runtime only, since NVDA-only modules are not importable."
         )
 

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -8,9 +8,12 @@ No real gRPC server is required.
 
 import sys
 import pytest
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from sonata_neural_voices import grpc_client
 from sonata_neural_voices.tts_system import (
     SonataVoice,
     SonataTextToSpeechSystem,
@@ -302,6 +305,46 @@ class TestSpeakerSingleVoice:
     def test_set_speaker_on_non_multispeaker_is_noop(self, tts):
         # Should not raise
         tts.speaker = FALLBACK_SPEAKER_NAME
+
+
+# ---------------------------------------------------------------------------
+# Synthesis options (gRPC-backed accessors)
+# ---------------------------------------------------------------------------
+
+class TestSynthOptionAccessors:
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [("noise_scale", 0.667), ("length_scale", 1.0), ("noise_w", 0.8)],
+    )
+    def test_getter_reads_option_from_server(self, multi_voice, name, expected):
+        assert getattr(multi_voice, name) == expected
+
+    @pytest.mark.parametrize("name", ["noise_scale", "length_scale", "noise_w"])
+    def test_setter_forwards_option_to_server(self, multi_voice, name):
+        grpc_client.set_synth_options.reset_mock()
+        setattr(multi_voice, name, 1.5)
+        grpc_client.set_synth_options.assert_called_once_with(
+            multi_voice.remote_id, **{name: 1.5}
+        )
+
+    def test_speaker_getter_reads_from_server_for_multi_speaker(self, multi_voice):
+        assert multi_voice.speaker == "default"
+
+    def test_speaker_setter_forwards_to_server_for_multi_speaker(self, multi_voice):
+        grpc_client.set_synth_options.reset_mock()
+        multi_voice.speaker = "Bob"
+        grpc_client.set_synth_options.assert_called_once_with(
+            multi_voice.remote_id, speaker="Bob"
+        )
+
+    def test_accessors_bound_the_wait_on_the_server(self, multi_voice, monkeypatch):
+        monkeypatch.setattr(grpc_client, "CALL_TIMEOUT", 0.05)
+        monkeypatch.setattr(
+            grpc_client, "get_synth_options", MagicMock(return_value=Future())
+        )
+        with pytest.raises(FuturesTimeoutError):
+            multi_voice.noise_scale
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #27: Resolves the NVDA main thread crash/freeze when double-tapping the profile reload shortcut (`NVDA + Control + R`).

## Root Cause
When NVDA profile is reloaded, NVDA calls `SynthDriver.terminate()`, which invoked `aio.terminate()`. `aio.terminate()` stopped the background `ASYNCIO_EVENT_LOOP` and destroyed `THREADED_EXECUTOR`. When NVDA immediately instantiated a new `SynthDriver()`, the module was not re-imported (it remained cached in `sys.modules`), so top-level module initialization did not run. `SynthDriver.__init__()` attempted to load voices via `grpc_client.load_voice(...).result()`, which submitted coroutines to the stopped `ASYNCIO_EVENT_LOOP` via `asyncio.run_coroutine_threadsafe`. Calling `.result()` on the NVDA main speech thread blocked indefinitely, silencing the screen reader.

## Changes Made
1. **Idempotent `aio` Lifecycle**:
   - Made `aio.initialize()` and `ensure_running()` idempotent and self-healing. If `THREADED_EXECUTOR` or `ASYNCIO_LOOP_THREAD` is stopped, it cleans up and launches a fresh event loop thread.
   - Updated `terminate()` to join background threads safely without race conditions.
2. **gRPC Channel Re-binding**:
   - Updated `grpc_client.initialize()` to re-bind channels and stubs automatically if the underlying event loop thread is recreated.
3. **Driver Instance Cleanup & Timeout Safety**:
   - Removed module-wide `aio.terminate()` from per-instance `SynthDriver.terminate()`.
   - Called `aio.ensure_running()` in `SynthDriver.__init__()`.
   - Added explicit `timeout=10` to blocking `.result()` calls on futures to ensure NVDA's main thread never deadlocks.
4. **Test Suite**:
   - Added `tests/test_driver_lifecycle.py` to verify `aio` idempotency, re-initialization after termination, and task execution across teardown cycles.