### PR TITLE
ci: harden the workflow supply chain against SonarQube findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       prefix: "ci"
       include: "scope"
 
-  # CI tooling pinned in requirements-build.txt / requirements-test.txt.
+  # CI tooling pinned in requirements-bootstrap.txt / requirements-build.txt /
+  # requirements-test.txt.
   # The libraries vendored under addon/.../lib are NOT covered here; they are
   # recorded in lib/VENDORED.txt and bumped via the repo-root update_*.py scripts.
   - package-ecosystem: "pip"

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -26,8 +26,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip wheel
-        pip install -r requirements-build.txt
+        python -m pip install --upgrade --only-binary :all: -r requirements-bootstrap.txt
+        pip install --only-binary :all: -r requirements-build.txt
         sudo apt-get update  -y
         sudo apt-get install -y gettext
 
@@ -60,8 +60,8 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-test.txt
+          python -m pip install --upgrade --only-binary :all: -r requirements-bootstrap.txt
+          pip install --only-binary :all: -r requirements-test.txt
 
       - name: Run tests
         run: pytest
@@ -101,11 +101,11 @@ jobs:
       run: |
         touch changelog.md
         echo -e "\nSHA256: " >> changelog.md
-        sha256sum *.nvda-addon >> changelog.md
+        sha256sum -- *.nvda-addon >> changelog.md
 
     - name: Release
       id: release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
       with:
         files: |
           *.nvda-addon
@@ -116,7 +116,7 @@ jobs:
 
     - name: Store submission summary
       run: |
