### PR TITLE
chore: record versions of the vendored third-party libraries

### DIFF
--- a/addon/synthDrivers/sonata_neural_voices/lib/VENDORED.txt
+++ b/addon/synthDrivers/sonata_neural_voices/lib/VENDORED.txt
@@ -1,0 +1,16 @@
+# Third-party libraries vendored into this directory.
+# Target runtime: CPython 3.13 / win_amd64 (NVDA 2026.1).
+#
+# Audit for known vulnerabilities with:  pip-audit -r VENDORED.txt
+#
+# cffi, grpcio and miniaudio are rewritten by the repo-root update_*.py
+# scripts. The rest were vendored by hand and must be bumped by hand.
+
+cffi==2.0.0
+grpcio==1.80.0
+miniaudio==1.71
+
+protobuf==4.24.4
+psutil==5.9.6
+pycparser==2.22
+mureq==0.2.0

--- a/update_cffi.py
+++ b/update_cffi.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import glob
 
+import vendored_manifest
+
 # PyPI JSON API for cffi
 url = "https://pypi.org/pypi/cffi/json"
 
@@ -74,6 +76,8 @@ shutil.copytree(os.path.join(extract_dir, "cffi"), cffi_target)
 print("Cleaning up...")
 os.remove(wheel_path)
 shutil.rmtree(extract_dir)
+
+vendored_manifest.record_version("cffi", version)
 
 print("\nSuccessfully updated bundled cffi to 64-bit Python 3.13!")
 print("The addon is now natively compatible with NVDA 2026.1.")

--- a/update_grpc.py
+++ b/update_grpc.py
@@ -4,6 +4,8 @@ import zipfile
 import os
 import shutil
 
+import vendored_manifest
+
 # PyPI JSON API for grpcio
 url = "https://pypi.org/pypi/grpcio/json"
 
@@ -58,6 +60,8 @@ shutil.copytree(os.path.join(extract_dir, "grpc"), target_dir)
 print("Cleaning up...")
 os.remove(wheel_path)
 shutil.rmtree(extract_dir)
+
+vendored_manifest.record_version("grpcio", version)
 
 print("\nSuccessfully updated bundled grpc to 64-bit Python 3.13!")
 print("The addon is now natively compatible with NVDA 2026.1.")

--- a/update_miniaudio.py
+++ b/update_miniaudio.py
@@ -4,6 +4,8 @@ import zipfile
 import os
 import shutil
 
+import vendored_manifest
+
 # PyPI JSON API for miniaudio
 url = "https://pypi.org/pypi/miniaudio/json"
 
@@ -62,6 +64,8 @@ for name in ("_miniaudio.pyd", "miniaudio.py"):
 print("Cleaning up...")
 os.remove(wheel_path)
 shutil.rmtree(extract_dir)
+
+vendored_manifest.record_version("miniaudio", version)
 
 print("\nSuccessfully updated bundled miniaudio to 64-bit Python 3.13!")
 print("The addon is now natively compatible with NVDA 2026.1.")

--- a/vendored_manifest.py
+++ b/vendored_manifest.py
@@ -1,0 +1,30 @@
+"""Shared helper for the update_*.py scripts: keeps lib/VENDORED.txt in sync."""
+
+import os
+import re
+
+MANIFEST_PATH = os.path.join(
+    "addon", "synthDrivers", "sonata_neural_voices", "lib", "VENDORED.txt"
+)
+
+
+def record_version(package, version):
+    with open(MANIFEST_PATH, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    pattern = re.compile(rf"^(\s*){re.escape(package)}==(\S+)(.*)$")
+    for index, line in enumerate(lines):
+        match = pattern.match(line)
+        if not match:
+            continue
+        indent, recorded, trailer = match.groups()
+        if recorded == version:
+            print(f"{MANIFEST_PATH}: {package} already records {version}")
+            return
+        lines[index] = f"{indent}{package}=={version}{trailer}\n"
+        with open(MANIFEST_PATH, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+        print(f"{MANIFEST_PATH}: {package} {recorded} -> {version}")
+        return
+
+    raise SystemExit(f"{MANIFEST_PATH} has no {package} entry; add one first.")


### PR DESCRIPTION
Part of #53.

## Summary

The libraries vendored into `addon/synthDrivers/sonata_neural_voices/lib/` ship with no `.dist-info` and no version recorded anywhere in the repo, so there was no way to state what the add-on bundles — which makes a CVE in a vendored library undetectable. This adds a manifest and wires the existing update scripts to keep it accurate.

## Changes

- **`addon/synthDrivers/sonata_neural_voices/lib/VENDORED.txt`** (new) — records all seven vendored libraries. Versions were read out of the vendored code itself (`grpc/_grpcio_metadata.py`, `__version__` attributes), not guessed:

  | | | |
  |---|---|---|
  | `cffi==2.0.0` | `grpcio==1.80.0` | `miniaudio==1.71` |
  | `protobuf==4.24.4` | `psutil==5.9.6` | `pycparser==2.22` |
  | `mureq==0.2.0` | | |

  Kept in requirements format so it can be fed straight to `pip-audit -r VENDORED.txt`.

- **`vendored_manifest.py`** (new) — `record_version()` rewrites the manifest line-by-line so comments and layout survive. It raises on an unknown package instead of appending, so a typo cannot create a phantom entry.

- **`update_cffi.py`, `update_grpc.py`, `update_miniaudio.py`** — each now records the version it resolved from PyPI, so the manifest cannot drift from what was installed.

#### Notes for the reviewer

`VENDORED.txt` will be packaged inside the `.nvda-addon`, since `sconstruct:84` bundles the whole `addon/` directory and `buildVars.excludedFiles` is empty. It is ~400 bytes and is arguably worth shipping as a record of what the add-on contains — happy to exclude it if you would rather not.

Two of the hand-vendored libraries are well behind upstream — **protobuf 4.24.4** (upstream 6.x) and **psutil 5.9.6** (upstream 7.x). Neither has an updater script. Surfacing that is the point of this change; bumping them is follow-up work.

Also left for follow-up: the three update scripts still fetch PyPI *latest* rather than a pinned target, so they remain non-reproducible. Recording what ships comes first.

## Test plan

- [x] Syntax check passes — all four Python files pass `ast.parse` (what the `check-ast` hook does).
- [x] Manifest round-trip is lossless — bumping a version and back leaves an empty `git diff`; the already-recorded and unknown-package paths both behave as intended.
- [x] Existing suite green — 126 passed.
- [ ] CI build + test green.

Not verified locally: the full `scons` package, which fails here on a missing `msgfmt`. CI installs `gettext`, so the build job covers it.