### PR TITLE
test: add Layer 2 gRPC version-handshake contract test

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -74,6 +74,16 @@ jobs:
       - name: Run tests
         run: pytest
 
+      # Separate invocation, not folded into `pytest` above: testpaths=tests
+      # already keeps this out of that run, and tests_contract/'s conftest.py
+      # imports the real grpc package (incompatible with tests/conftest.py's
+      # MagicMock stub of it). sonata-grpc.exe is a Windows binary, so this
+      # only does anything on the windows-latest leg of the matrix; the test
+      # module self-skips on other platforms.
+      - name: Run gRPC contract tests
+        if: runner.os == 'Windows'
+        run: pytest tests_contract/ -v
+
   # Stable check name for branch protection: matrix jobs report as
   # "test_matrix (<os>)", so the bare name would never be published.
   test:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,10 @@
 # Tooling for the test matrix and the Sonar coverage run.
 pytest==9.1.1
 pytest-cov==7.1.0
+
+# The vendored `grpc` under synthDrivers/sonata_neural_voices/lib/ eagerly
+# imports grpc.aio, which needs this. NVDA's own bundled Python already has
+# it (pulled in by some other dependency), so production never hits this;
+# a bare CI Python does. Only tests_contract/ (Windows-only) exercises the
+# real grpc package -- everywhere else it's a MagicMock stub.
+typing_extensions==4.16.0

--- a/tests_contract/__init__.py
+++ b/tests_contract/__init__.py
@@ -1,0 +1,1 @@
+# gRPC contract tests against the real, vendored sonata-grpc.exe (Windows only).

--- a/tests_contract/conftest.py
+++ b/tests_contract/conftest.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+"""
+conftest.py for the gRPC contract tests — these talk to the real, vendored
+sonata-grpc.exe over a real gRPC channel.
+
+Deliberately not part of tests/: that suite's conftest.py stubs `grpc`
+itself (sys.modules["grpc"] = MagicMock()) for every test in it, and
+pytest.ini's testpaths=tests keeps this directory out of a bare `pytest`
+run, so the two never collide in the same process. Run this tree with
+`pytest tests_contract/` explicitly.
+
+No NVDA stubbing here. The generated protobuf/grpc client
+(synthDrivers/sonata_neural_voices/grpc_client/grpc_protos/) has no NVDA
+dependencies, so tests talk to it directly instead of going through
+grpc_client/__init__.py — that module pulls in globalVars, logHandler, and
+Windows subprocess flags meant for NVDA's own background process lifecycle,
+not a short-lived test process.
+
+Windows-only: sonata-grpc.exe is a Windows PE binary and the vendored
+`grpc` package under lib/ is compiled for cp313-win_amd64. Test modules
+must check `sys.platform` and call `pytest.skip(..., allow_module_level=True)`
+before importing `grpc` — a plain skipif marker does not prevent pytest
+from importing the module (and therefore `grpc`) during collection.
+"""
+
+import os
+import sys
+
+_TESTS_CONTRACT_DIR = os.path.dirname(__file__)
+REPO_ROOT = os.path.abspath(os.path.join(_TESTS_CONTRACT_DIR, ".."))
+_SYNTH_PKG_DIR = os.path.join(REPO_ROOT, "addon", "synthDrivers", "sonata_neural_voices")
+
+LIB_DIRECTORY = os.path.join(_SYNTH_PKG_DIR, "lib")
+BIN_DIRECTORY = os.path.join(_SYNTH_PKG_DIR, "bin")
+GRPC_CLIENT_DIR = os.path.join(_SYNTH_PKG_DIR, "grpc_client")
+GRPC_SERVER_EXE = os.path.join(BIN_DIRECTORY, "sonata-grpc.exe")
+
+# Same vendored `grpc` the addon itself uses at runtime (see
+# helpers.import_bundled_library) — no new pip dependency needed for these
+# tests, and it's the exact build that talks to sonata-grpc.exe in production.
+for _p in (LIB_DIRECTORY, GRPC_CLIENT_DIR):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)

