### PR TITLE
[Fix] Correct Russian Length scale label and six accelerator collisions

### DIFF
--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -349,9 +349,11 @@ msgstr "&Hablante"
 msgid "&Noise scale"
 msgstr "&Escala de ruido"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to D: E collided with "&Escala de ruido" in the same panel.
 #: addon\synthDrivers\sonata_neural_voices\__init__.py:169
 msgid "&Length scale"
-msgstr "&Escala de duración"
+msgstr "Escala de &duración"
 
 #: addon\synthDrivers\sonata_neural_voices\__init__.py:170
 msgid "Noise &w"
@@ -392,10 +394,12 @@ msgstr ""
 "Verifica el registro de NVDA para más detalles."
 
 # Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to P: D collided with "&Descarga variante estándar" on the same
+# tab, and P matches the "&Probar" state of this same button.
 #. Translators: label of the preview button while audio is playing
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:361
 msgid "&Stop preview"
-msgstr "&Detener prueba"
+msgstr "Detener &prueba"
 
 # Draft translation added by the fork maintainer; review welcome.
 #. Translators: error shown when voice preview fails to play

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -165,10 +165,12 @@ msgstr "Qualité"
 msgid "Language"
 msgstr "Langue"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to M: F collided with the "&Fermer" dialog button.
 #. Translators: label for a button for showing voice model card
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:60
 msgid "&Voice model card..."
-msgstr "&Fiche du modèle de la voix..."
+msgstr "Fiche du &modèle de la voix..."
 
 #. Translators: label for a button for removing a voice
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:62

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -326,10 +326,12 @@ msgstr "&Pêşdîtin"
 msgid "&Download standard variant"
 msgstr "Guhertoya &standard daxîne"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to D: B collided with the "&Bigire" dialog button.
 #. Translators: label of a button to download the fast variant of voice
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:270
 msgid "Download &fast variant"
-msgstr "Guhertoya &bilez daxîne"
+msgstr "Guhertoya bilez &daxîne"
 
 #. Translators: label of a button to refresh the voices list
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:272

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -292,20 +292,24 @@ msgstr "Диктор"
 msgid "&Preview"
 msgstr "&Прослушать образец"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to С: З collided with the "&Закрыть" dialog button.
 #. Translators: label of a button to download the standard variant of the voice
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:265
 msgid "&Download standard variant"
-msgstr "&Загрузить стандартный вариант"
+msgstr "Загрузить &стандартный вариант"
 
 #. Translators: label of a button to download the fast variant of voice
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:267
 msgid "Download &fast variant"
 msgstr "Загрузить &быстрый вариант"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to Г: О collided with "&Остановить воспроизведение" on the same tab.
 #. Translators: label of a button to refresh the voices list
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:269
 msgid "&Refresh voices list"
-msgstr "&Обновить список голосов"
+msgstr "Обновить список &голосов"
 
 #. Translators: message in a dialog
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:289
@@ -349,9 +353,12 @@ msgstr "&Диктор"
 msgid "&Noise scale"
 msgstr "&Уровень шума"
 
+# Draft translation added by the fork maintainer; review welcome.
+# Was "Уровень паузы между словами" (level of pause between words), which described
+# the wrong parameter: length_scale scales the duration of every speech sound.
 #: addon\synthDrivers\sonata_neural_voices\__init__.py:169
 msgid "&Length scale"
-msgstr "&Уровень паузы между словами"
+msgstr "&Масштаб длительности"
 
 #: addon\synthDrivers\sonata_neural_voices\__init__.py:170
 msgid "Noise &w"

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -171,10 +171,12 @@ msgstr "Dil"
 msgid "&Voice model card..."
 msgstr "&Ses model kartı..."
 
+# Draft translation added by the fork maintainer; review welcome.
+# Accelerator moved to D: K collided with the "&Kapat" dialog button.
 #. Translators: label for a button for removing a voice
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:62
 msgid "&Remove voice..."
-msgstr "Sesi &kaldır..."
+msgstr "Sesi kal&dır..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\sonata_tts_global_plugin\voice_manager.py:67


### PR DESCRIPTION
Closes #40.

## Summary

Fixes two translation defects found while documenting the synthesizer settings: the Russian label for `Length scale` described a parameter the add-on does not have, and six accelerator keys collided with another control reachable at the same time.

First of two chained PRs; the documentation work builds on this one.

## Changes

### Russian `&Length scale`

`Уровень паузы между словами` ("level of pause between words") → `Масштаб длительности`. `length_scale` scales the duration of every speech sound (`addon/synthDrivers/sonata_neural_voices/__init__.py:395-406`) and does not affect inter-word pauses. The new wording matches every other locale (es `Escala de duración`, fr `Échelle de durée`, tr `Uzunluk ölçeği`, kmr `Pîvana dirêjahiyê`).

### Accelerator collisions

| Locale | Dialog | Was | Now | Collided with |
|---|---|---|---|---|
| es | Download tab | `&Detener prueba` | `Detener &prueba` | `&Descarga variante estándar` |
| es | Voice settings | `&Escala de duración` | `Escala de &duración` | `&Escala de ruido` |
| fr | Installed tab | `&Fiche du modèle de la voix...` | `Fiche du &modèle de la voix...` | `&Fermer` |
| ru | Download tab | `&Загрузить стандартный вариант` | `Загрузить &стандартный вариант` | `&Закрыть` |
| ru | Download tab | `&Обновить список голосов` | `Обновить список &голосов` | `&Остановить воспроизведение` |
| tr | Installed tab | `Sesi &kaldır...` | `Sesi kal&dır...` | `&Kapat` |
| kmr | Download tab | `Guhertoya &bilez daxîne` | `Guhertoya bilez &daxîne` | `&Bigire` |

Only the `&` moves — **no visible label text changes**, so nothing that quotes these labels needs updating. In each case the letter stays on the conventional `Close` button or the more prominent control and the other moves to a free letter, preferring word-initial; only `Sesi kal&dır...` needed a mid-word letter, since both its word-initials (S, K) were already taken in that tab.

The Spanish `Detener &prueba` fix does slightly more than resolve the collision: it lands Stop-preview on the same letter as `&Probar`, which is the same physical button in its other state, so the accelerator no longer changes under the user while a preview plays. French already behaved this way (`&Aperçu` / `&Arrêter l'aperçu`, both A). Russian and Kurmanji still switch letters between states, which is not a collision and was left alone.

Each changed entry carries a comment explaining the move plus the repo's draft-translation marker.

## Test plan

- [x] Syntax check passes. All five catalogues parse with balanced msgid/msgstr pairs (67 each); no comment lands between `msgid` and `msgstr`.
- [ ] CI build + test green.
- [x] Collision check across the three coexisting-control groups (Installed tab, Download tab, Voice settings) in all five locales reports clean.
- [ ] Manual: tab through the voice manager and Voice settings in each locale and confirm the accelerators reach the intended control.

### Review notes

- The chosen replacement letters are a judgement call — any can be reassigned to another free letter if a native speaker prefers.
- The collision check only covers labels owned by this add-on. `Voice settings` also hosts NVDA-core controls whose accelerators are not in this repo, so a collision with those remains possible and was not checkable here.