### PR TITLE
refactor: drop the timeout parameter from check_grpc_server

### DIFF
--- a/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
+++ b/addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py
@@ -73,6 +73,7 @@ SONATA_GRPC_SERVER_PORT = None
 GRPC_SERVER_PROCESS = None
 CHANNEL = None
 SONATA_GRPC_SERVICE = None
+SERVER_CHECK_TIMEOUT = 15
 
 
 def start_grpc_server():
@@ -156,8 +157,8 @@ def terminate():
 
 
 @aio.asyncio_coroutine_to_concurrent_future
-async def check_grpc_server(timeout=15) -> str:
-    async with asyncio.timeout(timeout):
+async def check_grpc_server() -> str:
+    async with asyncio.timeout(SERVER_CHECK_TIMEOUT):
         return await get_sonata_version()
 
 


### PR DESCRIPTION
Part of #45 — this clears the last open SonarCloud issue on `main`, but does **not** close the issue, which also tracks the remaining latent bugs.

## Summary

#59 did not actually clear `python:S7483`, so `main` went 5 → 1 rather than 5 → 0 after that merge. The rule is **"Asynchronous functions should not accept timeout parameters"** — it flags the parameter in the signature, not the implementation inside the function. The issue's text range covers `timeout=15` on the `def` line (offsets 28–38), with a secondary location on `async` reading *"This function is async."* #59 replaced `asyncio.wait_for` with `async with asyncio.timeout` in the body, which was a reasonable change on its own but left the flagged parameter in place.

This removes the parameter. Open Sonar issues go **1 → 0**.

## Changes

`addon/synthDrivers/sonata_neural_voices/grpc_client/__init__.py`

- `check_grpc_server` no longer takes a `timeout` parameter; the bound comes from a new `SERVER_CHECK_TIMEOUT = 15` module constant.

## Test plan

- [x] Syntax check passes (`py_compile`).
- [ ] CI build + test green.
- [x] Existing suite green — 126 passed.
- [x] **No behaviour change.** 15 seconds was already the default value, and the sole caller (`synthDrivers/sonata_neural_voices/__init__.py:199`) calls `check_grpc_server()` with no arguments, so the removed parameter was never exercised. `tests/conftest.py:238` replaces the entire function with a `MagicMock`, so the arity change is invisible to the suite.
- [x] **No repeats.** `grep 'async def .*timeout' addon/` matches nothing after this change, so no second instance of the pattern is waiting to be flagged.

#### Note on #30

#30 (`fix/issue-27-profile-reload-crash`) independently rewrote this function to `check_grpc_server(timeout=SERVER_CHECK_TIMEOUT)`, introducing the same constant name and value. That branch will conflict here on rebase; the resolution is to **keep the no-parameter signature from this PR**, otherwise merging #30 reintroduces the finding.
