### PR TITLE
fix: match dialect voices by underscore prefix, not hyphen

### DIFF
--- a/addon/synthDrivers/sonata_neural_voices/tts_system.py
+++ b/addon/synthDrivers/sonata_neural_voices/tts_system.py
@@ -316,7 +316,7 @@ class SonataTextToSpeechSystem:
         lang = normalizeLanguage(new_language)
         if self.speech_options.voice.language == lang:
             return
-        lang_code = lang.split("-")[0] + "-"
+        lang_code = lang.split("_")[0] + "_"
         possible_voices = []
         for voice in self.voices:
             if voice.language == lang:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,18 @@ _stub_module("globalVars", appArgs=types.SimpleNamespace(configPath="/tmp/nvda_t
 
 # languageHandler
 def _normalize_language(lang: str) -> str:
-    return lang.lower().replace("_", "-")
+    """Port of NVDA's languageHandler.normalizeLanguage: dash -> underscore,
+    lowercase language, uppercase dialect. Kept in sync with NVDA's real
+    implementation so tests catch separator/casing bugs the real driver
+    would hit (see issue #63)."""
+    lang = lang.replace("-", "_")
+    ld = lang.split("_")
+    ld[0] = ld[0].lower()
+    if ld[0] == "x":
+        return None
+    if len(ld) >= 2:
+        ld[1] = ld[1].upper()
+    return "_".join(ld)
 
 _stub_module("languageHandler", normalizeLanguage=_normalize_language)
 

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -235,6 +235,25 @@ class TestTTSVoiceSwitching:
 
         assert system.voice == dialect_voice.key
 
+    @pytest.mark.parametrize("requested", ["en-US", "en_US", "EN-us", "en_us"])
+    def test_set_language_normalizes_dash_and_case(self, requested):
+        """normalizeLanguage converts dashes to underscores and fixes casing
+        before the driver ever compares languages, so a dash- or
+        differently-cased request must resolve to the same dialect voice as
+        the canonical 'en_US' form."""
+        dialect_voice = _make_voice(key="en_US-alex-medium", name="Alex", language="en_US")
+        opts = SpeechOptions.__new__(SpeechOptions)
+        opts.voice = dialect_voice
+        opts.rate = opts.volume = opts.pitch = opts.sentence_silence_ms = None
+        system = SonataTextToSpeechSystem.__new__(SonataTextToSpeechSystem)
+        system.voices = [dialect_voice]
+        system.speech_options = opts
+
+        system.language = requested
+
+        assert system.voice == dialect_voice.key
+        assert system.language == "en_US"
+
 
 # ---------------------------------------------------------------------------
 # SonataTextToSpeechSystem — rate / volume / pitch

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -215,6 +215,26 @@ class TestTTSVoiceSwitching:
         tts.language = "en"
         assert tts.language == "en"
 
+    def test_set_bare_language_matches_dialect_voice(self, single_voice):
+        """A bare language code (e.g. 'en' from a LangChangeCommand) must match an
+        installed dialect voice (e.g. 'en_US') rather than raising VoiceNotFoundError.
+
+        Regression test for issue #63: the prefix match compared against a
+        hyphen-joined code ('en-') while voice.language is underscore-joined
+        ('en_US'), so the match always failed for dialect voices.
+        """
+        dialect_voice = _make_voice(key="en_US-alex-medium", name="Alex", language="en_US")
+        opts = SpeechOptions.__new__(SpeechOptions)
+        opts.voice = dialect_voice
+        opts.rate = opts.volume = opts.pitch = opts.sentence_silence_ms = None
+        system = SonataTextToSpeechSystem.__new__(SonataTextToSpeechSystem)
+        system.voices = [dialect_voice]
+        system.speech_options = opts
+
+        system.language = "en"
+
+        assert system.voice == dialect_voice.key
+
 
 # ---------------------------------------------------------------------------
 # SonataTextToSpeechSystem — rate / volume / pitch


### PR DESCRIPTION
## Summary
- `TTSSystem.language`'s dialect-fallback prefix match built `lang_code` with a trailing hyphen (`"en-"`), but `voice.language` values are underscore-joined (e.g. `"en_US"`), so the prefix check could never match and every bare language code (`LangChangeCommand('en')`) fell through to `raise VoiceNotFoundError`.
- This is the root cause of #63: NVDA sends a bare `"en"` for text/elements without a specific dialect tag (common on real sites, e.g. the reporter's repro on Gemini's site in Browse Mode), the currently loaded voice was a dialect voice (`en_US`), the prefix match silently failed, and the unhandled exception on the speech path produced the error chime while reading text / moving by line / moving by heading.
- Fix: split `lang_code` on `_` instead of `-`, matching the separator `voice.language` actually uses (confirmed elsewhere in the codebase, e.g. `voice_download.py` explicitly does `normalizeLanguage(...).replace("_", "-")` when it needs a hyphenated form — underscore is the internal convention).

## Root cause verification
Reproduced directly from the reporter's attached NVDA log (`nvda.zip` on #63): 32 identical tracebacks, all `VoiceNotFoundError: A voice with the given language \`en\` was not found`, raised from `tts_system.py` via `speech.manager._pushNextSpeech` → `SynthDriver.speak` right as the active voice was `MacAlex (en-US)`.

## Test plan
- [x] Added `TestTTSVoiceSwitching::test_set_bare_language_matches_dialect_voice`, which builds a single `en_US` voice and sets `language = "en"` — reproduces `VoiceNotFoundError` on the old code, passes with the fix.
- [x] `python3 -m pytest -q` — full suite passes (149 passed).

Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)