### PR TITLE
fix: assert on only the throwing call in the aio future test

### DIFF
--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -65,8 +65,9 @@ class TestCoroutineToConcurrentFuture:
         async def boom():
             raise ValueError("nope")
 
+        future = boom()
         with pytest.raises(ValueError, match="nope"):
-            boom().result(timeout=5)
+            future.result(timeout=5)
 
     def test_preserves_the_wrapped_function_metadata(self, running_aio):
         @running_aio.asyncio_coroutine_to_concurrent_future


### PR DESCRIPTION
Part of #45. Clears the one `S5778` that #50 introduced.

`boom().result(timeout=5)` placed two possibly-throwing calls inside the `pytest.raises` block, so the test would have passed even if the decorator itself raised rather than the future it returns — which is not what the test claims to verify. Binding the future first puts only `.result()` under assertion.

A real finding on my own code from #50, not pre-existing debt, so it's worth clearing before `SonarCloud Code Analysis` becomes a required check rather than leaving it on the board.

Verified: `tests/test_aio.py` still passes, and the test still fails if the propagation behaviour is broken.
