### PR TITLE
refactor: clear the last five Sonar findings on main

### DIFF
--- a/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/sonata_tts_global_plugin/voice_download.py
@@ -13,6 +13,7 @@ import tarfile
 import tempfile
 import typing
 import urllib.parse
+from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum, auto
 from fnmatch import fnmatch
@@ -49,6 +50,9 @@ VOICE_INFO_REGEX = re.compile(
     re.I
 )
 THREAD_POOL_EXECUTOR = ThreadPoolExecutor()
+REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+REDIRECT_LIMIT = 5
+DOWNLOAD_CHUNK_SIZE = 4096
 
 
 class PiperVoiceQualityLevel(Enum):
@@ -179,6 +183,43 @@ class PiperVoice:
         return f"{RT_VOICE_DOWNLOAD_URL_PREFIX}/{rt_voice_key}.tar.gz"
 
 
+@contextmanager
+def _follow_redirects(url, label):
+    # mureq does not follow redirects, and HuggingFace serves every file as one.
+    for _redirect in range(REDIRECT_LIMIT):
+        with request.yield_response('GET', url) as response:
+            if response.status in REDIRECT_STATUSES:
+                location = response.getheader("Location")
+                if not location:
+                    raise ValueError("Redirect without Location header.")
+                url = urllib.parse.urljoin(url, location)
+                continue
+
+            if response.status != 200:
+                raise RuntimeError(f"Download failed for {label} (status {response.status})")
+
+            content_type = response.getheader("Content-Type", "").lower()
+            if "text/html" in content_type or "xml" in content_type:
+                raise RuntimeError(f"Wrong content-type while downloading {label}: {content_type}")
+
+            yield response
+            return
+
+    raise RuntimeError(f"Too many redirects while downloading {label}")
+
+
+def _stream_to_file(response, target_file, total_size, progress_callback, hasher=None):
+    downloaded_til_now = 0
+    with open(target_file, "wb") as file_buffer:
+        for chunk in iter(partial(response.read, DOWNLOAD_CHUNK_SIZE), b""):
+            file_buffer.write(chunk)
+            if hasher is not None:
+                hasher.update(chunk)
+            downloaded_til_now += len(chunk)
+            if total_size > 0:
+                progress_callback(math.floor((downloaded_til_now / total_size) * 100))
+
+
 class PiperVoiceDownloader:
     def __init__(self, voice: PiperVoice, success_callback):
         self.voice = voice
@@ -287,42 +328,14 @@ class PiperVoiceDownloader:
         os.makedirs(os.path.dirname(target_file), exist_ok=True)
 
         hasher = md5(usedforsecurity=False)
-        total_size = file.size_in_bytes
-        downloaded_til_now = 0
-
-        url = file.download_url
-        redirect_limit = 5
-
-        for _redirect in range(redirect_limit):
-            with request.yield_response('GET', url) as response:
-                if response.status in (301, 302, 303, 307, 308):
-                    location = response.getheader("Location")
-                    if not location:
-                        raise ValueError("Redirect without Location header.")
-                    url = urllib.parse.urljoin(url, location)
-                    continue
-
-                if response.status != 200:
-                    raise RuntimeError(f"Download failed for {file.file_path} (status {response.status})")
-
-                content_type = response.getheader("Content-Type", "").lower()
-                if "text/html" in content_type or "xml" in content_type:
-                    raise RuntimeError(f"Wrong content-type while downloading {file.file_path}: {content_type}")
-
-                with open(target_file, "wb") as file_buffer:
-                    while True:
-                        chunk = response.read(4096)
-                        if not chunk:
-                            break
-                        file_buffer.write(chunk)
-                        hasher.update(chunk)
-                        downloaded_til_now += len(chunk)
-                        if total_size > 0:
-                            progress = math.floor((downloaded_til_now / total_size) * 100)
-                            progress_callback(progress)
-                break
-        else:
-            raise RuntimeError(f"Too many redirects while downloading {file.file_path}")
+        with _follow_redirects(file.download_url, file.file_path) as response:
+            _stream_to_file(
+                response,
+                target_file,
+                file.size_in_bytes,
+                progress_callback,
+                hasher,
+            )
 
         return (file, target_file, hasher.hexdigest())
 
@@ -428,40 +441,13 @@ class PiperRTVoiceDownloader:
     @classmethod
     def _do_download_archive(cls, download_url, voice_name, download_dir, progress_callback):
         target_file = os.path.join(download_dir, voice_name)
