### PR TITLE
chore: harden GitHub Actions workflows and gate them with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    # Skip versions published in the last week, so a compromised release has time
+    # to be yanked before Dependabot proposes it.
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci"
       include: "scope"
@@ -17,6 +21,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -11,16 +11,21 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: "3.13"
 
@@ -37,7 +42,7 @@ jobs:
     - name: building addon
       run: scons && scons pot
 
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
         name: packaged_addon
         path: |
@@ -51,10 +56,12 @@ jobs:
         os: [windows-latest, ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 
@@ -87,10 +94,12 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      with:
+        persist-credentials: false
     
     - name: download releases files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: packaged_addon
 

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -11,13 +11,12 @@ on:
 
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -51,6 +50,8 @@ jobs:
 
   test_matrix:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
@@ -77,6 +78,7 @@ jobs:
   # "test_matrix (<os>)", so the bare name would never be published.
   test:
     runs-on: ubuntu-latest
+    permissions: {}
     needs: ["test_matrix"]
     if: always()
     steps:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 
-permissions:
-  contents: read
-
 jobs:
   update_release_draft:
     permissions:

--- a/.github/workflows/sonar-fork-fallback.yml
+++ b/.github/workflows/sonar-fork-fallback.yml
@@ -10,7 +10,7 @@ name: Sonar fork fallback
 # That trigger runs in the base repo's context with its secrets, so this
 # workflow deliberately does NOT check out or execute anything from the PR.
 
-on:
+on:  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     branches: [ main ]
 

--- a/.github/workflows/sonar-fork-fallback.yml
+++ b/.github/workflows/sonar-fork-fallback.yml
@@ -14,9 +14,6 @@ on:  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     branches: [ main ]
 
-permissions:
-  statuses: write
-
 concurrency:
   group: sonar-fork-fallback-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -25,6 +22,8 @@ jobs:
   neutral_status:
     name: Sonar fork fallback
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     # Same-repo PRs get a real analysis; never overwrite it.
     if: github.event.pull_request.head.repo.full_name != github.repository
     steps:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,13 +13,12 @@ concurrency:
   group: sonar-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Fork PRs are never given repository secrets, so SONAR_TOKEN would be empty
     # and the scan would fail with a red X the contributor cannot clear.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -27,12 +27,13 @@ jobs:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 0  # Sonar needs full history for new-code detection and blame
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # Only touch issues that have been parked pending a reproducer.
           # Everything else (active bugs, feature requests, etc.) stays open

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,12 +6,11 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
-permissions:
-  issues: write
-
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,7 @@
+rules:
+  superfluous-actions:
+    ignore:
+      # `gh release create` cannot replace this step: it has no equivalent of
+      # fail_on_unmatched_files, which is what keeps a release from publishing
+      # without the .nvda-addon attached.
+      - build_addon.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,3 +5,8 @@ repos:
       - id: check-ast
       - id: check-case-conflict
       - id: check-yaml
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.28.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
## Summary

A [zizmor](https://docs.zizmor.sh) audit of the five workflows reported 20 findings, 11 of them high severity. Most were mutable action references — third-party actions were already SHA-pinned, but every first-party `actions/*` ref still resolved through a movable major tag. This pins them, tightens token scope and checkout credentials, and wires zizmor into pre-commit so new findings fail CI.

## Changes

- **`unpinned-uses` (10 findings)** — all `actions/*` refs pinned to the commit SHA their major tag resolves to today, with the exact version in a trailing comment: `checkout` → `v5.1.0`, `setup-python` → `v6.3.0`, `upload-artifact` → `v5.0.0`, `download-artifact` → `v4.3.0`, `stale` → `v9.1.0`. Same commits as before, so no behavior change, and Dependabot maintains SHA pins natively.
- **`excessive-permissions` (4)** — per-job permissions in `build_addon.yml`: `contents: read` for the two jobs that check out, `permissions: {}` for the aggregate `test` job, and `upload_release` keeps its existing `contents: write`. Job-level rather than workflow-level because Sonar's `githubactions:S8264` rates a workflow-wide grant a MAJOR vulnerability, which failed the quality gate on the first push now that `.github/workflows` is inside `sonar.sources` (`fb591f9`). zizmor is satisfied either way.
- **`artipacked` (4)** — `persist-credentials: false` on all four checkouts.
- **`dependabot-cooldown` (2)** — `cooldown: default-days: 7` on both ecosystems, so a compromised release has a week to be yanked before Dependabot proposes it. Free on a monthly schedule.
- **`dangerous-triggers` (1)** — suppressed inline in `sonar-fork-fallback.yml:13`. That `pull_request_target` checks out nothing and executes no PR-controlled code; the rationale is already in the file header.
- **`superfluous-actions` (1, informational)** — ignored via new `.github/zizmor.yml`. `gh release create` has no `fail_on_unmatched_files` equivalent, which is what keeps a release from publishing without the `.nvda-addon` attached.
- **`githubactions:S8264`** — no workflow declares permissions at workflow level any more. `sonar`, `stale`, `sonar-fork-fallback` and `release-drafter` each have a single job that now carries its own grant (`contents: read`, `issues: write`, `statuses: write`, and release-drafter's existing job override with the redundant workflow-level block dropped). Not flagged on the first push only because Sonar judges changed lines, but each would have tripped the gate on the next edit near its header.
- **`.pre-commit-config.yaml`** — adds the `zizmor` hook, so the existing `Code checks` step fails on new workflow findings.

## Test plan

- [x] Syntax check passes (`check-yaml`).
- [x] `zizmor --offline .github/` → `No findings to report` (exit 0), down from 20 findings.
- [x] `pre-commit run --all-files` → 4/4 passed, including the new hook.
- [x] CI build + test green; SonarCloud quality gate OK.
- [ ] Release path: `persist-credentials: false` in `upload_release` only executes on a tag push. `softprops/action-gh-release` authenticates via `github.token` rather than the git credential helper, so it should be unaffected, but the first tag cut after this merges is the real check.

