### PR TITLE
ci: post the Sonar check for fork PRs so they stay mergeable

### DIFF
--- a/.github/workflows/sonar-fork-fallback.yml
+++ b/.github/workflows/sonar-fork-fallback.yml
@@ -1,0 +1,42 @@
+name: Sonar fork fallback
+
+# "SonarCloud Code Analysis" is a required check on main, but the Sonar job in
+# sonar.yml is deliberately skipped for fork PRs because forks are never given
+# SONAR_TOKEN. A required check that never reports leaves the PR stuck on
+# "Expected — waiting for status", so this posts the context itself.
+#
+# pull_request_target is used because GITHUB_TOKEN is read-only on
+# pull_request for forks, and writing a commit status needs write access.
+# That trigger runs in the base repo's context with its secrets, so this
+# workflow deliberately does NOT check out or execute anything from the PR.
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+permissions:
+  statuses: write
+
+concurrency:
+  group: sonar-fork-fallback-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  neutral_status:
+    name: Sonar fork fallback
+    runs-on: ubuntu-latest
+    # Same-repo PRs get a real analysis; never overwrite it.
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Report the Sonar check as skipped
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api --method POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f state=success \
+            -f context='SonarCloud Code Analysis' \
+            -f description='Skipped for fork PR: SONAR_TOKEN is unavailable' \
+            -f target_url="${RUN_URL}"


### PR DESCRIPTION
Part of #45. Closes the gap that making `SonarCloud Code Analysis` required opened up.

### The problem

`SonarCloud Code Analysis` is now a required check on `main`. The `sonar` job skips for fork PRs by design — forks are never given `SONAR_TOKEN` — so on an outside contribution the required check never reports and the PR sits on **"Expected — waiting for status"** forever. `enforce_admins` is off so you could always override it manually, but that's friction on every outside contribution to a public add-on.

### Why `pull_request_target`

This is required, not preferred. `GITHUB_TOKEN` is **read-only on `pull_request` for fork PRs**, so a workflow triggered that way cannot write a commit status to the base repo no matter what `permissions:` it declares. `pull_request_target` runs in the base repo's context with its token and secrets, which is the only way to post the status.

That trigger is the one to be careful with, so to be explicit about the safety argument: **this workflow never checks out or executes anything from the pull request.** It has no `actions/checkout` step at all — its only action is a single `gh api` call to the statuses endpoint. Nothing from the contributor's branch is evaluated, so the usual `pull_request_target` code-injection risk doesn't apply.

### Behaviour

- Runs only when `head.repo.full_name != github.repository`, so same-repo PRs are untouched and their real analysis is never overwritten.
- Posts to the PR's **head** SHA, which is what branch protection evaluates — not the merge commit in `github.sha`.
- Scoped to `permissions: statuses: write` and nothing else.

### One honest caveat

The status is posted as `success`, with the description `Skipped for fork PR: SONAR_TOKEN is unavailable` so the reason is visible in the UI. A required *commit status* has no neutral state that unblocks a merge — the options are `success`, `pending`, `failure`, `error` — so `success` is the only value that achieves the goal.

The tradeoff is therefore explicit and worth stating plainly: **fork PRs are gated on `build` and `test`, but not on Sonar.** Their analysis only appears once the change reaches `main`. That is inherent to fork PRs not having the token; nothing here can analyse code without it.

### Required config change, already applied

The required check had its `app_id` auto-pinned to SonarCloud's app (`12526`), which would have rejected a status posted by Actions (`15368`). I've unpinned that one context to `-1` (any app); `build` and `test` remain pinned to Actions:

```
{"context": "build",                     "app_id": 15368}
{"context": "test",                      "app_id": 15368}
{"context": "SonarCloud Code Analysis",  "app_id": null}
```

Only actors with write access can post statuses, so on a public repo this is not reachable by fork contributors.

### Verification

YAML parses and the job graph is as intended. The path this actually exercises — a fork PR — can't be triggered from inside this repo, so **this PR's own CI does not prove the fallback works**; it only proves the workflow is well-formed and that same-repo PRs are unaffected (this PR should get a real Sonar analysis, not the fallback). The first genuine test is the next fork PR.