-        url = download_url
-        redirect_limit = 5
-
-        for _redirect in range(redirect_limit):
-            with request.yield_response('GET', url) as response:
-                if response.status in (301, 302, 303, 307, 308):
-                    location = response.getheader("Location")
-                    if not location:
-                        raise ValueError("Redirect without Location header.")
-                    url = urllib.parse.urljoin(url, location)
-                    continue
-
-                if response.status != 200:
-                    raise RuntimeError(f"Download failed for {voice_name} (status {response.status})")
-
-                content_type = response.getheader("Content-Type", "").lower()
-                if "text/html" in content_type or "xml" in content_type:
-                    raise RuntimeError(f"Wrong content-type while downloading {voice_name}: {content_type}")
-
-                total_size = int(response.getheader("Content-Length", 0))
-                downloaded_til_now = 0
-                with open(target_file, "wb") as file_buffer:
-                    while True:
-                        chunk = response.read(4096)
-                        if not chunk:
-                            break
-                        file_buffer.write(chunk)
-                        downloaded_til_now += len(chunk)
-                        if total_size > 0:
-                            progress = math.floor((downloaded_til_now / total_size) * 100)
-                            progress_callback(progress)
-                break
-        else:
-            raise RuntimeError(f"Too many redirects while downloading {voice_name}")
+        with _follow_redirects(download_url, voice_name) as response:
+            _stream_to_file(
+                response,
+                target_file,
+                int(response.getheader("Content-Length", 0)),
+                progress_callback,
+            )
 
         return target_file
 
@@ -558,29 +544,34 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
     return voice_key
 
 
-def get_available_voices(force_online=False):
-    # Trry an offline cache first
-    if not force_online and os.path.exists(PIPER_VOICES_JSON_LOCAL_CACHE):
-        try:
-            with open(PIPER_VOICES_JSON_LOCAL_CACHE, "rb") as file:
-                voices = json.load(file)
-        except Exception:
-            log.exception("Failed to get voices from local file", exc_info=True)
-        else:
-            installed_voices = SonataTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
-            installed_voice_keys = {voice.key for voice in installed_voices}
-            not_installed = []
-            for (key, value) in voices.items():
-                std_key, rt_key = SonataTextToSpeechSystem.get_voice_variants(key)
-                value["standard_variant_installed"] = std_key in installed_voice_keys
-                value["fast_variant_installed"] = rt_key in installed_voice_keys
-                if value["standard_variant_installed"] and value["fast_variant_installed"]:
-                    continue
-                if value["standard_variant_installed"] and not value["has_rt_variant"]:
-                    continue
-                not_installed.append(value)
-            voice_objs = PiperVoice.from_list_of_dicts(not_installed)
-            return voice_objs
+def _select_not_installed_voices(voices):
+    installed_voices = SonataTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
+    installed_voice_keys = {voice.key for voice in installed_voices}
+    not_installed = []
+    for (key, value) in voices.items():
+        std_key, rt_key = SonataTextToSpeechSystem.get_voice_variants(key)
+        value["standard_variant_installed"] = std_key in installed_voice_keys
+        value["fast_variant_installed"] = rt_key in installed_voice_keys
+        if value["standard_variant_installed"] and value["fast_variant_installed"]:
+            continue
+        if value["standard_variant_installed"] and not value["has_rt_variant"]:
+            continue
+        not_installed.append(value)
+    return not_installed
+
+
+def _get_voices_from_cache():
+    """Return the not-installed voices from the on-disk cache, or None if unreadable."""
+    try:
+        with open(PIPER_VOICES_JSON_LOCAL_CACHE, "rb") as file:
+            voices = json.load(file)
+    except Exception:
+        log.exception("Failed to get voices from local file", exc_info=True)
+        return None
+    return PiperVoice.from_list_of_dicts(_select_not_installed_voices(voices))
+
+
+def _refresh_voices_cache():
     std_resp = request.get(PIPER_VOICE_LIST_URL)
     std_resp.raise_for_status()
     std_voices = std_resp.json()
@@ -592,12 +583,20 @@ def get_available_voices(force_online=False):
     }
     voice_list = {}
     for vname, vdata in std_voices.items():
