### PR TITLE
fix: stop bare except clauses swallowing KeyboardInterrupt and SystemExit

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/__init__.py
@@ -75,5 +75,5 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def terminate(self):
         try:
             gui.mainFrame.sysTrayIcon.menu.DestroyItem(self.itemHandle)
-        except:
-            pass
+        except Exception:
+            log.debug("Failed to remove the Sonata menu item", exc_info=True)

--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
@@ -363,7 +363,7 @@ class PiperRTVoiceDownloader:
             )
             try:
                 install_voice_from_tar_archive(result, SONATA_VOICES_DIR)
-            except:
+            except Exception:
                 log.exception("Failed to extract voice archive", exc_info=True)
                 has_error = True
         self.progress_dialog.Hide()
@@ -564,7 +564,7 @@ def get_available_voices(force_online=False):
         try:
             with open(PIPER_VOICES_JSON_LOCAL_CACHE, "rb") as file:
                 voices = json.load(file)
-        except:
+        except Exception:
             log.exception("Failed to get voices from local file", exc_info=True)
         else:
             installed_voices = SonataTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()

--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
@@ -157,7 +157,7 @@ class InstalledSonataVoicesPanel(SizedPanel):
         if retval == wx.YES:
             try:
                 shutil.rmtree(selected.location)
-            except:
+            except Exception:
                 log.exception("Failed to remove voice directory", exc_info=True)
                 gui.messageBox(
                     # Translators: message in a message box
@@ -296,7 +296,7 @@ class OnlineSonataVoicesPanel(SizedPanel):
     def _voice_list_retrieved_callback(self, future):
         try:
             result = future.result()
-        except:
+        except Exception:
             log.exception("Failed to retreive voices list", exc_info=True)
             wx.CallAfter(
                 gui.messageBox,

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -197,7 +197,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             return
         try:
             sonata_grpc_server_version = grpc_client.check_grpc_server().result()
-        except:
+        except Exception:
             log.exception(
                 f"Failed to connect to sonata GRPC server. Synthesizer will not be available.",
                 exc_info=True,

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -107,7 +107,7 @@ def start_grpc_server():
         server_log_file = os.path.join(SONATA_VOICES_BASE_DIR, "logs", "sonata-grpc.log")
         Path(server_log_file).parent.mkdir(parents=True, exist_ok=True)
         server_stdout = open(server_log_file, "wb")
-    except:
+    except OSError:
         log.exception("Failed to open server log file for writing", exc_info=True)
         server_stdout = subprocess.DEVNULL
     try:
@@ -119,7 +119,7 @@ def start_grpc_server():
             stdout=server_stdout,
             stderr=subprocess.STDOUT,
         )
-    except:
+    except Exception:
         log.exception(
             "Failed to start Sonata GRPC server. The synth will not be available.",
             exc_info=True


### PR DESCRIPTION
Part of #45.

All eight first-party bare `except:` clauses (`S5754`, 8 issues, maintainability HIGH). A bare `except:` catches `BaseException`, so `KeyboardInterrupt` and `SystemExit` were being logged as ordinary failures and discarded — including inside a voice download, the gRPC server connection check, and the voice list fetch.

| Site | Was |
|---|---|
| `globalPlugins/__init__.py:78` | `except: pass` in `terminate()` |
| `voice_download.py:366` | archive extraction |
| `voice_download.py:567` | offline voice-list cache read |
| `voice_manager.py:160` | `shutil.rmtree` on voice removal |
| `voice_manager.py:299` | `future.result()` for the voice list |
| `synthDrivers/.../__init__.py:200` | gRPC server version check |
| `grpc_client/__init__.py:110` | opening the server log file |
| `grpc_client/__init__.py:122` | `Popen` for the gRPC server |

### Why `except Exception:` and not something narrower

Deliberate, not laziness. Seven of the eight are log-and-degrade handlers where the broad reach is the point: the download keeps going, the synth reports itself unavailable, the voice list falls back to the network. Narrowing them to specific classes changes behaviour on paths that can only be exercised by NVDA on Windows, and getting it wrong converts graceful degradation into a crash — in a screen reader, that means the user loses speech. `except Exception:` fixes the actual defect the rule identifies and nothing else.

One exception: `grpc_client/__init__.py:110` becomes `except OSError:`. `Path.mkdir` and `open` raise nothing else, and that handler falls back to `subprocess.DEVNULL` rather than just logging, so a wrong guess there is contained.

`GlobalPlugin.terminate()` was `except: pass`, which also hid genuine wx errors during menu teardown. It now logs at debug level — debug rather than exception because the menu item legitimately may already be gone by the time the plugin unloads.

### Verification

- 91 tests pass
- `grep -rn "except:"` across first-party code returns nothing
- Not runtime-tested: these paths need NVDA on Windows. The change is mechanical and the failure mode of getting it wrong is narrower than the status quo.
