### PR TITLE
ci: add SonarQube Cloud analysis with fork PR guard

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,14 @@
+[run]
+# A single repo-root source keeps coverage.xml paths repo-root-relative, which is
+# what Sonar resolves against. Listing the addon package dirs here would also
+# report never-imported modules at 0%, but it makes coverage emit paths relative
+# to each source root (bare `__init__.py`), which Sonar cannot resolve.
+source = .
+omit =
+    .venv/*
+    tests/*
+    site_scons/*
+    update_*.py
+    addon/synthDrivers/sonata_neural_voices/lib/*
+    addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/*
+relative_files = True

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,43 @@
+name: Sonar
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    # Fork PRs are never given repository secrets, so SONAR_TOKEN would be empty
+    # and the scan would fail with a red X the contributor cannot clear.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Sonar needs full history for new-code detection and blame
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+
+      - name: Run tests with coverage
+        run: pytest --cov --cov-report=xml
+
+      - name: SonarQube scan
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@v8.2

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ manifest.ini
 /[0-9]*.[0-9]*.[0-9]*.json
 .venv/
 .idea
+.coverage
+coverage.xml
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ manifest.ini
 .coverage
 coverage.xml
 .pytest_cache/
+.envrc
+.sonar/
+.scannerwork/

--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,0 +1,5 @@
+{
+    "sonarCloudOrganization": "austek",
+    "projectKey": "austek_sonata-nvda",
+    "region": "EU"
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=austek_sonata-nvda
+sonar.organization=austek
+
+sonar.sources=addon/globalPlugins,addon/synthDrivers/sonata_neural_voices,addon/installTasks.py,buildVars.py
+sonar.tests=tests
+
+# Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq) and generated gRPC stubs.
+sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**
+
+sonar.python.version=3.13
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,8 +4,9 @@ sonar.organization=austek
 sonar.sources=addon/globalPlugins,addon/synthDrivers/sonata_neural_voices,addon/installTasks.py,buildVars.py
 sonar.tests=tests
 
-# Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq) and generated gRPC stubs.
-sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**
+# Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq), generated gRPC stubs,
+# and the shipped engine binaries.
+sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/sonata_neural_voices/bin/**
 
 sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Closes #39.

## Summary

Adds SonarQube Cloud static analysis and coverage reporting to CI, scoped to the ~3.6k LOC of first-party code rather than the ~74.9k LOC that `addon/` contains in total. Fork PRs are deliberately skipped — see below.

## Changes

- **`.github/workflows/sonar.yml`** — a separate workflow rather than a job in `build_addon.yml`, which only triggers on tags and PRs and so would never analyse `main`, leaving PR new-code detection without a baseline.
  - Fork guard: `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`. The `event_name` clause is load-bearing — a bare `head.repo.full_name` check evaluates false on `push` and would skip main-branch analysis entirely.
  - Second guard `if: env.SONAR_TOKEN != ''` on the scan step, so this is inert until the token is set and can be merged in any order relative to provisioning. `SONAR_TOKEN` is in job-level `env` because the `secrets` context is unavailable in a job-level `if`.
  - `fetch-depth: 0` for new-code detection and blame.
- **`sonar-project.properties`** — `sonar.sources` allowlist, `sonar.tests=tests`, exclusions for the nested vendored (`lib/**`) and generated (`grpc_protos/**`) subtrees, `sonar.python.version=3.13`.
- **`.coveragerc`** — `pytest-cov` config. See the note below on why `source = .`.
- **`.sonarlint/connectedMode.json`** — binds SonarLint in the IDE to this project (org key, project key, region; no secrets) so local analysis matches CI.
- **`.gitignore`** — `.coverage`, `coverage.xml`, `.pytest_cache/`, `.envrc`, and the `.sonar/` / `.scannerwork/` scanner working dirs.

### Why fork PRs are out of scope

GitHub withholds repository secrets from `pull_request` runs originating in a fork, so `SONAR_TOKEN` is empty and the scan fails with a red X the contributor has no way to clear. Automatic Analysis is not a fallback: it only covers PRs from the repository itself, cannot import coverage, and cannot coexist with CI-based analysis. This affects #28, the only fork PR in this repo's history.

`pull_request_target` is **not** an option — a fork PR can ship its own `sonar-project.properties` and redirect `sonar.host.url` to exfiltrate the token, documented as a CVE-class pwn-request in [Apache Caldera's fork-PR workflow](https://github.com/apache/caldera/blob/master/.github/workflows/sonar-fork-pr.yml). The hardened `workflow_run` alternative (untrusted job uploads `coverage.xml`; privileged job checks out the trusted base and consumes it as data only) is used by [caldera](https://github.com/apache/caldera/blob/master/.github/workflows/sonar-fork-pr.yml), [gammapy](https://github.com/gammapy/gammapy/blob/main/.github/workflows/sonar.yml), and [apache/kvrocks](https://github.com/apache/kvrocks/blob/unstable/.github/workflows/sonar.yaml), but it is not worth the attack surface for roughly one external PR a year — [matrix-org/sonarcloud-workflow-action](https://github.com/matrix-org/sonarcloud-workflow-action), the most-referenced wrapper for this problem, was archived 2026-07-23 concluding there is no foolproof way to do it.

### Coverage configuration

`--cov=addon` reports only 4 of 15 first-party files: coverage's file discovery only descends into directories containing `__init__.py`, and `addon/` has none. That yields a flattering 72% while ignoring `globalPlugins/**` (1,558 LOC, no tests).

Adding the package dirs to `source` reports all 13 files, but emits paths relative to each source root — including a bare `__init__.py` — which Sonar cannot resolve, the classic cause of silently importing zero coverage. `source = .` was chosen so paths resolve.

Verified against a real analysis rather than assumed: Sonar's Zero Coverage Sensor fills in files that are in `sonar.sources` but absent from `coverage.xml` as 0%, so project coverage reports as **12.3%** — the honest figure, not the flattering 72%. Never-imported modules are therefore still policed by the gate's `new_coverage` condition.

### Follow-up, not in this PR

- Automatic Analysis must be disabled in project Administration → Analysis Method before the token is set, or CI scans will fail.
- `sonar.organization=austek` is inferred from SonarCloud's convention; `sonar.projectKey=austek_sonata-nvda` is confirmed from the project URL.
- The quality gate stays advisory — branch protection is untouched. Adding it as a required check would block #28 and #30 on a check that never reports.

## Test plan

- [x] Syntax check passes — workflow YAML parses, guard and step conditions verified.
- [x] CI build + test green — `Sonar` and `SonarCloud Code Analysis` both pass on this PR; gate status OK, 0 new violations.
- [x] `pytest --cov --cov-report=xml` verified locally: 91 tests pass, `coverage.xml` paths confirmed repo-root-relative against a single `.` source root.
- [ ] First scan on `main` after merge drops LOC from 50k to ~3.6k and clears the vendored-code issues.