-        if vname in rt_voice_names:
-            vdata["has_rt_variant"] = True
-        else:
-            vdata["has_rt_variant"] = False
+        vdata["has_rt_variant"] = vname in rt_voice_names
         voice_list[vname] = vdata
     with open(PIPER_VOICES_JSON_LOCAL_CACHE, "w", encoding="utf-8") as file:
         json.dump(voice_list, file, ensure_ascii=False, indent=2)
-    return get_available_voices()
+
+
+def get_available_voices(force_online=False):
+    if not force_online and os.path.exists(PIPER_VOICES_JSON_LOCAL_CACHE):
+        cached_voices = _get_voices_from_cache()
+        if cached_voices is not None:
+            return cached_voices
+    _refresh_voices_cache()
+    voices = _get_voices_from_cache()
+    if voices is None:
+        raise RuntimeError("Failed to read the voice list cache that was just written")
+    return voices
 

--- a/addon/synthDrivers/sonata_neural_voices/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/__init__.py
@@ -249,6 +249,11 @@ class SynthDriver(synthDriverHandler.SynthDriver):
 
     def _fast_prepare_and_run_speech_task(self, speech_sequence):
         self.cancel()
+        self._current_task = process_speech(
+            self._build_speech_tasks(speech_sequence)
+        ).result()
+
+    def _build_speech_tasks(self, speech_sequence):
         speech_seq = []
         text_list = []
         index_command_list = []
@@ -258,42 +263,18 @@ class SynthDriver(synthDriverHandler.SynthDriver):
             if item_type is IndexCommand:
                 index_command_list.append(item.index)
                 continue
-            elif item_type is str:
+            if item_type is str:
                 text_list.append(item)
                 continue
+            # Pending text must be flushed before the command takes effect.
             if any(text_list):
-                speech_seq.append(
-                    SpeechTask(
-                        self.tts.create_speech_provider("\n".join(text_list)),
-                        self._player,
-                    )
-                )
+                speech_seq.append(self._create_speech_task(text_list))
                 text_list.clear()
-            if item_type is BreakCommand:
-                speech_seq.append(
-                    BreakTask(
-                        self.tts.create_break_provider(item.time),
-                        self._player,
-                    )
-                )
-            elif item_type is LangChangeCommand:
-                if item.isDefault:
-                    self.tts.language = default_lang
-                else:
-                    self.tts.language = item.lang
-            elif item_type is RateCommand:
-                self.tts.rate = item.newValue
-            elif item_type is VolumeCommand:
-                self.tts.volume = item.newValue
-            elif item_type is PitchCommand:
-                self.tts.pitch = item.newValue
+            break_task = self._apply_speech_command(item, default_lang)
+            if break_task is not None:
+                speech_seq.append(break_task)
         if any(text_list):
-            speech_seq.append(
-                SpeechTask(
-                    self.tts.create_speech_provider("\n".join(text_list)),
-                    self._player,
-                )
-            )
+            speech_seq.append(self._create_speech_task(text_list))
         if any(index_command_list):
             speech_seq.append(IndexReachedTask(self._on_index_reached, index_command_list))
         speech_seq.append(
@@ -301,9 +282,30 @@ class SynthDriver(synthDriverHandler.SynthDriver):
                 self._player, self._on_index_reached
             )
         )
-        self._current_task = process_speech(
-            speech_seq
-        ).result()
+        return speech_seq
+
+    def _create_speech_task(self, text_list):
+        return SpeechTask(
+            self.tts.create_speech_provider("\n".join(text_list)),
+            self._player,
+        )
+
+    def _apply_speech_command(self, item, default_lang):
+        item_type = type(item)
+        if item_type is BreakCommand:
+            return BreakTask(
+                self.tts.create_break_provider(item.time),
+                self._player,
+            )
+        if item_type is LangChangeCommand:
+            self.tts.language = default_lang if item.isDefault else item.lang
+        elif item_type is RateCommand:
+            self.tts.rate = item.newValue
+        elif item_type is VolumeCommand:
+            self.tts.volume = item.newValue
+        elif item_type is PitchCommand:
+            self.tts.pitch = item.newValue
+        return None
 
     def cancel(self):
         if self._current_task is not None:

--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -157,7 +157,8 @@ def terminate():
 
 @aio.asyncio_coroutine_to_concurrent_future
 async def check_grpc_server(timeout=15) -> str:
-    return await asyncio.wait_for(get_sonata_version(), timeout)
+    async with asyncio.timeout(timeout):
+        return await get_sonata_version()
 
 
 async def get_sonata_version():


