### PR TITLE
ci: publish a stable "test" check for branch protection

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -46,7 +46,7 @@ jobs:
           ./*.nvda-addon
           ./*.pot
 
-  test:
+  test_matrix:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -67,6 +67,20 @@ jobs:
 
       - name: Run tests
         run: pytest
+
+  # Stable check name for branch protection: matrix jobs report as
+  # "test_matrix (<os>)", so the bare name would never be published.
+  test:
+    runs-on: ubuntu-latest
+    needs: ["test_matrix"]
+    if: always()
+    steps:
+      - name: Check matrix result
+        run: |
+          if [ "${{ needs.test_matrix.result }}" != "success" ]; then
+            echo "test_matrix concluded: ${{ needs.test_matrix.result }}"
+            exit 1
+          fi
 
   upload_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Every open pull request is currently unmergeable, showing `test — Expected — Waiting for status to be reported` while all jobs pass. Branch protection on `main` requires the contexts `build` and `test`, but `b4ff6db` gave the `test` job an os matrix, and GitHub publishes matrix jobs as `test (windows-latest)` / `test (ubuntu-latest)` — never the bare job name. The required context has nothing to report it, and a required check that never arrives has no timeout.

It went unnoticed because `upload_release` declares `needs: ["build", "test"]`, and `needs` matches job ids rather than check-run names, so the workflow's own graph kept working.

## Changes

`.github/workflows/build_addon.yml`:

- Renamed the matrix job `test` → `test_matrix`.
- Added an aggregate job named `test` that `needs: ["test_matrix"]`, restoring a check run with the name branch protection expects.
- The aggregate runs `if: always()` and fails explicitly unless `needs.test_matrix.result == 'success'`. Without `always()` it would be *skipped* when the matrix fails, and a skipped required check can satisfy branch protection — which would let a red test suite merge.

Fixing it here rather than by repointing the protection rule at the two matrix contexts means the required context stays valid the next time the runner list changes.

## Test plan

- [ ] CI build + test green.
- [ ] This PR's own run publishes a check named `test`, so it should become mergeable on its own — that is the verification that the fix works.
- [ ] After merge, the other open PRs need updating from `main` to pick up the new workflow before their runs report the context. Protection has `strict: true`, so they need updating regardless.
