### PR TITLE
chore: clear five Sonar findings in the addon Python

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
@@ -286,7 +286,7 @@ class PiperVoiceDownloader:
         target_file = os.path.join(download_dir, file.file_path.replace('/', os.sep))
         os.makedirs(os.path.dirname(target_file), exist_ok=True)
 
-        hasher = md5()
+        hasher = md5(usedforsecurity=False)
         total_size = file.size_in_bytes
         downloaded_til_now = 0
 

--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_manager.py
@@ -272,7 +272,6 @@ class OnlineSonataVoicesPanel(SizedPanel):
         refresh_list_btn = wx.Button(self, -1, _("&Refresh voices list"))
         self.Bind(wx.EVT_CHOICE, self.on_language_selection_change, self.language_choice)
         self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_voice_selected, self.voices_list)
-        self.Bind(wx.EVT_CHOICE, self.on_speaker_selection_changed, self.speaker_choice)
         self.Bind(wx.EVT_BUTTON, self.on_preview, self.preview_btn)
         self.Bind(wx.EVT_BUTTON, self.on_download, self.download_std_btn)
         self.Bind(wx.EVT_BUTTON, self.on_download_rt, self.download_rt_btn)
@@ -339,9 +338,6 @@ class OnlineSonataVoicesPanel(SizedPanel):
             self.speaker_choice.SetSelection(0)
         else:
             self.speaker_choice.Enable(False)
-
-    def on_speaker_selection_changed(self, event):
-        pass
 
     def on_preview(self, event):
         # While a preview is playing, the same button acts as Stop. This keeps

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -93,7 +93,7 @@ class SpeechTask:
         if sayAll.SayAllHandler.isRunning():
             self.task.text = self.task.text.replace("\n", " ")
             self.task.speech_options.sentence_silence_ms = 50
-        speech_stream = await self.task.generate_audio()
+        speech_stream = self.task.generate_audio()
         feed_func = self.player.feed
         async for wave_samples in speech_stream:
             await run_in_executor(feed_func, wave_samples)

--- a/addon/synthDrivers/sonata_neural_voices/tts_system.py
+++ b/addon/synthDrivers/sonata_neural_voices/tts_system.py
@@ -17,7 +17,14 @@ from languageHandler import normalizeLanguage
 
 from . import aio
 from . import grpc_client
-from .const import *
+from .const import (
+    DEFAULT_PITCH,
+    DEFAULT_RATE,
+    DEFAULT_VOLUME,
+    FALLBACK_SPEAKER_NAME,
+    IGNORED_PUNCS,
+    SONATA_VOICES_DIR,
+)
 from .helpers import import_bundled_library, LIB_DIRECTORY
 
 
@@ -64,8 +71,8 @@ class SpeechProvider(AudioProvider):
         self.text = text
         self.speech_options = speech_options
 
-    async def generate_audio(self):
-        return await self.speech_options.speak_text(self.text)
+    def generate_audio(self):
+        return self.speech_options.speak_text(self.text)
 
 
 @dataclass
@@ -218,7 +225,7 @@ class SpeechOptions:
     def copy(self):
         return copy.copy(self)
 
-    async def speak_text(self, text):
+    def speak_text(self, text):
         return self.voice.synthesize(
             text,
             self.rate,
@@ -251,6 +258,8 @@ class SonataTextToSpeechSystem:
         self.speech_options = old_speech_options
 
     def shutdown(self):
+        # No-op by design: the gRPC engine process outlives any single TTS
+        # system, so it is torn down by grpc_client's atexit handler instead.
         pass
 
     @property


### PR DESCRIPTION
Part of #45.

## Summary

Clears 5 of the 16 open SonarCloud findings on `main`, covering items 3 and 5 from that issue's "Remaining, in the order worth tackling" list. No user-facing change. The 4 `S3776` complexity refactors and `S7483` are deliberately left alone — they want their own review.

## Changes

| Rule | Location | Fix |
|---|---|---|
| `S4790` | `voice_download.py:289` | `md5(usedforsecurity=False)` |
| `S2208` | `tts_system.py:20` | explicit imports replace `from .const import *` |
| `S7503` | `tts_system.py:221` | drop redundant `async` from `speak_text` + its caller |
| `S1186` | `tts_system.py:253` | comment the intentional no-op `shutdown()` |
| `S1186` | `voice_manager.py:343` | delete the dead handler and its binding |

### Two corrections to the plan in #45

**`S2208` is not purely internal.** #45 says "nothing reads those names through the `tts_system` namespace". That is not the case — `globalPlugins/sonata_tts_global_plugin/__init__.py:28` does `from sonata_neural_voices.tts_system import SONATA_VOICES_DIR`, which only resolves because the star import re-exports it. `SONATA_VOICES_DIR` is therefore kept in the explicit import list; dropping it as unused would have broken the global plugin at load time.

**`S1186` at `voice_manager.py:343` is deleted, not commented.** #45 calls it "required to exist" because it is bound at `voice_manager.py:275`. Being bound is only a reason to exist while the `Bind` stays, and nothing needs to happen on selection change: `on_preview` reads `speaker_choice.GetSelection()` at press time. Removed the handler and the `wx.EVT_CHOICE` binding together. Say the word if you would rather keep the binding and take the one-line comment instead.

### On `S4790`

#45 planned to resolve this server-side as safe. `usedforsecurity=False` states the same thing in code, so it survives re-analysis and needs no manual Sonar action — one fewer item on that checklist.

### On `S7503`

`SonataVoice.synthesize` is an async *generator* function, so calling it already returns the generator without awaiting; `speak_text` and `SpeechProvider.generate_audio` were both pointless coroutine wrappers. Making only `speak_text` sync would have relocated the finding onto `generate_audio`, so both changed, and `__init__.py:96` drops its `await`. This also harmonizes `AudioProvider` — `SilenceProvider.generate_audio` was already sync, matching the abstract declaration. `BreakTask` at `__init__.py:114` is untouched: its `await` is on `run_in_executor`, not on `generate_audio`.

## Test plan

- [x] Syntax check passes (`check-ast` equivalent on all 4 files).
- [x] Existing suite green — 126 passed.
- [x] Confirmed no remaining `await` on either method made sync.
- [ ] CI build + test green.
- [ ] SonarCloud reports 16 → 11 open issues once analysed on `main`.