### PR DESCRIPTION
Part of #45 — this clears the last five open SonarCloud issues, but does **not** close the issue: the two latent bugs it tracks (the implicit `aio` binding at `synthDrivers/.../__init__.py:54` and `os.cpu_count() // 2` at `aio.py:23`) are still open.

## Summary

The five findings left on `main` after #57 and #58 were the four `python:S3776` cognitive-complexity warnings and the one `python:S7483`, which #45 ranked last because they "want real review rather than a sweep". This does that review. No behaviour changes are intended beyond one deliberate fix noted below.

Open Sonar issues go **5 → 0** (45min of estimated effort). Nothing here is user-facing.

## Changes

`addon/globalPlugins/sonata_tts_global_plugin/voice_download.py`

- `_do_download_file` (L285) and `_do_download_archive` (L429) were near-identical 30-line copies of one redirect loop, status check, content-type check and chunked read with progress reporting. Extracted `_follow_redirects` (a `@contextmanager`) and `_stream_to_file`; both call sites are now five lines.
- `get_available_voices` (L561) split into `_select_not_installed_voices`, `_get_voices_from_cache` and `_refresh_voices_cache`.

`addon/synthDrivers/sonata_neural_voices/__init__.py`

- `_fast_prepare_and_run_speech_task` (L250) now only cancels and runs. The sequence walk moved to `_build_speech_tasks`, with `_create_speech_task` and `_apply_speech_command` extracted.

`addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py`

- `check_grpc_server` (L159) uses `async with asyncio.timeout` instead of `asyncio.wait_for`.

### Cognitive complexity

| function | before | after |
| --- | --- | --- |
| `_do_download_file` | 20 | 0 |
| `_do_download_archive` | 20 | 0 |
| `get_available_voices` | 22 | 5 |
| `_fast_prepare_and_run_speech_task` | 18 | 0 |
| largest new function (`_follow_redirects`) | — | 11 |

Limit is 15. `done_callback` still measures 15 — that is unchanged by this PR and sits exactly at the threshold, so it is not flagged.

### One deliberate behaviour change

`get_available_voices` used to end in `return get_available_voices()`, recursing after writing the cache. If the freshly written cache stayed unreadable — corrupt disk, truncated write — it would fetch, write and recurse forever. It now raises `RuntimeError` instead.

### Why `asyncio.timeout` is safe

#45 flagged `S7483` as "probably won't-fix" because `asyncio.timeout()` needs Python 3.11+. That floor is met: `addon_minimumNVDAVersion` is `2025.1`. On 3.11+ `asyncio.TimeoutError` **is** the builtin `TimeoutError`, so the raised type is unchanged, and the only caller (`synthDrivers/.../__init__.py:199`) catches bare `Exception` regardless.

## Test plan

- [x] Syntax check passes (`py_compile` on all three files).
- [ ] CI build + test green.
- [x] Existing suite green — 126 passed.
- [x] **Speech path differential.** `globalPlugins/**` and the SynthDriver are coverage-excluded, so no existing test touches any of this. Ran the pre- and post-refactor `_fast_prepare_and_run_speech_task` side by side over **1109 generated command sequences** (every 2- and 3-element permutation of text, `IndexCommand`, `BreakCommand`, `LangChangeCommand` both default and explicit, `Rate`/`Volume`/`PitchCommand`, plus longer realistic sequences), comparing the emitted task list, the full ordered log of `tts` mutations and the final language state. 0 mismatches. This is what confirms the flush-before-command ordering survived.
- [x] **Download helpers.** 16 checks against a fake response: bytes written verbatim, md5 matching an independent digest, progress monotonic and ending at 100, chunk count, redirect chain resolved via `urljoin`, 4-redirects-then-success still inside the limit, and every error path (non-200, `text/html`, `xml`, redirect without `Location`, too many redirects). Also that the response is closed on both the success and error paths, and that `total_size == 0` reports no progress rather than dividing by zero.
- [x] **Cache flow.** 9 checks on install-state filtering (neither variant installed, standard-only with and without an RT variant, both installed), reading a good cache, falling through to refresh on a corrupt one, logging the corruption, `force_online` bypassing the cache, and the new `RuntimeError` replacing the old infinite recursion.
- [ ] Manual: install a standard voice and a fast (RT) variant through the Voice Manager, confirming the progress dialog advances and the hash check still passes. Not covered by CI — needs Windows, NVDA and a real HuggingFace download.
