### PR TITLE
chore: clear 20 mechanical Sonar findings

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/components.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/components.py
@@ -61,9 +61,9 @@ class SimpleDialog(sc.SizedDialog):
 
         panel = self.GetContentsPane()
         self.addControls(panel)
-        buttonsSizer = self.getButtons(panel)
-        if buttonsSizer is not None:
-            self.SetButtonSizer(buttonsSizer)
+        buttons_sizer = self.getButtons(panel)
+        if buttons_sizer is not None:
+            self.SetButtonSizer(buttons_sizer)
 
         self.Layout()
         self.Fit()
@@ -71,11 +71,11 @@ class SimpleDialog(sc.SizedDialog):
         self.Center(wx.BOTH)
 
     def SetButtonSizer(self, sizer):
-        bottomSizer = wx.BoxSizer(wx.VERTICAL)
+        bottom_sizer = wx.BoxSizer(wx.VERTICAL)
         line = wx.StaticLine(self, -1, size=(20, -1), style=wx.LI_HORIZONTAL)
-        bottomSizer.Add(line, 0, wx.TOP | wx.EXPAND, 15)
-        bottomSizer.Add(sizer, 0, wx.EXPAND | wx.ALL, 10)
-        super().SetButtonSizer(bottomSizer)
+        bottom_sizer.Add(line, 0, wx.TOP | wx.EXPAND, 15)
+        bottom_sizer.Add(sizer, 0, wx.EXPAND | wx.ALL, 10)
+        super().SetButtonSizer(bottom_sizer)
 
     def addControls(self, parent):
         raise NotImplementedError
@@ -83,11 +83,11 @@ class SimpleDialog(sc.SizedDialog):
     def getButtons(self, parent):
         btnsizer = wx.StdDialogButtonSizer()
         # Translators: the label of the OK button in a dialog
-        okBtn = wx.Button(self, wx.ID_OK, _("OK"))
-        okBtn.SetDefault()
+        ok_btn = wx.Button(self, wx.ID_OK, _("OK"))
+        ok_btn.SetDefault()
         # Translators: the label of the cancel button in a dialog
-        cancelBtn = wx.Button(self, wx.ID_CANCEL, _("Cancel"))
-        for btn in (okBtn, cancelBtn):
+        cancel_btn = wx.Button(self, wx.ID_CANCEL, _("Cancel"))
+        for btn in (ok_btn, cancel_btn):
             btnsizer.AddButton(btn)
         btnsizer.Realize()
         return btnsizer
@@ -160,10 +160,10 @@ class AsyncSnakDialog:
         gui.runScriptModalDialog(self.snak_dg)
 
     def on_future_completed(self, completed_future):
-        self.Dismiss()
+        self.dismiss()
         wx.CallAfter(self.done_callback, completed_future)
 
-    def Dismiss(self):
+    def dismiss(self):
         if self.snak_dg:
             wx.CallAfter(self.snak_dg.Hide)
             wx.CallAfter(self.snak_dg.Close)

--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
@@ -39,7 +39,7 @@ class InstalledSonataVoicesPanel(SizedPanel):
         self.__already_populated = threading.Event()
         # Add controls
         # Translators: label for a list of installed voices
