### PR TITLE
ci: cancel superseded Sonar scans

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,6 +7,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# SonarCloud keeps whichever report finishes processing last, not the newest
+# commit, so overlapping scans can leave main showing an older analysis.
+concurrency:
+  group: sonar-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Part of #45.

Merging #46 and #47 seven seconds apart produced two `main` scans. The **older** commit's report finished processing last, so `main` sat showing 44 issues — the state after #46 alone — until the workflow was dispatched by hand. SonarCloud keeps whichever report arrives last, not the one for the newest commit.

```yaml
concurrency:
  group: sonar-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` keys the group per branch and per PR (`refs/pull/N/merge`), so a push to `main` cannot cancel a PR scan or vice versa.

### Scope of the fix

This closes the window, it does not eliminate it. Cancellation only helps while the superseded run is still scanning — if it has already uploaded its report, that report is queued server-side and will still process out of order. In the case observed, the older run was 7 seconds in against a ~40 second scan, so it would have been killed well before upload.

### Verification

The workflow parses and the `on:` triggers, `permissions:` and the `sonar` job are unchanged. The behaviour itself only shows up under two overlapping runs, which this PR alone cannot produce.
