### PR TITLE
ci: pin the CI tooling in tracked requirements files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  # CI tooling pinned in requirements-build.txt / requirements-test.txt.
+  # The libraries vendored under addon/.../lib are NOT covered here; they are
+  # recorded in lib/VENDORED.txt and bumped via the repo-root update_*.py scripts.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    - run: echo -e "pre-commit\nscons\nmarkdown">requirements.txt
-
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -29,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install -r requirements.txt
+        pip install -r requirements-build.txt
         sudo apt-get update  -y
         sudo apt-get install -y gettext
 
@@ -63,7 +61,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install -r requirements-test.txt
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest pytest-cov
+          pip install -r requirements-test.txt
 
       - name: Run tests with coverage
         run: pytest --cov --cov-report=xml

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,4 @@
+# Tooling for packaging the addon (scons) and the pre-commit code checks.
+markdown==3.10.3
+pre-commit==4.6.1
+scons==4.10.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+# Tooling for the test matrix and the Sonar coverage run.
+pytest==9.1.1
+pytest-cov==7.1.0


### PR DESCRIPTION
Closes #53.

> [!NOTE]
> Stacked on #54 — base is `chore/issue-53-record-vendored-versions`. Review that one first; the diff here shows only this change. Retarget to `main` once #54 merges.

## Summary

CI installed its own tooling unpinned, so a given run resolved whatever was latest that day and was not reproducible. It also left Dependabot with no pip manifest to track. This pins everything into tracked requirements files and puts Dependabot on them.

## Changes

- **`requirements-build.txt`** (new) — `markdown==3.10.3`, `pre-commit==4.6.1`, `scons==4.10.1`
- **`requirements-test.txt`** (new) — `pytest==9.1.1`, `pytest-cov==7.1.0`

  Split rather than one file so each job installs only what it needs, instead of paying for `pre-commit` and `scons` on the Windows test runner.

- **`.github/workflows/build_addon.yml`** — drops the runtime-generated manifest (`- run: echo -e "pre-commit\nscons\nmarkdown">requirements.txt`) in favour of `-r requirements-build.txt`; the test matrix installs `-r requirements-test.txt`.
- **`.github/workflows/sonar.yml`** — installs `-r requirements-test.txt` instead of bare `pytest pytest-cov`.
- **`.github/dependabot.yml`** — adds the `pip` ecosystem, monthly, `chore` prefix, matching the existing Actions entry. Commented to record that the vendored libraries are *not* covered here and are tracked in `lib/VENDORED.txt` instead.

#### Notes for the reviewer

Worth confirming after merge that Dependabot actually discovers `requirements-build.txt` / `requirements-test.txt` — both match the `requirements*.txt` glob and should be picked up, but that is not testable locally. Insights -> Dependency graph -> Dependabot will show it. The pins deliver reproducibility either way, so this is not blocking.

Unrelated, spotted while in the file: `build_addon.yml` sets `SKIP=no-commit-to-branch` in the code-checks step, but that hook is not in `.pre-commit-config.yaml` — a dead env var. Left alone to keep this diff focused.

## Test plan

- [x] Syntax check passes — all three YAML files parse via `yaml.safe_load`.
- [x] Both requirements files resolve cleanly (`pip install --dry-run`).
- [x] Test suite green against the pinned versions — 126 passed.
- [ ] CI build + test green.

Not verified locally: the full `scons` package, which fails here on a missing `msgfmt`. CI installs `gettext`, so the build job covers it — and since this PR changes how the build job installs `scons`, that check matters here.