-        voices_label = wx.StaticText(self, -1, _("Installed voices"))
+        wx.StaticText(self, -1, _("Installed voices"))
         self.voices_list = ImmutableObjectListView(
             self,
             -1,
@@ -177,7 +177,7 @@ class InstalledSonataVoicesPanel(SizedPanel):
                 self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
 
     def _on_install_voice_from_tar(self, event):
-        openFileDialog = wx.FileDialog(
+        open_file_dialog = wx.FileDialog(
             parent=gui.mainFrame,
             # Translators: title for a dialog for opening a file
             message=_("Choose voice archive file "),
@@ -191,8 +191,8 @@ class InstalledSonataVoicesPanel(SizedPanel):
             style=wx.FD_OPEN,
         )
         gui.runScriptModalDialog(
-            openFileDialog,
-            functools.partial(self._get_process_tar_archive, openFileDialog),
+            open_file_dialog,
+            functools.partial(self._get_process_tar_archive, open_file_dialog),
         )
 
     def _get_process_tar_archive(self, dialog, res):
@@ -420,10 +420,10 @@ class OnlineSonataVoicesPanel(SizedPanel):
             self.lang_to_voices.setdefault(voice.language, []).append(voice)
         for vlist in self.lang_to_voices.values():
             vlist.sort(key=operator.attrgetter("key"))
-        self.languages = list(sorted(
+        self.languages = sorted(
             self.lang_to_voices.keys(),
             key=operator.attrgetter("name_english")
-        ))
+        )
         self.language_choice.SetItems([lang.description for lang in self.languages])
         self.__already_populated.set()
 
@@ -466,8 +466,8 @@ class SonataVoiceManagerDialog(SimpleDialog):
     def getButtons(self, parent):
         btnsizer = wx.StdDialogButtonSizer()
         # Translators: the label of the close button in a dialog
-        cancelBtn = wx.Button(self, wx.ID_CANCEL, _("&Close"))
-        btnsizer.AddButton(cancelBtn)
+        cancel_btn = wx.Button(self, wx.ID_CANCEL, _("&Close"))
+        btnsizer.AddButton(cancel_btn)
         btnsizer.Realize()
         return btnsizer
 

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -46,10 +46,8 @@ def force_kill_sonata_grpc_server(psutil):
 def _temporary_import_psutil():
     temp_import_dir = tempfile.TemporaryDirectory()
     src = os.path.join(LIB_DIR, "psutil")
-    # py3_lib_src = os.path.join(LIB_DIR, "python3.dll")
     dst = os.path.join(temp_import_dir.name, "psutil")
     shutil.copytree(src, dst)
-    # shutil.copy2(py3_lib_src, dst)
     sys.path.insert(0, temp_import_dir.name)
     import psutil
     yield psutil

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -58,9 +58,9 @@ _GRPC_IS_INIT = grpc_client.initialize()
 class DoneSpeakingTask:
     __slots__ = ["player", "on_index_reached",]
 
-    def __init__(self, player, onIndexReached):
+    def __init__(self, player, on_index_reached):
         self.player = player
-        self.on_index_reached = onIndexReached
+        self.on_index_reached = on_index_reached
 
     async def __call__(self):
         await run_in_executor(self.player.idle)
@@ -191,7 +191,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             _GRPC_IS_INIT.result()
         except Exception:
             log.exception(
-                f"Failed to initialize Sonata services. Synthesizer will not be available.",
+                "Failed to initialize Sonata services. Synthesizer will not be available.",
                 exc_info=True,
             )
             return
@@ -199,7 +199,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             sonata_grpc_server_version = grpc_client.check_grpc_server().result()
         except Exception:
             log.exception(
-                f"Failed to connect to sonata GRPC server. Synthesizer will not be available.",
+                "Failed to connect to sonata GRPC server. Synthesizer will not be available.",
                 exc_info=True,
             )
             return
@@ -247,13 +247,13 @@ class SynthDriver(synthDriverHandler.SynthDriver):
         with self.tts.create_synthesis_context():
             self._fast_prepare_and_run_speech_task(speechSequence)
 
-    def _fast_prepare_and_run_speech_task(self, speechSequence):
+    def _fast_prepare_and_run_speech_task(self, speech_sequence):
         self.cancel()
         speech_seq = []
         text_list = []
         index_command_list = []
         default_lang = self.tts.language
-        for item in speechSequence:
+        for item in speech_sequence:
             item_type = type(item)
             if item_type is IndexCommand:
                 index_command_list.append(item.index)
@@ -433,7 +433,7 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def _set_voice(self, value):
         if value not in self.availableVoices:
-            value = list(self.availableVoices)[0]
+            value = next(iter(self.availableVoices))
         self.__voice = value
         with suppress(AttributeError):
             del self._availableVariants

--- a/addon/synthDrivers/sonata_neural_voices/aio.py
+++ b/addon/synthDrivers/sonata_neural_voices/aio.py
@@ -88,5 +88,5 @@ def call_threaded(func: t.Callable[..., None]) -> t.Callable[..., "Future"]:
 
 
 def run_in_executor(func, *args, **kwargs):
-    callable = partial(func, *args, **kwargs)
-    return ASYNCIO_EVENT_LOOP.run_in_executor(THREADED_EXECUTOR, callable)
+    bound_func = partial(func, *args, **kwargs)
+    return ASYNCIO_EVENT_LOOP.run_in_executor(THREADED_EXECUTOR, bound_func)

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -220,6 +220,6 @@ async def speak(
 async def bench(n=10000):
     initialize()
     t0 = time.perf_counter()
-    for i in range(n):
+    for _ in range(n):
         await get_sonata_version()
     return time.perf_counter() - t0

--- a/addon/synthDrivers/sonata_neural_voices/helpers.py
+++ b/addon/synthDrivers/sonata_neural_voices/helpers.py
@@ -33,7 +33,7 @@ def is_free_port(port):
             s.bind(("localhost", port))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             return True
-        except (OSError, socket.error) as e:
+        except OSError:
             return False
 
 

--- a/addon/synthDrivers/sonata_neural_voices/tts_system.py
+++ b/addon/synthDrivers/sonata_neural_voices/tts_system.py
@@ -76,7 +76,7 @@ class SonataVoice:
     description: str
     location: str
     properties: Optional[Mapping[str, int]] = field(default_factory=dict)
-    remote_id: str = None
+    remote_id: Optional[str] = None
     supports_streaming_output: bool = False
 
     @classmethod

--- a/tests/test_buildvars.py
+++ b/tests/test_buildvars.py
@@ -133,9 +133,8 @@ class TestAuthorFormat:
 
     def test_author_contains_email(self):
         author = INFO["addon_author"]
-        assert "<" in author and ">" in author, (
-            f"addon_author '{author}' should contain an email in angle brackets"
-        )
+        assert "<" in author, f"addon_author '{author}' should contain an opening angle bracket"
+        assert ">" in author, f"addon_author '{author}' should contain a closing angle bracket"
 
     def test_author_email_is_valid(self):
         author = INFO["addon_author"]


### PR DESCRIPTION
Part of #45.

Clears 20 of the 36 remaining Sonar findings on `main`. Every one is a one-line change with no intended behaviour change, and each was checked against its call sites before being touched.

### Why this batch is bigger than #45 implied

#45 filed 11 findings under "rules the NVDA and wx APIs contradict." Checking callers, only **2** of those are actually load-bearing — `installTasks.onUninstall` and `SynthDriver.speak(speechSequence)`. Both keep their names here. The other 9 had no external contract:

- `buttonsSizer`, `bottomSizer`, `okBtn`, `cancelBtn`, `openFileDialog` and a second `cancelBtn` are **plain local variables**. camelCase mimicry of wx style; nothing reads them.
- `AsyncSnakDialog.Dismiss` — `AsyncSnakDialog` is a **plain class, not a wx subclass**, so this overrides no wx method. Its only caller is `on_future_completed` in the same file.
- `DoneSpeakingTask.__init__(…, onIndexReached)` and `_fast_prepare_and_run_speech_task(speechSequence)` are internal, each with exactly one positional call site in the same module.

### The rest

| Fix | Rule |
|---|---|
| `except (OSError, socket.error) as e:` → `except OSError:` | S1481 |
| unused loop index `i` → `_` in `bench()` | S1481 |
| drop the unused `voices_label` binding | S1481 |
| `list(sorted(...))` → `sorted(...)` | S7508 |
| remove the commented-out `python3.dll` copy | S125 |
| drop `f` prefix from two field-less f-strings | S3457 |
| local `callable` shadowed the builtin | S5806 |
| `remote_id: str = None` → `Optional[str]` | S5890 |
| split a composite assertion | S9073 |
| `list(self.availableVoices)[0]` → `next(iter(...))` | S8519 |

Two notes on those:

`socket.error` has been an alias of `OSError` since Python 3.3 (verified: `socket.error is OSError` → `True`), so the exception tuple was redundant and removing it takes the unused `e` with it in one move.

The unused `voices_label` needed care — the binding is dead but the `wx.StaticText` construction is not, since the sized panel adds children on construction. Only the assignment is gone.

### One behaviour change

`list(self.availableVoices)[0]` → `next(iter(...))` avoids materializing the mapping, but changes the empty-input exception from `IndexError` to `StopIteration`. `_set_voice` isn't a generator, so it propagates rather than being silently swallowed, and an empty `availableVoices` already means the driver is unusable. Calling it out because it isn't pure cleanup.

### Verification

- 91 tests pass; all 9 edited files compile.
- Grepped for stale references to every renamed identifier — none remain.
- Expected effect on `main`: **36 → 16 issues**, with LOW dropping 15 → 1 and MEDIUM 14 → 8.

Only observable in the `main` analysis after merge — PR-scoped Sonar analysis reports issues on changed lines only, so this PR's own Sonar check cannot confirm a debt reduction on pre-existing lines.

### What's left after this

16 findings: 4 `S3776` complexity refactors, 4 to resolve Sonar-side as safe (`S4790` md5, 3× `S1656`), 2 `S1186` empty methods that are both verified as required to exist (one is bound to `wx.EVT_CHOICE`, the other is called from the driver's `terminate`), 3 won't-fix names, and `S2208`/`S7503`/`S7483`.

`S2208` is cheaper than it looks: `const.py` declares an explicit `__all__` of 9 names, `tts_system.py` uses 6, and nothing accesses them through the `tts_system` namespace — so the star-import can be made explicit mechanically.
