### PR TITLE
fix: move ARTIFACT_DIR out of job-level env in sonar-fork-scan.yml

### DIFF
--- a/.github/workflows/sonar-fork-scan.yml
+++ b/.github/workflows/sonar-fork-scan.yml
@@ -34,9 +34,12 @@ jobs:
       actions: read # needed by download-artifact to fetch an artifact from another run
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
     steps:
+      # The `runner` context isn't available in a job-level `env:` block (only
+      # in steps and later), so ARTIFACT_DIR is set per-step below instead.
       - name: Download coverage artifact
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: sonar-fork-coverage
@@ -48,6 +51,8 @@ jobs:
       # below doesn't wipe it before it's copied into place.
       - name: Read PR metadata
         id: meta
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
         run: |
           {
             echo "pr_number=$(cat "$ARTIFACT_DIR/pr_number.txt")"
@@ -62,6 +67,8 @@ jobs:
           persist-credentials: false
 
       - name: Place coverage report
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
         run: cp "$ARTIFACT_DIR/coverage.xml" coverage.xml
 
       - name: SonarQube scan


### PR DESCRIPTION
## Summary
- PR #72's `sonar-fork-scan.yml` set `ARTIFACT_DIR: ${{ runner.temp }}/...` in the job-level `env:` block. The `runner` context isn't available there (only in steps and later) -- it's a genuine GitHub Actions schema violation, not just a lint nit.
- The practical effect: GitHub couldn't parse the workflow at all. Every push/PR since #72 merged recorded a phantom failed run for this file, and -- more importantly -- its `workflow_run` listener never actually registered, so it never fired when `sonar-fork-coverage.yml` completed on the live test, PR #64.
- Fix: move `ARTIFACT_DIR` into each step's own `env:` block instead, where `runner` is valid.
- Caught this with `actionlint`, run for the first time against these files -- `zizmor` and a plain YAML parse both passed the broken version since it's a schema issue, not a YAML or generic-Action-security one. Both `actionlint` and `zizmor --persona=pedantic` are clean now.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger PR #64 (push a trivial commit, or re-run the `Sonar fork coverage` workflow) and confirm `sonar-fork-scan.yml` actually fires via `workflow_run` this time and posts a real `SonarCloud Code Analysis` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)