### PR TITLE
feat(i18n): add Turkish and Kurdish (Kurmanji) translations

### DIFF
--- a/addon/doc/kmr/readme.md
+++ b/addon/doc/kmr/readme.md
@@ -1,0 +1,55 @@
+# Dengên neuronî yên Sonata ji bo NVDA
+
+> **Danezana lênêrîna vê çapê (fork)**
+>
+> Nivîskarê resen, Musharraf Omer ([@mush42](https://github.com/mush42)), [di lîsteya pêvekên NVDA de ragihand](https://nvda-addons.groups.io/g/nvda-addons/message/27636) ku nakokiyên peymanên bazirganî nahêlin ku ew lênêrîna vê pêveka çavkaniya vekirî bidomîne. Ev çap projeyê didomîne da ku pêvek li ser guhertoyên heyî yên NVDA-yê bixebite. Hemû keda xebata resen a Musharraf Omer e.
+>
+> Dibe ku ev werger li paş [benioku ya îngilîzî](https://github.com/austek/sonata-nvda/blob/main/readme.md) bimîne.
+
+Ev pêvek bi modelên TTS ên neuronî ajokarekî sentezkera axaftinê ji bo NVDA-yê pêk tîne. Ew piştgiriyê dide [Piper](https://github.com/rhasspy/piper).
+
+[Piper](https://github.com/rhasspy/piper) pergaleke bilez û herêmî ya neuronî ya nivîs-bo-axaftinê ye ku dengê wê xweş e û ji bo cîhazên kêm-hêz ên wek Raspberry Pi hatiye xweşkirin.
+
+Tu dikarî nimûneyên dengên Piper li vir guhdarî bikî: [Piper voice samples](https://rhasspy.github.io/piper-samples/).
+
+Ev pêvek [Sonata: motoreke Rust a pir-platformî ji bo modelên TTS ên neuronî](https://github.com/mush42/sonata) bi kar tîne, ku ji aliyê Musharraf Omer ve tê pêşxistin.
+
+
+# Pêdiviyên pergalê
+
+- NVDA 2025.1 an nûtir (heta 2026.1 hat ceribandin).
+- [Microsoft Visual C++ 2015-2022 Redistributable (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe). Motora axaftinê ya ku bi pêvekê re tê, bi MSVC hatiye avakirin û bêyî wê dest pê nake. Ger ew kêm be, pêvek peyamekê nîşan dide ku te ber bi vê daxistinê ve dibe; wê saz bike û NVDA ji nû ve dest pê bike. Li ser piraniya komputerên Windows ew jixwe sazkirî ye.
+
+# Sazkirin
+
+## Daxistina pêvekê
+
+Tu dikarî pakêta pêvekê di beşa assets a [rûpela berdanê](https://github.com/austek/sonata-nvda/releases/latest) de bibînî.
+
+## Ragihandina pirsgirêkan
+
+Ji kerema xwe çewtiyan û daxwazên taybetmendiyan li [şopînerê pirsgirêkan ê vê çapê](https://github.com/austek/sonata-nvda/issues) ragihîne.
+
+## Zêdekirina dengan
+
+Pêvek tenê ajokarek e, bi xwe re tu dengî nayne. Divê tu dengên ku dixwazî ji rêveberê dengan daxînî û saz bikî.
+
+Piştî sazkirina pêvekê û ji nû ve destpêkirina NVDA-yê, pêvek dê ji te bixwaze ku bi kêmî ve dengekî daxînî û saz bikî, û dê vebijarka vekirina rêveberê dengan pêşkêş bike.
+
+Tu dikarî rêveberê dengan ji pêşeka sereke ya NVDA-yê jî vekî.
+
+Em pêşniyar dikin ku ji bo zimanê xwe yê armanc dengên kalîteya `low` an `medium` hilbijêrî, ji ber ku ew bi gelemperî bersivdayîneke çêtir didin. Ji bo bersivdayîneke hîn bileztir, tu dikarî guhertoya `fast` a dengekî daxînî; lê kalîteya axaftinê hinekî kêmtir dibe.
+
+Tu dikarî dengan ji arşîvên herêmî jî saz bikî. Piştî ku te pelê dengî peyda kir, rêveberê dengan veke, di rûpela Sazkirî de li ser bişkoka bi navê `Ji pelê herêmî saz bike` bitikîne. Pelê dengî hilbijêre, li bendê bimîne heta deng saz bibe, û ji bo nûkirina lîsteya dengan NVDA ji nû ve dest pê bike.
+
+## Têbîniyek li ser kalîteya dengan
+
+Dengên ku niha berdest in bi komên daneyên TTS ên belaş hatine perwerdekirin, ku bi gelemperî kalîteya wan nizm e (bi piranî pirtûkên deng ên di warê giştî de an tomarên bi kalîteya lêkolînê).
+
+Wekî din, ev komên daneyan ne berfireh in, loma dibe ku hin deng bilêvkirineke çewt an ecêb derxînin. Her du pirsgirêk jî bi bikaranîna komên daneyên çêtir ji bo perwerdekirinê çareser dibin.
+
+Bi bextewarî, pêşxistkarê `Piper` û hin pêşxistkarên ji civata kor û kêmbînan li ser perwerdekirina dengên çêtir dixebitin.
+
+# Lîsans
+
+Copyright(c) 2024, Musharraf Omer. Copyright(c) 2026, Ali Ustek û beşdarên vê çapê. Ev nermalav bi GNU GENERAL PUBLIC LICENSE Version 2 (GPL v2) hatiye lîsanskirin.

--- a/addon/doc/tr/readme.md
+++ b/addon/doc/tr/readme.md
@@ -1,0 +1,55 @@
+# NVDA için Sonata sinir ağı sesleri
+
+> **Bakım çatalı bildirimi**
+>
+> Özgün yazar Musharraf Omer ([@mush42](https://github.com/mush42)), ticari sözleşme çakışmaları nedeniyle bu açık kaynaklı eklentiyi sürdüremeyeceğini [NVDA Eklentileri listesinde duyurdu](https://nvda-addons.groups.io/g/nvda-addons/message/27636). Bu çatal, eklentiyi güncel NVDA sürümlerinde çalışır durumda tutmak için projeyi sürdürüyor. Özgün çalışmanın tüm hakkı Musharraf Omer'e aittir.
+>
+> Bu çeviri, [İngilizce benioku dosyasının](https://github.com/austek/sonata-nvda/blob/main/readme.md) gerisinde kalmış olabilir.
+
+Bu eklenti, sinir ağı tabanlı TTS modellerini kullanarak NVDA için bir konuşma sentezleyici sürücüsü sağlar. [Piper](https://github.com/rhasspy/piper) desteklenir.
+
+[Piper](https://github.com/rhasspy/piper), kulağa doğal gelen ve Raspberry Pi gibi düşük donanımlı cihazlar için iyileştirilmiş, hızlı ve yerel çalışan bir sinir ağı metin okuma sistemidir.
+
+Piper'ın ses örneklerini buradan dinleyebilirsiniz: [Piper voice samples](https://rhasspy.github.io/piper-samples/).
+
+Bu eklenti, Musharraf Omer tarafından geliştirilen [Sonata: sinir ağı TTS modelleri için platformlar arası bir Rust motoru](https://github.com/mush42/sonata) kullanır.
+
+
+# Gereksinimler
+
+- NVDA 2025.1 veya sonrası (2026.1 sürümüne kadar sınandı).
+- [Microsoft Visual C++ 2015-2022 Yeniden Dağıtılabilir Paketi (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe). Eklentiyle birlikte gelen konuşma motoru MSVC ile derlenmiştir ve bu paket olmadan başlatılamaz. Paket eksikse eklenti sizi bu indirmeye yönlendiren bir ileti gösterir; paketi kurup NVDA'yı yeniden başlatın. Windows çalıştıran çoğu bilgisayarda bu paket zaten kuruludur.
+
+# Kurulum
+
+## Eklentiyi indirme
+
+Eklenti paketini [sürüm sayfasındaki](https://github.com/austek/sonata-nvda/releases/latest) assets bölümünde bulabilirsiniz.
+
+## Sorun bildirme
+
+Lütfen hataları ve özellik isteklerini [bu çatalın sorun izleyicisinde](https://github.com/austek/sonata-nvda/issues) bildirin.
+
+## Ses ekleme
+
+Eklenti yalnızca bir sürücüdür, öntanımlı olarak hiçbir sesle gelmez. İstediğiniz sesleri ses yöneticisinden indirip yüklemeniz gerekir.
+
+Eklentiyi kurup NVDA'yı yeniden başlattığınızda eklenti sizden en az bir ses indirip yüklemenizi ister ve ses yöneticisini açma seçeneği sunar.
+
+Ses yöneticisini NVDA'nın ana menüsünden de açabilirsiniz.
+
+Hedef dil veya dilleriniz için `low` ya da `medium` kalitedeki sesleri seçmenizi öneririz; bunlar genellikle daha iyi yanıt hızı sağlar. Daha da hızlı bir yanıt için bir sesin `fast` sürümünü indirmeyi seçebilirsiniz; bu, konuşma kalitesinde hafif bir düşüşe yol açar.
+
+Sesleri yerel arşivlerden de yükleyebilirsiniz. Ses dosyasını edindikten sonra ses yöneticisini açın, Yüklü sekmesinde `Yerel dosyadan yükle` etiketli düğmeye tıklayın. Ses dosyasını seçin, sesin yüklenmesini bekleyin ve ses listesini tazelemek için NVDA'yı yeniden başlatın.
+
+## Ses kalitesi üzerine bir not
+
+Şu anda kullanılabilen sesler, genellikle düşük kaliteli olan (çoğunlukla kamu malı sesli kitaplar veya araştırma amaçlı kayıtlar) ücretsiz TTS veri kümeleriyle eğitilmiştir.
+
+Ayrıca bu veri kümeleri kapsamlı değildir, bu nedenle bazı sesler hatalı veya tuhaf telaffuzlar üretebilir. Her iki sorun da eğitim için daha iyi veri kümeleri kullanılarak giderilebilir.
+
+Neyse ki `Piper` geliştiricisi ile kör ve az gören topluluğundan bazı geliştiriciler daha iyi sesler eğitmek üzere çalışıyor.
+
+# Lisans
+
+Copyright(c) 2024, Musharraf Omer. Copyright(c) 2026, Ali Ustek ve bu çatalın katkıcıları. Bu yazılım GNU GENERAL PUBLIC LICENSE Version 2 (GPL v2) ile lisanslanmıştır.

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -1,0 +1,419 @@
+# Translation of the 'sonata_neural_voices' NVDA add-on into Kurdish (Kurmanji).
+# Copyright (C) 2024 Musharraf Omer, 2026 Ali Ustek and contributors.
+# This file is distributed under the same license as the 'sonata_neural_voices' package.
+# Initial draft; corrections from native speakers are welcome.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 'sonata_neural_voices' '3.2.0'\n"
+"Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
+"POT-Creation-Date: 2026-07-31 00:00+0000\n"
+"PO-Revision-Date: 2026-07-31 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: kmr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Translators: label of a menu item
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:46
+msgid "Sonata &voice manager..."
+msgstr "&Rêveberê dengên Sonata..."
+
+#. Translators: Sonata's voice manager menu item help
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:48
+msgid "Open the voice manager to preview, install or download sonata voices"
+msgstr "Ji bo pêşdîtin, sazkirin an daxistina dengên Sonata rêveberê dengan veke"
+
+#. Translators: message telling the user that no voice is installed
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:63
+msgid ""
+"No Sonata voice was found.\n"
+"You can preview and download voices from the voice manager.\n"
+"Do you want to open the voice manager now?"
+msgstr ""
+"Tu dengê Sonata nehat dîtin.\n"
+"Tu dikarî dengan ji rêveberê dengan pêşdîtin û daxînî.\n"
+"Ma tu dixwazî rêveberê dengan niha vekî?"
+
+#. Translators: title of a message telling the user that no Sonata voice was found
+#. Add-on summary/title, usually the user visible name of the add-on
+#. Translators: Summary/title for this add-on
+#. to be shown on installation and add-on information found in add-on store
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:69
+#: buildVars.py:21
+msgid "Sonata Neural Voices"
+msgstr "Dengên Neuronî yên Sonata"
+
+#. Translators: the label of the OK button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\components.py:86
+msgid "OK"
+msgstr "Temam"
+
+#. Translators: the label of the cancel button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\components.py:89
+msgid "Cancel"
+msgstr "Betal"
+
+#. Translators: message of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:193
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:353
+msgid "Downloaded: {progress}%"
+msgstr "Hat daxistin: {progress}%"
+
+#. Translators: message shown in the voice download progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:202
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:362
+msgid "Installing voice"
+msgstr "Deng tê sazkirin"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:230
+msgid ""
+"Successfully downloaded voice  {voice}.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+"Dengê {voice} bi serkeftî hat daxistin.\n"
+"Ji bo bikaranîna vî dengî divê tu NVDA ji nû ve dest pê bikî.\n"
+"Ma tu dixwazî NVDA niha ji nû ve dest pê bikî?"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:238
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:385
+msgid "Voice downloaded"
+msgstr "Deng hat daxistin"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:247
+msgid ""
+"Cannot download voice {voice}.\n"
+"Please check your connection and try again."
+msgstr ""
+"Dengê {voice} nayê daxistin.\n"
+"Ji kerema xwe girêdana xwe kontrol bike û dîsa biceribîne."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:250
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:397
+msgid "Download failed"
+msgstr "Daxistin bi ser neket"
+
+#. Translators: title of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:261
+msgid "Downloading voice {voice}"
+msgstr "Dengê {voice} tê daxistin"
+
+#. Translators: message of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:265
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:412
+msgid "Retrieving download information..."
+msgstr "Agahiyên daxistinê tên anîn..."
+
+#. Translators: message shown in progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:277
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:423
+msgid "Downloading file: {file}"
+msgstr "Pel tê daxistin: {file}"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:377
+msgid ""
+"Successfully downloaded fast variant of the voice  {voice}.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+"Guhertoya bilez a dengê {voice} bi serkeftî hat daxistin.\n"
+"Ji bo bikaranîna vî dengî divê tu NVDA ji nû ve dest pê bikî.\n"
+"Ma tu dixwazî NVDA niha ji nû ve dest pê bikî?"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:394
+msgid ""
+"Cannot download fast variant of the voice {voice}.\n"
+"Please check your connection and try again."
+msgstr ""
+"Guhertoya bilez a dengê {voice} nayê daxistin.\n"
+"Ji kerema xwe girêdana xwe kontrol bike û dîsa biceribîne."
+
+#. Translators: title of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:408
+msgid "Downloading fast variant of the voice {voice}"
+msgstr "Guhertoya bilez a dengê {voice} tê daxistin"
+
+#. Add controls
+#. Translators: label for a list of installed voices
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:42
+msgid "Installed voices"
+msgstr "Dengên sazkirî"
+
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:48
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:245
+msgid "Name"
+msgstr "Nav"
+
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:51
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:247
+msgid "Quality"
+msgstr "Kalîte"
+
+#. Build controls
+#. Translators: label of a choice
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:54
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:240
+msgid "Language"
+msgstr "Ziman"
+
+#. Translators: label for a button for showing voice model card
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:60
+msgid "&Voice model card..."
+msgstr "&Karta modela dengî..."
+
+#. Translators: label for a button for removing a voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:62
+msgid "&Remove voice..."
+msgstr "Dengî &rake..."
+
+#. Translators: the main label of the install button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:67
+msgid "Install from local file"
+msgstr "Ji pelê herêmî saz bike"
+
+#. Translators: the note for this button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:69
+msgid ""
+"Install a voice from a local archive.\n"
+"The archive contains the voice model and configuration.\n"
+"The archive should have a (.tar.gz) file extension."
+msgstr ""
+"Dengekî ji arşîveke herêmî saz bike.\n"
+"Arşîv modela dengî û mîhengan dihewîne.\n"
+"Divê dirêjahiya pelê arşîvê (.tar.gz) be."
+
+#. ! Intentionally untranslatable
+#. Translators: title of a message box showing voice model card
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:116
+msgid "Model card"
+msgstr "Karta modelê"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:122
+msgid "Model card information is unavailable for this voice"
+msgstr "Ji bo vî dengî agahiya karta modelê tune ye"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:124
+msgid "Not found"
+msgstr "Nehat dîtin"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:141
+msgid "You cannot remove the currently active voice!"
+msgstr "Tu nikarî dengê ku niha çalak e rakî!"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:143
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:304
+msgid "Error"
+msgstr "Çewtî"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:149
+msgid ""
+"Do you want to remove this voice?\n"
+"Voice: {name}"
+msgstr ""
+"Ma tu dixwazî vî dengî rakî?\n"
+"Deng: {name}"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:154
+msgid "Remove voice?"
+msgstr "Deng were rakirin?"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:164
+msgid ""
+"Failed to remove voice.\n"
+"See NVDA's log for more details."
+msgstr ""
+"Deng nehat rakirin.\n"
+"Ji bo hûrgiliyan li tomara NVDA binêre."
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:166
+msgid "Failed"
+msgstr "Bi ser neket"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:172
+msgid "Voice removed successfully."
+msgstr "Deng bi serkeftî hat rakirin."
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:174
+msgid "Done"
+msgstr "Qediya"
+
+#. Translators: title for a dialog for opening a file
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:183
+msgid "Choose voice archive file "
+msgstr "Pelê arşîva dengî hilbijêre "
+
+#. Translators: file dialog filter for tar archives
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:187
+msgid "Tar archives (*.tar.gz, *.tgz)"
+msgstr "Arşîvên tar (*.tar.gz, *.tgz)"
+
+#. Translators: file dialog filter for all files
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:189
+msgid "All files"
+msgstr "Hemû pel"
+
+#. Translators: message telling the user that installing the voice has failed
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:212
+msgid ""
+"Failed to install voice from archive.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+"Deng ji arşîvê nehat sazkirin.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Ji bo hûrgiliyan li tomara NVDA binêre."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:216
+msgid "Voice installation failed"
+msgstr "Sazkirina dengî bi ser neket"
+
+#. Translators: message telling the user that installing the voice is successful
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:223
+msgid "Voice {voice} has been installed successfully."
+msgstr "Dengê {voice} bi serkeftî hat sazkirin."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:226
+msgid "Voice installed successfully"
+msgstr "Deng bi serkeftî hat sazkirin"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:242
+msgid "Available voices"
+msgstr "Dengên berdest"
+
+#. Translators: header of a group of controls for previewing the voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:258
+msgid "Preview"
+msgstr "Pêşdîtin"
+
+#. Translators: Label for a setting in synth settings ring.
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:260
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:126
+msgid "Speaker"
+msgstr "Axêver"
+
+#. Translators: label of a button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:263
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:370
+msgid "&Preview"
+msgstr "&Pêşdîtin"
+
+#. Translators: label of a button to download the standard variant of the voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:268
+msgid "&Download standard variant"
+msgstr "Guhertoya &standard daxîne"
+
+#. Translators: label of a button to download the fast variant of voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:270
+msgid "Download &fast variant"
+msgstr "Guhertoya &bilez daxîne"
+
+#. Translators: label of a button to refresh the voices list
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:272
+msgid "&Refresh voices list"
+msgstr "Lîsteya dengan &nû bike"
+
+#. Translators: message in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:292
+msgid "Retrieving voices list. Please wait..."
+msgstr "Lîsteya dengan tê anîn. Ji kerema xwe li bendê bimîne..."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:303
+msgid ""
+"Could not retrieve voice list.\n"
+"Please check your connection and try again."
+msgstr ""
+"Lîsteya dengan nehat anîn.\n"
+"Ji kerema xwe girêdana xwe kontrol bike û dîsa biceribîne."
+
+#. Translators: label of the preview button while audio is playing
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:361
+msgid "&Stop preview"
+msgstr "Pêşdîtinê &raweste"
+
+#. Translators: error shown when voice preview fails to play
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:378
+msgid ""
+"Could not play voice preview.\n"
+"Check your connection and try again."
+msgstr ""
+"Pêşdîtina dengî nehat lêdan.\n"
+"Girêdana xwe kontrol bike û dîsa biceribîne."
+
+#. Translators: title of an error message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:380
+msgid "Preview failed"
+msgstr "Pêşdîtin bi ser neket"
+
+#. Translators: title of voice manager dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:437
+msgid "Sonata voice manager"
+msgstr "Rêveberê dengên Sonata"
+
+#. Translators: label of a tab in a tab control
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:448
+msgid "Installed"
+msgstr "Sazkirî"
+
+#. Translators: label of a tab in a tab control
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:453
+msgid "Download"
+msgstr "Daxistin"
+
+#. Translators: the label of the close button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:469
+msgid "&Close"
+msgstr "&Bigire"
+
+#. Translators: Label for a setting in voice settings dialog.
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:123
+msgid "&Speaker"
+msgstr "&Axêver"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:166
+msgid "&Noise scale"
+msgstr "Pîvana &xişînê"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:167
+msgid "&Length scale"
+msgstr "Pîvana &dirêjahiyê"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:168
+msgid "Noise &w"
+msgstr "Xişîn &w"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-on store
+#: buildVars.py:24
+msgid "Neural voices for NVDA based on Sonata"
+msgstr "Dengên neuronî yên NVDA-yê li ser bingeha Sonata"
+
+#. Brief changelog for this version
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:29
+msgid "First stable release of the maintenance fork. Adds NVDA 2026.1 compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, miniaudio, and cffi binaries. Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
+msgstr "Berdana yekem a stabîl a vê çapa lênêrînê. Bi ji nû ve avakirina pelên binary ên gRPC, miniaudio û cffi yên pêçayî, lihevhatina bi NVDA 2026.1 re (Python 3.13, 64-bit) hat zêdekirin. Birêvebirina URL-ya lîsteya dengan, şêweya sazkirina dengan ji bo navên bi hejmar, nûkirina lîsteya dengan piştî daxistineke serkeftî, ezmûna sazkirinê ji pelê herêmî û peyamên çewtiyê hatin rastkirin; her wiha kontroleke pêşîn a Visual C++ Redistributable hat zêdekirin."
+

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -1,0 +1,419 @@
+# Translation of the 'sonata_neural_voices' NVDA add-on into Turkish.
+# Copyright (C) 2024 Musharraf Omer, 2026 Ali Ustek and contributors.
+# This file is distributed under the same license as the 'sonata_neural_voices' package.
+# Initial draft; corrections from native speakers are welcome.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 'sonata_neural_voices' '3.2.0'\n"
+"Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
+"POT-Creation-Date: 2026-07-31 00:00+0000\n"
+"PO-Revision-Date: 2026-07-31 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. Translators: label of a menu item
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:46
+msgid "Sonata &voice manager..."
+msgstr "Sonata &ses yöneticisi..."
+
+#. Translators: Sonata's voice manager menu item help
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:48
+msgid "Open the voice manager to preview, install or download sonata voices"
+msgstr "Sonata seslerini önizlemek, yüklemek veya indirmek için ses yöneticisini açın"
+
+#. Translators: message telling the user that no voice is installed
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:63
+msgid ""
+"No Sonata voice was found.\n"
+"You can preview and download voices from the voice manager.\n"
+"Do you want to open the voice manager now?"
+msgstr ""
+"Hiçbir Sonata sesi bulunamadı.\n"
+"Sesleri ses yöneticisinden önizleyebilir ve indirebilirsiniz.\n"
+"Ses yöneticisini şimdi açmak ister misiniz?"
+
+#. Translators: title of a message telling the user that no Sonata voice was found
+#. Add-on summary/title, usually the user visible name of the add-on
+#. Translators: Summary/title for this add-on
+#. to be shown on installation and add-on information found in add-on store
+#: addon\globalPlugins\sonata_tts_global_plugin\__init__.py:69
+#: buildVars.py:21
+msgid "Sonata Neural Voices"
+msgstr "Sonata Sinir Ağı Sesleri"
+
+#. Translators: the label of the OK button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\components.py:86
+msgid "OK"
+msgstr "Tamam"
+
+#. Translators: the label of the cancel button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\components.py:89
+msgid "Cancel"
+msgstr "İptal"
+
+#. Translators: message of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:193
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:353
+msgid "Downloaded: {progress}%"
+msgstr "İndirilen: {progress}%"
+
+#. Translators: message shown in the voice download progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:202
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:362
+msgid "Installing voice"
+msgstr "Ses yükleniyor"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:230
+msgid ""
+"Successfully downloaded voice  {voice}.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+"{voice} sesi başarıyla indirildi.\n"
+"Bu sesi kullanmak için NVDA'yı yeniden başlatmanız gerekir.\n"
+"NVDA'yı şimdi yeniden başlatmak ister misiniz?"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:238
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:385
+msgid "Voice downloaded"
+msgstr "Ses indirildi"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:247
+msgid ""
+"Cannot download voice {voice}.\n"
+"Please check your connection and try again."
+msgstr ""
+"{voice} sesi indirilemiyor.\n"
+"Lütfen bağlantınızı denetleyip yeniden deneyin."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:250
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:397
+msgid "Download failed"
+msgstr "İndirme başarısız"
+
+#. Translators: title of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:261
+msgid "Downloading voice {voice}"
+msgstr "{voice} sesi indiriliyor"
+
+#. Translators: message of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:265
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:412
+msgid "Retrieving download information..."
+msgstr "İndirme bilgileri alınıyor..."
+
+#. Translators: message shown in progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:277
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:423
+msgid "Downloading file: {file}"
+msgstr "Dosya indiriliyor: {file}"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:377
+msgid ""
+"Successfully downloaded fast variant of the voice  {voice}.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+"{voice} sesinin hızlı sürümü başarıyla indirildi.\n"
+"Bu sesi kullanmak için NVDA'yı yeniden başlatmanız gerekir.\n"
+"NVDA'yı şimdi yeniden başlatmak ister misiniz?"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:394
+msgid ""
+"Cannot download fast variant of the voice {voice}.\n"
+"Please check your connection and try again."
+msgstr ""
+"{voice} sesinin hızlı sürümü indirilemiyor.\n"
+"Lütfen bağlantınızı denetleyip yeniden deneyin."
+
+#. Translators: title of a progress dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_download.py:408
+msgid "Downloading fast variant of the voice {voice}"
+msgstr "{voice} sesinin hızlı sürümü indiriliyor"
+
+#. Add controls
+#. Translators: label for a list of installed voices
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:42
+msgid "Installed voices"
+msgstr "Yüklü sesler"
+
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:48
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:245
+msgid "Name"
+msgstr "Ad"
+
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:51
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:247
+msgid "Quality"
+msgstr "Kalite"
+
+#. Build controls
+#. Translators: label of a choice
+#. Translators: list view column title
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:54
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:240
+msgid "Language"
+msgstr "Dil"
+
+#. Translators: label for a button for showing voice model card
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:60
+msgid "&Voice model card..."
+msgstr "&Ses model kartı..."
+
+#. Translators: label for a button for removing a voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:62
+msgid "&Remove voice..."
+msgstr "Sesi &kaldır..."
+
+#. Translators: the main label of the install button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:67
+msgid "Install from local file"
+msgstr "Yerel dosyadan yükle"
+
+#. Translators: the note for this button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:69
+msgid ""
+"Install a voice from a local archive.\n"
+"The archive contains the voice model and configuration.\n"
+"The archive should have a (.tar.gz) file extension."
+msgstr ""
+"Yerel bir arşivden ses yükleyin.\n"
+"Arşiv, ses modelini ve yapılandırmasını içerir.\n"
+"Arşivin dosya uzantısı (.tar.gz) olmalıdır."
+
+#. ! Intentionally untranslatable
+#. Translators: title of a message box showing voice model card
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:116
+msgid "Model card"
+msgstr "Model kartı"
+
+#. Translators: content of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:122
+msgid "Model card information is unavailable for this voice"
+msgstr "Bu ses için model kartı bilgisi bulunmuyor"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:124
+msgid "Not found"
+msgstr "Bulunamadı"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:141
+msgid "You cannot remove the currently active voice!"
+msgstr "Şu anda etkin olan sesi kaldıramazsınız!"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:143
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:304
+msgid "Error"
+msgstr "Hata"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:149
+msgid ""
+"Do you want to remove this voice?\n"
+"Voice: {name}"
+msgstr ""
+"Bu sesi kaldırmak istiyor musunuz?\n"
+"Ses: {name}"
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:154
+msgid "Remove voice?"
+msgstr "Ses kaldırılsın mı?"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:164
+msgid ""
+"Failed to remove voice.\n"
+"See NVDA's log for more details."
+msgstr ""
+"Ses kaldırılamadı.\n"
+"Ayrıntılar için NVDA günlüğüne bakın."
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:166
+msgid "Failed"
+msgstr "Başarısız"
+
+#. Translators: message in a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:172
+msgid "Voice removed successfully."
+msgstr "Ses başarıyla kaldırıldı."
+
+#. Translators: title of a message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:174
+msgid "Done"
+msgstr "Tamamlandı"
+
+#. Translators: title for a dialog for opening a file
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:183
+msgid "Choose voice archive file "
+msgstr "Ses arşivi dosyasını seçin "
+
+#. Translators: file dialog filter for tar archives
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:187
+msgid "Tar archives (*.tar.gz, *.tgz)"
+msgstr "Tar arşivleri (*.tar.gz, *.tgz)"
+
+#. Translators: file dialog filter for all files
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:189
+msgid "All files"
+msgstr "Tüm dosyalar"
+
+#. Translators: message telling the user that installing the voice has failed
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:212
+msgid ""
+"Failed to install voice from archive.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+"Ses arşivden yüklenemedi.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Ayrıntılar için NVDA günlüğüne bakın."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:216
+msgid "Voice installation failed"
+msgstr "Ses yüklemesi başarısız"
+
+#. Translators: message telling the user that installing the voice is successful
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:223
+msgid "Voice {voice} has been installed successfully."
+msgstr "{voice} sesi başarıyla yüklendi."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:226
+msgid "Voice installed successfully"
+msgstr "Ses başarıyla yüklendi"
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:242
+msgid "Available voices"
+msgstr "Kullanılabilir sesler"
+
+#. Translators: header of a group of controls for previewing the voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:258
+msgid "Preview"
+msgstr "Önizleme"
+
+#. Translators: Label for a setting in synth settings ring.
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:260
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:126
+msgid "Speaker"
+msgstr "Konuşmacı"
+
+#. Translators: label of a button
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:263
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:370
+msgid "&Preview"
+msgstr "&Önizle"
+
+#. Translators: label of a button to download the standard variant of the voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:268
+msgid "&Download standard variant"
+msgstr "&Standart sürümü indir"
+
+#. Translators: label of a button to download the fast variant of voice
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:270
+msgid "Download &fast variant"
+msgstr "&Hızlı sürümü indir"
+
+#. Translators: label of a button to refresh the voices list
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:272
+msgid "&Refresh voices list"
+msgstr "Ses listesini &yenile"
+
+#. Translators: message in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:292
+msgid "Retrieving voices list. Please wait..."
+msgstr "Ses listesi alınıyor. Lütfen bekleyin..."
+
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:303
+msgid ""
+"Could not retrieve voice list.\n"
+"Please check your connection and try again."
+msgstr ""
+"Ses listesi alınamadı.\n"
+"Lütfen bağlantınızı denetleyip yeniden deneyin."
+
+#. Translators: label of the preview button while audio is playing
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:361
+msgid "&Stop preview"
+msgstr "Önizlemeyi &durdur"
+
+#. Translators: error shown when voice preview fails to play
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:378
+msgid ""
+"Could not play voice preview.\n"
+"Check your connection and try again."
+msgstr ""
+"Ses önizlemesi çalınamadı.\n"
+"Bağlantınızı denetleyip yeniden deneyin."
+
+#. Translators: title of an error message box
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:380
+msgid "Preview failed"
+msgstr "Önizleme başarısız"
+
+#. Translators: title of voice manager dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:437
+msgid "Sonata voice manager"
+msgstr "Sonata ses yöneticisi"
+
+#. Translators: label of a tab in a tab control
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:448
+msgid "Installed"
+msgstr "Yüklü"
+
+#. Translators: label of a tab in a tab control
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:453
+msgid "Download"
+msgstr "İndir"
+
+#. Translators: the label of the close button in a dialog
+#: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:469
+msgid "&Close"
+msgstr "&Kapat"
+
+#. Translators: Label for a setting in voice settings dialog.
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:123
+msgid "&Speaker"
+msgstr "&Konuşmacı"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:166
+msgid "&Noise scale"
+msgstr "&Gürültü ölçeği"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:167
+msgid "&Length scale"
+msgstr "&Uzunluk ölçeği"
+
+#: addon\synthDrivers\sonata_neural_voices\__init__.py:168
+msgid "Noise &w"
+msgstr "Gürültü &w"
+
+#. Add-on description
+#. Translators: Long description to be shown for this add-on on add-on information from add-on store
+#: buildVars.py:24
+msgid "Neural voices for NVDA based on Sonata"
+msgstr "Sonata tabanlı, NVDA için sinir ağı sesleri"
+
+#. Brief changelog for this version
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:29
+msgid "First stable release of the maintenance fork. Adds NVDA 2026.1 compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, miniaudio, and cffi binaries. Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
+msgstr "Bakım çatalının ilk kararlı sürümü. Paketlenmiş gRPC, miniaudio ve cffi ikili dosyaları yeniden derlenerek NVDA 2026.1 uyumluluğu (Python 3.13, 64 bit) eklendi. Ses listesi URL işleme, rakam içeren adlar için ses yükleme kalıbı, başarılı indirmenin ardından ses listesinin yenilenmesi, yerel dosyadan yükleme deneyimi ve hata iletileri düzeltildi; ayrıca bir Visual C++ Yeniden Dağıtılabilir Paketi ön denetimi eklendi."
+


### PR DESCRIPTION
Closes #33.

## Summary

Adds Turkish (`tr`) and Kurmanji (`kmr`) locales — interface strings and documentation for each. All four files are new, so this does not conflict with #32 and the two can merge in either order.

## Changes

- `addon/locale/tr/LC_MESSAGES/nvda.po`, `addon/locale/kmr/LC_MESSAGES/nvda.po` — 66 entries each.
- `addon/doc/tr/readme.md`, `addon/doc/kmr/readme.md` — same section structure as the English readme: maintenance-fork notice, requirements, download, reporting issues, adding voices, voice-quality note, licence.

No build wiring needed: `sconstruct:86` globs `addon/locale/*/` and `sconstruct:118` globs `addon/doc/*/*.md`.

#### Locale codes

`kmr`, not `ku`. NVDA's `source/localesData.py` names `kmr` "Northern Kurdish" and carries Central Kurdish separately as `ckb`; `source/locale/kmr/` is a full NVDA locale while `source/locale/ku` does not exist. A `ku` folder would also have been actively misleading — `languageHandler.py` maps the Windows `ku-Arab-IQ` LCIDs to `ckb`, so `ku` denotes Sorani in Windows locale naming.

#### Catalogue generation

Generated by walking the ASTs of the current sources for `_()` calls rather than copying an existing locale, so both catalogues cover all 66 translatable strings.

## Test plan

- [x] Both catalogues parse, compile to `.mo` and load through `gettext.GNUTranslations` — 66 entries each, lookups resolve, and the `addon_summary` that `md2html` uses for the HTML `<title>` translates in both.
- [x] Checked every entry for empty `msgstr`, `{placeholder}` drift, newline-count drift and lost `&` accelerators — no problems.
- [ ] CI build + test green (`msgfmt` is not installed locally, so the real compile happens in CI).
- [ ] Kurmanji reviewed by a native speaker. The technical vocabulary is a judgement call — `daxistin` for download, `pêşdîtin` for preview, `xişîn` for noise (avoiding a clash with `deng` for voice), `axêver` for speaker. Both files carry a header comment inviting corrections and leave `Last-Translator` empty.

