### PR TITLE
test: scope coverage to executable code and cover three more modules

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,17 @@ sonar.tests=tests
 # sized_controls), generated gRPC stubs, and the shipped engine binaries.
 sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/sonata_neural_voices/bin/**,addon/globalPlugins/sonata_tts_global_plugin/sized_controls.py
 
+# Code that cannot be executed by CI, so Sonar's Zero Coverage Sensor would
+# otherwise report it at 0% and drag every new-code coverage measurement down.
+# These stay in sonar.sources: they are still analysed for issues, they are
+# only removed from the coverage metric.
+#   globalPlugins/**  needs winsound (Windows-only stdlib) and real wx.lib
+#   grpc_client/**    needs the bundled grpc extension and sonata-grpc.exe
+#   synthDrivers/sonata_neural_voices/__init__.py
+#                     the SynthDriver itself; opens a WavePlayer against a real
+#                     audio device and calls grpc_client.initialize() on import
+sonar.coverage.exclusions=addon/globalPlugins/**,addon/synthDrivers/sonata_neural_voices/grpc_client/**,addon/synthDrivers/sonata_neural_voices/__init__.py
+
 sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.sourceEncoding=UTF-8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,16 +45,33 @@ _TESTS_DIR = os.path.dirname(__file__)
 _SYNTH_DIR = os.path.join(_TESTS_DIR, "..", "addon", "synthDrivers")
 _SYNTH_PKG_DIR = os.path.join(_SYNTH_DIR, "sonata_neural_voices")
 
+REPO_ROOT = os.path.abspath(os.path.join(_TESTS_DIR, ".."))
+SYNTH_PKG_DIR = os.path.abspath(_SYNTH_PKG_DIR)
 
-def _load_real_module(module_name: str, filename: str) -> types.ModuleType:
-    """Execute a real .py file as a registered module (with relative imports)."""
-    path = os.path.join(_SYNTH_PKG_DIR, filename)
+
+def load_module_from_path(
+    module_name: str, path: str, package: str = None
+) -> types.ModuleType:
+    """Execute a real .py file as a registered module.
+
+    Tests use this to reach modules the NVDA runtime would normally import, so
+    they register under a private name and leave any same-named stub installed
+    below untouched. Coverage attributes by file path, not module name.
+    """
     spec = importlib.util.spec_from_file_location(module_name, path)
     mod = importlib.util.module_from_spec(spec)
-    mod.__package__ = "sonata_neural_voices"
+    if package:
+        mod.__package__ = package
     sys.modules[module_name] = mod
     spec.loader.exec_module(mod)
     return mod
+
+
+def _load_real_module(module_name: str, filename: str) -> types.ModuleType:
+    """Execute a real package submodule (with relative imports)."""
+    return load_module_from_path(
+        module_name, os.path.join(_SYNTH_PKG_DIR, filename), "sonata_neural_voices"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -1,0 +1,168 @@
+# coding: utf-8
+"""
+Tests for aio.py — the thread pool and asyncio event loop the synth driver
+runs all of its gRPC and audio work on.
+
+Loaded under a private module name so the `sonata_neural_voices.aio` stub that
+conftest installs for tts_system stays in place.
+"""
+
+import asyncio
+import concurrent.futures
+import os
+import threading
+
+import pytest
+
+from tests.conftest import SYNTH_PKG_DIR, load_module_from_path
+
+aio = load_module_from_path(
+    "sonata_neural_voices._aio_under_test",
+    os.path.join(SYNTH_PKG_DIR, "aio.py"),
+    package="sonata_neural_voices",
+)
+
+
+@pytest.fixture(scope="module")
+def running_aio():
+    aio.initialize()
+    yield aio
+    # TestTerminate shuts things down itself, so only tear down if it has not.
+    if aio.THREADED_EXECUTOR is not None:
+        aio.terminate()
+
+
+class TestInitialize:
+    def test_creates_executor_and_loop_thread(self, running_aio):
+        assert running_aio.THREADED_EXECUTOR is not None
+        assert running_aio.ASYNCIO_LOOP_THREAD is not None
+
+    def test_loop_thread_is_daemon_so_nvda_can_exit(self, running_aio):
+        assert running_aio.ASYNCIO_LOOP_THREAD.daemon is True
+
+    def test_loop_thread_is_alive_and_running(self, running_aio):
+        assert running_aio.ASYNCIO_LOOP_THREAD.is_alive()
+        assert running_aio.ASYNCIO_EVENT_LOOP.is_running()
+
+    def test_reinitialize_keeps_the_existing_loop_thread(self, running_aio):
+        thread = running_aio.ASYNCIO_LOOP_THREAD
+        running_aio.initialize()
+        assert running_aio.ASYNCIO_LOOP_THREAD is thread
+
+
+class TestCoroutineToConcurrentFuture:
+    def test_returns_a_concurrent_future_carrying_the_result(self, running_aio):
+        @running_aio.asyncio_coroutine_to_concurrent_future
+        async def add(a, b):
+            return a + b
+
+        future = add(2, 3)
+        assert isinstance(future, concurrent.futures.Future)
+        assert future.result(timeout=5) == 5
+
+    def test_propagates_exceptions_to_the_future(self, running_aio):
+        @running_aio.asyncio_coroutine_to_concurrent_future
+        async def boom():
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError, match="nope"):
+            boom().result(timeout=5)
+
+    def test_preserves_the_wrapped_function_metadata(self, running_aio):
+        @running_aio.asyncio_coroutine_to_concurrent_future
+        async def documented():
+            """A docstring."""
+
+        assert documented.__name__ == "documented"
+        assert documented.__doc__ == "A docstring."
+
+
+class TestCallThreaded:
+    def test_submits_to_the_executor_and_returns_a_future(self, running_aio):
+        @running_aio.call_threaded
+        def double(value):
+            return value * 2
+
+        future = double(21)
+        assert isinstance(future, concurrent.futures.Future)
+        assert future.result(timeout=5) == 42
+
+    def test_runs_off_the_calling_thread(self, running_aio):
+        @running_aio.call_threaded
+        def which_thread():
+            return threading.current_thread().name
+
+        name = which_thread().result(timeout=5)
+        assert name != threading.current_thread().name
+        assert name.startswith("piper4nvda_executor")
+
+    def test_preserves_the_wrapped_function_metadata(self, running_aio):
+        @running_aio.call_threaded
+        def documented():
+            """Another docstring."""
+
+        assert documented.__name__ == "documented"
+        assert documented.__doc__ == "Another docstring."
+
+
+class TestRunInExecutor:
+    def test_awaits_a_sync_function_from_inside_the_loop(self, running_aio):
+        recorded = []
+
+        async def drive():
+            return await running_aio.run_in_executor(recorded.append, "value")
+
+        asyncio.run_coroutine_threadsafe(
+            drive(), running_aio.ASYNCIO_EVENT_LOOP
+        ).result(timeout=5)
+        assert recorded == ["value"]
+
+    def test_passes_through_keyword_arguments(self, running_aio):
+        def join(a, b="default"):
+            return f"{a}-{b}"
+
+        async def drive():
+            return await running_aio.run_in_executor(join, "x", b="y")
+
+        result = asyncio.run_coroutine_threadsafe(
+            drive(), running_aio.ASYNCIO_EVENT_LOOP
+        ).result(timeout=5)
+        assert result == "x-y"
+
+
+class TestAsyncioTaskHelpers:
+    def test_create_task_schedules_the_coroutine(self, running_aio):
+        ran = threading.Event()
+
+        async def mark():
+            ran.set()
+
+        running_aio.asyncio_create_task(mark())
+        assert ran.wait(timeout=5)
+
+    def test_cancel_task_cancels_a_pending_task(self, running_aio):
+        loop = running_aio.ASYNCIO_EVENT_LOOP
+
+        async def make_task():
+            return loop.create_task(asyncio.sleep(30))
+
+        task = asyncio.run_coroutine_threadsafe(make_task(), loop).result(timeout=5)
+        running_aio.asyncio_cancel_task(task)
+
+        async def await_it():
+            try:
+                await task
+            except asyncio.CancelledError:
+                return "cancelled"
+            return "completed"
+
+        outcome = asyncio.run_coroutine_threadsafe(await_it(), loop).result(timeout=5)
+        assert outcome == "cancelled"
+
+
+class TestTerminate:
+    def test_clears_the_executor_and_the_loop_thread(self, running_aio):
+        assert running_aio.THREADED_EXECUTOR is not None
+        running_aio.terminate()
+        assert running_aio.THREADED_EXECUTOR is None
+        assert running_aio.ASYNCIO_LOOP_THREAD is None

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+"""
+Tests for _config.py — the thin mapping over NVDA's config section for this
+synth, which stores per-voice variant/speaker/scale settings.
+"""
+
+import os
+
+import config
+import pytest
+
+from tests.conftest import SYNTH_PKG_DIR, load_module_from_path
+
+_config = load_module_from_path(
+    "sonata_neural_voices._config_under_test",
+    os.path.join(SYNTH_PKG_DIR, "_config.py"),
+    package="sonata_neural_voices",
+)
+
+SECTION = "sonata_neural_voices"
+
+
+@pytest.fixture
+def manager():
+    config.conf["speech"][SECTION].clear()
+    return _config.SonataConfigManager()
+
+
+class TestModuleLevelSingleton:
+    def test_exposes_a_ready_made_manager(self):
+        assert isinstance(_config.SonataConfig, _config.SonataConfigManager)
+
+    def test_config_spec_declares_the_voice_and_lang_sections(self):
+        assert "[voices]" in _config._configSpec
+        assert "[lang]" in _config._configSpec
+
+    def test_config_spec_bounds_the_scale_settings(self):
+        for setting in ("noise_scale", "length_scale", "noise_w"):
+            assert f"{setting} = integer(default=50, min=0, max=100)" in (
+                _config._configSpec
+            )
+
+
+class TestMappingProtocol:
+    def test_missing_key_is_not_contained(self, manager):
+        assert "de_DE-thorsten-high" not in manager
+
+    def test_set_then_contains(self, manager):
+        manager["de_DE-thorsten-high"] = {"variant": "standard"}
+        assert "de_DE-thorsten-high" in manager
+
+    def test_set_then_get_round_trips(self, manager):
+        manager["en_US-amy-low"] = {"speaker": "amy"}
+        assert manager["en_US-amy-low"] == {"speaker": "amy"}
+
+    def test_writes_land_in_the_nvda_speech_section(self, manager):
+        manager["en_US-amy-low"] = {"speaker": "amy"}
+        assert config.conf["speech"][SECTION]["en_US-amy-low"] == {"speaker": "amy"}
+
+
+class TestSetdefault:
+    def test_returns_the_supplied_value_when_absent(self, manager):
+        assert manager.setdefault("new-voice", {"variant": "fast"}) == {
+            "variant": "fast"
+        }
+
+    def test_stores_the_supplied_value_when_absent(self, manager):
+        manager.setdefault("new-voice", {"variant": "fast"})
+        assert manager["new-voice"] == {"variant": "fast"}
+
+    def test_keeps_the_existing_value_when_present(self, manager):
+        manager["existing"] = {"variant": "standard"}
+        assert manager.setdefault("existing", {"variant": "fast"}) == {
+            "variant": "standard"
+        }
+
+    def test_does_not_overwrite_an_existing_value(self, manager):
+        manager["existing"] = {"variant": "standard"}
+        manager.setdefault("existing", {"variant": "fast"})
+        assert manager["existing"] == {"variant": "standard"}

--- a/tests/test_install_tasks.py
+++ b/tests/test_install_tasks.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+"""
+Tests for installTasks.py — the uninstall hook that force-kills a leftover
+sonata-grpc server process.
+
+`_temporary_import_psutil` and therefore `onUninstall` are not exercised: they
+copy the vendored psutil out of lib/ and import it, and that copy is a Windows
+build (.pyd), so it cannot load on a Linux CI runner.
+"""
+
+import os
+
+import pytest
+
+from tests.conftest import REPO_ROOT, load_module_from_path
+
+install_tasks = load_module_from_path(
+    "_install_tasks_under_test", os.path.join(REPO_ROOT, "addon", "installTasks.py")
+)
+
+GRPC_EXE = os.path.join(install_tasks.BIN_DIR, "sonata-grpc.exe")
+
+
+class _FakeProcess:
+    def __init__(self, name, exe, pid=1):
+        self._name = name
+        self._exe = exe
+        self.pid = pid
+        self.killed = False
+
+    def name(self):
+        return self._name
+
+    def exe(self):
+        return self._exe
+
+    def kill(self):
+        self.killed = True
+
+
+class _FakePsutil:
+    def __init__(self, processes):
+        self._processes = processes
+        self.waited_for = None
+        self.wait_timeout = None
+
+    def process_iter(self, attrs=None):
+        return iter(self._processes)
+
+    def wait_procs(self, processes, timeout=None):
+        self.waited_for = list(processes)
+        self.wait_timeout = timeout
+
+
+@pytest.fixture
+def samefile_by_path(monkeypatch):
+    """Compare paths as strings — the real files do not exist on the runner."""
+    monkeypatch.setattr(os.path, "samefile", lambda a, b: str(a) == str(b))
+
+
+class TestModulePaths:
+    def test_lib_and_bin_are_inside_the_synth_driver(self):
+        assert install_tasks.LIB_DIR.endswith(
+            os.path.join("synthDrivers", "sonata_neural_voices", "lib")
+        )
+        assert install_tasks.BIN_DIR.endswith(
+            os.path.join("synthDrivers", "sonata_neural_voices", "bin")
+        )
+
+    def test_private_path_temporaries_are_cleaned_off_the_module(self):
+        assert not hasattr(install_tasks, "_DIR")
+        assert not hasattr(install_tasks, "_PIPER_SYNTH_DIR")
+
+
+class TestForceKillSonataGrpcServer:
+    def test_kills_a_matching_server_process(self, samefile_by_path):
+        proc = _FakeProcess("sonata-grpc.exe", GRPC_EXE, pid=42)
+        psutil = _FakePsutil([proc])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert proc.killed
+
+    def test_matches_the_process_name_case_insensitively(self, samefile_by_path):
+        proc = _FakeProcess("SONATA-GRPC.EXE", GRPC_EXE)
+        psutil = _FakePsutil([proc])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert proc.killed
+
+    def test_ignores_unrelated_processes(self, samefile_by_path):
+        other = _FakeProcess("firefox", "/usr/bin/firefox")
+        psutil = _FakePsutil([other])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert not other.killed
+
+    def test_does_not_kill_a_same_named_exe_from_another_location(
+        self, samefile_by_path
+    ):
+        impostor = _FakeProcess("sonata-grpc.exe", "/tmp/elsewhere/sonata-grpc.exe")
+        psutil = _FakePsutil([impostor])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert not impostor.killed
+
+    def test_kills_only_the_matching_process_among_several(self, samefile_by_path):
+        ours = _FakeProcess("sonata-grpc.exe", GRPC_EXE, pid=1)
+        impostor = _FakeProcess("sonata-grpc.exe", "/tmp/sonata-grpc.exe", pid=2)
+        unrelated = _FakeProcess("bash", "/bin/bash", pid=3)
+        psutil = _FakePsutil([ours, impostor, unrelated])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert ours.killed
+        assert not impostor.killed
+        assert not unrelated.killed
+
+    def test_waits_on_the_name_matched_processes_with_a_timeout(
+        self, samefile_by_path
+    ):
+        ours = _FakeProcess("sonata-grpc.exe", GRPC_EXE, pid=1)
+        unrelated = _FakeProcess("bash", "/bin/bash", pid=2)
+        psutil = _FakePsutil([ours, unrelated])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert psutil.waited_for == [ours]
+        assert psutil.wait_timeout == 5
+
+    def test_handles_there_being_no_processes_at_all(self, samefile_by_path):
+        psutil = _FakePsutil([])
+        install_tasks.force_kill_sonata_grpc_server(psutil)
+        assert psutil.waited_for == []


### PR DESCRIPTION
Part of #45. Prerequisite for making `SonarCloud Code Analysis` a required check.

### The problem

#49 failed the Sonar gate on `new_coverage` (7.1% against an 80% threshold) despite introducing **zero** new issues and being almost entirely local-variable renames. The cause is not #49 — it is that Sonar's **Zero Coverage Sensor** fills in every source file missing from `coverage.xml` at 0%. Nine of the thirteen analysed files were reported that way, so *any* PR touching one of them measures near-0% new-code coverage regardless of its content. The gate was unactionable, which is exactly why it couldn't be made required.

### What I checked

Rather than assume which files are testable, I probed each of the nine by attempting to import it under the existing conftest stubs:

| | files |
|---|---|
**Importable already** | `_config.py`, `aio.py`, `installTasks.py` |
**Cannot run in CI** | `globalPlugins/**` — needs `winsound` (Windows-only stdlib) and real `wx.lib`; `grpc_client/**` — needs the bundled grpc extension and `sonata-grpc.exe`; `synthDrivers/.../__init__.py` — the SynthDriver, which opens a `WavePlayer` against a real audio device and calls `grpc_client.initialize()` at import |

That split drives both halves of this PR.

### 1. Stop measuring coverage of code CI cannot execute

`sonar.coverage.exclusions` for the second group. **These files stay in `sonar.sources` and are still fully analysed for issues** — this is a coverage-metric change only, and it takes nothing away from the #45 findings. Each entry has its reason recorded inline in the properties file.

### 2. Actually cover the three that were reachable

These were sitting at 0% while being perfectly testable, which is the part that was a genuine gap rather than a measurement artifact:

| module | now | what the tests exercise |
|---|---|---|
`aio.py` | **96%** | executor and event-loop lifecycle, both decorators, `run_in_executor`, task creation and cancellation |
`_config.py` | **95%** | the mapping protocol over NVDA's config section, `setdefault` both ways |
`installTasks.py` | **66%** | `force_kill_sonata_grpc_server`, including that it won't kill a same-named exe from a different path |

`conftest.py` gains a public `load_module_from_path`. Modules register under a private dotted name so the stubs installed for `tts_system` stay in place; coverage attributes by file path, so it still counts. The dotted name also keeps `__package__` consistent with the spec parent, avoiding a `DeprecationWarning` on relative imports.

`onUninstall` stays uncovered and I've said so in the test module docstring: it copies the vendored psutil out of `lib/` and imports it, and that copy is a Windows `.pyd`.

### Result

- **91 tests → 126**, all passing.
- Coverage over the measured set: **72% (4 files) → 75% (7 files)**.
- Sonar's reported project coverage should move **14.2% → ~75%**, because the denominator now contains only code CI can run.
- This PR should pass the gate on its own: it changes no file in `sonar.sources`, so `new_lines_to_cover` is 0 and the condition doesn't apply.

Once this is on `main`, #49 needs a rebase so its Sonar run picks up the new config — its remaining measured changed lines are in `helpers.py`, `tts_system.py` and `aio.py`, all covered, so it should come out at 100%.

### Two latent issues found while probing, not fixed here

Both are pre-existing and unrelated to coverage, so I've left them for their own PR and added them to #45:

1. **`synthDrivers/.../__init__.py:54`** calls `aio.initialize()`, but the bare name `aio` is never imported in that module — line 35 is `from .aio import (…)`, which binds only the listed names. It works solely because `grpc_client/__init__.py` does `from .. import aio`, and per the language reference that binding lands in the parent package's namespace, which *is* `__init__.py`'s globals. If `grpc_client` ever stopped importing `aio`, this would become a `NameError` at addon load. An explicit `from . import aio` would make it robust.
2. **`aio.py:23`** uses `os.cpu_count() // 2` as `max_workers`, which is `0` on a single-core machine and makes `ThreadPoolExecutor` raise `ValueError`. `const.py:31` guards the same expression with `max(…, 2)`; this one doesn't.