--- a/tests_contract/test_grpc_contract.py
+++ b/tests_contract/test_grpc_contract.py
@@ -1,0 +1,119 @@
+# coding: utf-8
+"""
+Contract test against the real, vendored sonata-grpc.exe: starts the actual
+engine binary and confirms it answers the GetSonataVersion handshake over a
+real gRPC channel — the same call grpc_client.check_grpc_server() makes
+during NVDA startup.
+
+Deliberately narrow (see issue #65): this only proves the process starts
+and speaks the expected protocol. It does not exercise LoadVoice/
+SynthesizeUtterance, since that needs a real trained voice model and none
+are vendored in this repo — a real HuggingFace download in CI is a bigger,
+flakier step planned as a separate follow-up once this handshake-level
+test is proven out.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+
+if sys.platform != "win32":
+    # A plain skipif marker would not be enough: pytest still imports this
+    # module during collection, and `import grpc` below fails outright on
+    # any platform other than the one the vendored lib/grpc was built for.
+    pytest.skip("sonata-grpc.exe is a Windows binary", allow_module_level=True)
+
+import grpc
+
+import grpc_protos.sonata_grpc_pb2 as msgs
+import grpc_protos.sonata_grpc_pb2_grpc as pb2_grpc
+
+from tests_contract.conftest import BIN_DIRECTORY, GRPC_SERVER_EXE
+
+STARTUP_TIMEOUT = 15
+STARTUP_POLL_INTERVAL = 0.5
+
+
+def _find_free_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def grpc_server():
+    assert os.path.exists(GRPC_SERVER_EXE), f"sonata-grpc.exe not found at {GRPC_SERVER_EXE}"
+
+    port = _find_free_port()
+    log_path = os.path.join(tempfile.mkdtemp(), "sonata-grpc.log")
+    env = os.environ.copy()
+    env.update({
+        "SONATA_GRPC_SERVER_PORT": str(port),
+        # Only needed for voice loading/synthesis, which this handshake-only
+        # test never exercises; an empty directory is enough for the server
+        # to start.
+        "SONATA_ESPEAKNG_DATA_DIRECTORY": tempfile.mkdtemp(),
+        "SONATA_GRPC": "info",
+    })
+
+    with open(log_path, "wb") as log_file:
+        process = subprocess.Popen(
+            args=GRPC_SERVER_EXE,
+            cwd=BIN_DIRECTORY,
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+
+    channel = grpc.insecure_channel(f"localhost:{port}")
+    stub = pb2_grpc.sonata_grpcStub(channel)
+
+    deadline = time.monotonic() + STARTUP_TIMEOUT
+    last_error = None
+    ready = False
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        try:
+            stub.GetSonataVersion(msgs.Empty(), timeout=STARTUP_POLL_INTERVAL)
+            ready = True
+            break
+        except grpc.RpcError as exc:
+            last_error = exc
+            time.sleep(STARTUP_POLL_INTERVAL)
+
+    if not ready:
+        channel.close()
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+        with open(log_path, "rb") as log_file:
+            server_log = log_file.read().decode(errors="replace")
+        pytest.fail(
+            f"sonata-grpc.exe did not become ready within {STARTUP_TIMEOUT}s "
+            f"(exit code: {process.poll()}, last gRPC error: {last_error}).\n"
+            f"Server log:\n{server_log}"
+        )
+
+    yield stub
+
+    channel.close()
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+
+
+class TestVersionHandshake:
+    def test_get_sonata_version_returns_a_non_empty_version_string(self, grpc_server):
+        response = grpc_server.GetSonataVersion(msgs.Empty())
+        assert isinstance(response.version, str)
+        assert response.version.strip() != ""


### PR DESCRIPTION
## Summary
- Adds the first Layer 2 contract test from #65: starts the real, vendored `sonata-grpc.exe` and confirms `GetSonataVersion` answers over a real gRPC channel (the same handshake `grpc_client.check_grpc_server()` does on NVDA startup). Everywhere else in the suite, `grpc_client` is mocked — this is the first test that talks to the actual engine binary.
- New `tests_contract/` tree, separate from `tests/`: that suite's `conftest.py` stubs `grpc` itself for every test, which can't coexist with a test that needs the real package. `pytest.ini`'s `testpaths=tests` already keeps a bare `pytest` from collecting it.
- Windows-only, self-skipping (`pytest.skip(..., allow_module_level=True)`, not just a marker — a plain skipif doesn't stop pytest importing `grpc` during collection, which fails outright on any platform other than the one the vendored copy was built for). Verified locally on Linux: the module skips cleanly and the rest of `pytest` (208 tests) is unaffected.
- Wired into `build_addon.yml`'s `test_matrix` job as a separate step gated `if: runner.os == 'Windows'`.
- No new pip dependency — reuses the same vendored `grpc` build under `synthDrivers/sonata_neural_voices/lib/` that the addon itself talks to at runtime.

Deliberately scoped to just the version handshake: `LoadVoice`/`SynthesizeUtterance` need a real trained voice model, none of which are vendored in this repo, so exercising actual synthesis is a follow-up once this is proven out.

Part of #65.

## Test plan
- [x] `pytest tests_contract/` on Linux — skips cleanly (can't execute the real Windows binary from here).
- [x] `pytest` (main suite) — 208 passed, unaffected.
- [ ] `pytest tests_contract/` on `windows-latest` — this is the actual contract check; I can't run it locally, so CI on this PR is the first real verification.