### PR TITLE
chore: stub gettext and aio.ensure_running so the synth driver imports

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,15 +8,16 @@ sonar.tests=tests
 # sized_controls), generated gRPC stubs, and the shipped engine binaries.
 sonar.exclusions=addon/synthDrivers/sonata_neural_voices/lib/**,addon/synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/sonata_neural_voices/bin/**,addon/globalPlugins/sonata_tts_global_plugin/sized_controls.py
 
-# Code that cannot be executed by CI, so Sonar's Zero Coverage Sensor would
-# otherwise report it at 0% and drag every new-code coverage measurement down.
-# These stay in sonar.sources: they are still analysed for issues, they are
-# only removed from the coverage metric.
+# Not exercised by CI, so Sonar's Zero Coverage Sensor would otherwise report
+# these at 0% and drag every new-code coverage measurement down. They stay in
+# sonar.sources: they are still analysed for issues, they are only removed from
+# the coverage metric.
 #   globalPlugins/**  needs winsound (Windows-only stdlib) and real wx.lib
 #   grpc_client/**    needs the bundled grpc extension and sonata-grpc.exe
 #   synthDrivers/sonata_neural_voices/__init__.py
-#                     the SynthDriver itself; opens a WavePlayer against a real
-#                     audio device and calls grpc_client.initialize() on import
+#                     the SynthDriver itself; imports and constructs under the
+#                     conftest stubs, but no test drives it yet. Drop this entry
+#                     with the first test that does — see #65.
 sonar.coverage.exclusions=addon/globalPlugins/**,addon/synthDrivers/sonata_neural_voices/grpc_client/**,addon/synthDrivers/sonata_neural_voices/__init__.py
 
 # S8544 wants pip installs to resolve against a lock file. Our direct CI tooling

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ Strategy
 5. Load the real submodules we want to test (const, helpers, tts_system).
 """
 
+import builtins
 import sys
 import os
 import types
@@ -186,7 +187,11 @@ _stub_module(
 )
 
 # addonHandler
-_stub_module("addonHandler", initTranslation=MagicMock())
+# initTranslation() installs gettext's `_`, which module-level `_("...")` needs at import.
+def _init_translation():
+    builtins._ = lambda message: message
+
+_stub_module("addonHandler", initTranslation=_init_translation)
 
 # wx / gui
 _stub_module("wx", ID_ANY=0, YES=1, NO=2, YES_NO=3, ICON_WARNING=4, EVT_MENU=MagicMock())
@@ -250,6 +255,7 @@ _grpc_client.CALL_TIMEOUT = 10
 # aio — starts real threads/event loops; stub completely
 _aio = _stub_module("sonata_neural_voices.aio")
 _aio.initialize = MagicMock()
+_aio.ensure_running = MagicMock()
 _aio.terminate = MagicMock()
 _aio.ASYNCIO_EVENT_LOOP = MagicMock()
 _aio.CancelledError = Exception


### PR DESCRIPTION
Refs #65.

## Summary

Fills two gaps in the test stubs that were the only thing keeping the `SynthDriver` out of reach of the test suite, and corrects the `sonar-project.properties` comment that misdiagnosed why. No shipping code changes.

## Changes

- `tests/conftest.py` — `addonHandler.initTranslation` was a bare `MagicMock()`, so gettext's `_` was never installed and the module-level `_("&Speaker")` calls in `addon/synthDrivers/sonata_neural_voices/__init__.py:119` raised `NameError` at import. Replaced with a stub that installs a pass-through `_` into `builtins`, as real NVDA does.
- `tests/conftest.py` — added `ensure_running` to the `aio` stub; `SynthDriver.__init__` calls it (`__init__.py:193`).
- `sonar-project.properties` — the coverage-exclusion comment claimed the driver "opens a `WavePlayer` against a real audio device and calls `grpc_client.initialize()` on import". It does neither: `WavePlayer` is constructed in a lazily-called helper (`__init__.py:126`) and `initialize()` is in `SynthDriver.__init__` (`__init__.py:194`), which the stubbed `grpc_client` already satisfies with ready futures. Corrected, and the entry now says to drop the exclusion with the first test that covers the file.

The exclusion itself stays for now — nothing imports the file yet, so removing it would report 0% and drag new-code coverage down.

## Why this is worth its own PR

With these two lines, `addon/synthDrivers/sonata_neural_voices/__init__.py` imports and `SynthDriver()` constructs under the existing stubs, on Linux, with no production change. Driving `_build_speech_tasks()` with a synthetic sequence:

```python
seq = [IndexCommand(1), "hello ", "world", BreakCommand(100), IndexCommand(2), "after break"]
d._build_speech_tasks(seq)
# -> [SpeechTask, BreakTask, SpeechTask, IndexReachedTask, DoneSpeakingTask]
```

That's the flush-ordering behaviour that has broken before, now assertable without the AST/regex source extraction the other tests fall back to. Kept separate from the tests that will use it so the enabling change is reviewable on its own.

## Test plan

- [x] Syntax check passes.
- [x] CI build + test green — build, Sonar, and test_matrix on both windows-latest and ubuntu-latest all pass.
- [x] Full suite green locally — 148 passed.
- [x] Verified with a throwaway probe (not committed) that these two stubs alone are sufficient: import, construct, and drive `_build_speech_tasks()` with no test-local patching.

