### PR TITLE
chore: exclude vendored wx sized_controls from Sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,9 +4,9 @@ sonar.organization=austek
 sonar.sources=addon/globalPlugins,addon/synthDrivers/sonata_neural_voices,addon/installTasks.py,buildVars.py
 sonar.tests=tests
 
-# Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq), generated gRPC stubs,
-# and the shipped engine binaries.
-sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/sonata_neural_voices/bin/**
+# Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq, and wxPython's
+# sized_controls), generated gRPC stubs, and the shipped engine binaries.
+sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/sonata_neural_voices/bin/**,addon/globalPlugins/sonata_tts_global_plugin/sized_controls.py
 
 sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Part of #45.

`addon/globalPlugins/sonata_tts_global_plugin/sized_controls.py` is a vendored copy of `wx.lib.sized_controls` — Kevin Ollivier, 2006, wxWindows licence — carried in the add-on because NVDA does not ship it.

It produced **21 of the 65 findings** on the first `main`-branch analysis:

| Rule | Count | What it wants |
|---|---|---|
| `S1542` | 11 | rename `GetSizerProps`, `SetSizerProp`, … to `snake_case` |
| `S100` | 5 | rename `AddChild`, `GetSizerType`, `_AddToNewSizer`, … |
| `S3776` | 3 | split `GetSizerProps`, `SetSizerProp`, `SetSizerType` |
| `S116` | 1 | rename the `sizerType` field |
| `S1134` | 1 | action the `FIXME` at line 237 |

None is actionable. The names are the wx API this file implements, so renaming them breaks callers, and the `FIXME` is Kevin's note about `sizer.GetChildren.index(item)` from 2006. The file joins the vendored trees already excluded (`lib/**`, `grpc_protos/**`, `bin/**`).

Side effect worth having: it is 300 ncloc at 0% coverage, so excluding it lifts reported coverage from 12.3% to roughly 14% without a line of test code.

### Verification

CI is green, but it cannot confirm the outcome: PR analysis only reports issues on changed lines, so it shows 0 issues and no file count regardless. The 14 &rarr; 13 file drop and the coverage change are only observable in the `main` analysis after merge.