-        ADDON_FILE=$(ls *.nvda-addon)
+        ADDON_FILE=$(ls -- *.nvda-addon)
         SHA256=$(sha256sum "$ADDON_FILE" | awk '{print $1}')
         TAG=${GITHUB_REF#refs/tags/}
         REPO="${GITHUB_REPOSITORY}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -38,12 +38,12 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-test.txt
+          python -m pip install --upgrade --only-binary :all: -r requirements-bootstrap.txt
+          pip install --only-binary :all: -r requirements-test.txt
 
       - name: Run tests with coverage
         run: pytest --cov --cov-report=xml
 
       - name: SonarQube scan
         if: env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@v8.2
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -1,0 +1,3 @@
+# Installer tooling pinned so CI never resolves pip/wheel at run time.
+pip==26.2
+wheel==0.47.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=austek_sonata-nvda
 sonar.organization=austek
 
-sonar.sources=addon/globalPlugins,addon/synthDrivers/sonata_neural_voices,addon/installTasks.py,buildVars.py
+sonar.sources=addon/globalPlugins,addon/synthDrivers/sonata_neural_voices,addon/installTasks.py,buildVars.py,.github/workflows
 sonar.tests=tests
 
 # Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq, and wxPython's
@@ -18,6 +18,17 @@ sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrive
 #                     the SynthDriver itself; opens a WavePlayer against a real
 #                     audio device and calls grpc_client.initialize() on import
 sonar.coverage.exclusions=addon/globalPlugins/**,addon/synthDrivers/sonata_neural_voices/grpc_client/**,addon/synthDrivers/sonata_neural_voices/__init__.py
+
+# S8544 wants pip installs to resolve against a lock file. Our direct CI tooling
+# is already ==-pinned in requirements-bootstrap/-build/-test.txt; going further
+# means --require-hashes plus generated lock files covering every transitive dep
+# on both Linux and Windows, which is not worth the maintenance here. It is a
+# MAJOR VULNERABILITY, so leaving it open would hold new_security_rating at C and
+# fail the required gate on any PR touching these files. Scoped to the workflows
+# so S8541, S7637 and S6573 stay enforced there.
+sonar.issue.ignore.multicriteria=pipLock
+sonar.issue.ignore.multicriteria.pipLock.ruleKey=githubactions:S8544
+sonar.issue.ignore.multicriteria.pipLock.resourceKey=.github/workflows/**/*
 
 sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
Stacked on #57 — review that one first. Base will retarget to `main` automatically when #57 merges.

Sibling to #45 rather than part of it: these come from SonarQube for IDE on `.github/workflows`. 11 of 14 findings fixed.

> **Correction to an earlier claim in this PR:** I first wrote that the server never sees these. That is only true of the *current* scope. The server has raised 10 `githubactions` findings on `main` historically, created between 2025-06-19 and 2026-07-30 — and every one of them was auto-closed as `FIXED` on 2026-07-31 without being fixed, purely because the workflow files fell out of `sonar.sources` (the current `main` analysis covers 13 files, none under `.github`). Worth knowing, because it means these rules can regress invisibly. See the scope note below.

## Summary

Pins third-party actions to commit SHAs, stops pip from executing sdist setup scripts, and pins the installer itself. No change to what CI does — only to how reproducibly and safely it fetches things.

## Changes

**`S7637` — actions pinned to full commit SHAs (3).** A mutable tag can be repointed at new code. SHAs resolved via the API, not guessed:

| Action | SHA | Version |
|---|---|---|
| `softprops/action-gh-release` | `3bb1273` | v2.6.2 |
| `release-drafter/release-drafter` | `6a93d82` | v6.4.0 |
| `SonarSource/sonarqube-scan-action` | `2291811` | v8.2.1 |

`release-drafter`'s `v6` is an annotated tag object, so it needed dereferencing to reach the commit. `actions/*` are exempt from the rule. Dependabot's `github-actions` ecosystem already covers this repo, so it will keep both the pins and the trailing version comments current.

**`S6573` — globs prefixed with `--`, not `./` (2).** `./` would have leaked into user-visible output: `sha256sum ./*.nvda-addon` writes `<hash>  ./x.nvda-addon` into the release changelog, and `ls ./*.nvda-addon` would have put `./` into `ADDON_FILE`, producing a broken `DOWNLOAD_URL` in the Add-on Store submission summary. Verified `--` gives byte-identical output.

**`S8541` — `--only-binary :all:` (3).** Prevents pip building an sdist, which executes its setup script. Checked before applying: both requirements files resolve entirely to wheels, and the only two non-pure deps (`pyyaml` 6.0.3, `coverage` 7.15.2) publish cp313 wheels for both `win_amd64` and `manylinux_x86_64`, so the Windows/Ubuntu matrix holds.

**`S8544` — installer pinned in a new `requirements-bootstrap.txt` (3 of 6).** Pinning `pip`/`wheel` inline in each `run:` block would be invisible to Dependabot's `pip` ecosystem and would have rotted; a requirements file in `/` is picked up by the existing monthly config. `dependabot.yml`'s comment updated to list it.

`wheel` is arguably redundant now that nothing builds from an sdist, but it is kept — `pre-commit` builds hook environments through its own pip, where these flags do not reach.

### Not fixed: 3 remaining `S8544`

The `pip install -r requirements-*.txt` lines. Clearing them means `--require-hashes` plus generated lockfiles for transitive deps — new tooling (`pip-compile`/`uv`), cross-platform hash coverage for `pyyaml`/`coverage`, and regeneration on every bump. Direct deps are already `==`-pinned, so these are proposed as won't-fix.

### Scanner coverage note

SonarQube for IDE only reported the 3 files that were open. I checked the other two: `stale.yml` uses only `actions/stale@v9` (exempt) and `sonar-fork-fallback.yml` has no third-party actions or globs, so neither hides findings of these types.


### `.github/workflows` added to `sonar.sources`

Second commit. The workflow rules were only ever enforced by SonarQube for IDE, and only for whichever files happened to be open — which is how 10 findings sat on `main` and then auto-closed as `FIXED` on a scope change. `S8541`, `S7637` and `S6573` are now behind the required check and cannot regress silently.

**`S8544` is ignored for this path rather than fixed**, and that needed checking before the path could go in: it is a `VULNERABILITY` at `MAJOR` severity, not a Security Hotspot. A single MAJOR vulnerability puts `new_security_rating` at C, and that is a gate condition — so the 3 remaining occurrences (all on `-r requirements-*.txt` lines that this PR modifies, hence *new* code) would have failed the required check and blocked the merge. The ignore is scoped to `ruleKey` + `.github/workflows/**/*` so nothing else is suppressed:

```properties
sonar.issue.ignore.multicriteria=pipLock
sonar.issue.ignore.multicriteria.pipLock.ruleKey=githubactions:S8544
sonar.issue.ignore.multicriteria.pipLock.resourceKey=.github/workflows/**/*
```

Trade-off worth a second opinion: a rule-scoped ignore is durable and needs no manual Sonar action, but it is blanket for that path — a genuinely unpinned install added to a workflow later would also be suppressed. The precise alternative is to drop the ignore and mark the 3 specific issues as *Accept* server-side, which keeps future occurrences visible but costs one gate failure to raise them first, plus a manual step. Easy to swap if you prefer that.

## Test plan

- [x] All 5 workflows + `dependabot.yml` parse as valid YAML.
- [x] `--only-binary :all:` resolves both requirements files to wheels only.
- [x] cp313 `win_amd64` + `manylinux_x86_64` wheels confirmed on PyPI for `pyyaml` and `coverage`.
- [x] Bootstrap install verified in a clean venv → pip 26.2, wheel 0.47.0.
- [x] `--` glob prefix confirmed byte-identical to unprefixed for `sha256sum` and `ls`.
- [ ] CI build + test green on both `ubuntu-latest` and `windows-latest`.
- [ ] Release job exercised on the next tag (the two glob changes and the `action-gh-release` pin only run there).

