### PR TITLE
fix: replace automatic fork Sonar scan with a manual workflow_dispatch

### DIFF
--- a/.github/workflows/sonar-fork-coverage.yml
+++ b/.github/workflows/sonar-fork-coverage.yml
@@ -1,15 +1,20 @@
 name: Sonar fork coverage
 
 # The Sonar job in sonar.yml is deliberately skipped for fork PRs because
-# forks are never given SONAR_TOKEN. This workflow builds the pieces a real
-# scan needs -- the coverage report and PR metadata -- using only the
-# read-only, secret-less token that `pull_request` gets for fork PRs.
+# forks are never given SONAR_TOKEN. This workflow builds what a real scan
+# needs -- a full checkout (including git history, for Sonar's blame/new-code
+# detection) plus a coverage report -- using only the read-only, secret-less
+# token that `pull_request` gets for fork PRs, and packages it as a plain tar
+# archive artifact.
 #
-# sonar-fork-scan.yml (triggered by workflow_run, running in the base repo's
-# trusted context with SONAR_TOKEN) picks up the artifact produced here and
-# performs the actual scan. This workflow must never gain `secrets:` access
-# and must never do anything beyond running the PR's own test suite, exactly
-# as any other fork `pull_request` job already safely does.
+# sonar-fork-scan.yml (workflow_dispatch, manually triggered by a maintainer
+# after reviewing the diff) extracts that archive with plain `tar`, never a
+# git operation, so it never runs git fetch/checkout against fork content and
+# never executes anything from the fork -- the archive is only read
+# statically by the Sonar scanner. This workflow must never gain
+# `secrets:` access and must never do anything beyond running the PR's own
+# test suite, exactly as any other fork `pull_request` job already safely
+# does.
 
 on:
   pull_request:
@@ -32,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
+          fetch-depth: 0 # Sonar needs full history for new-code detection and blame
           persist-credentials: false
 
       - name: Set up Python
@@ -47,22 +53,11 @@ jobs:
       - name: Run tests with coverage
         run: pytest --cov --cov-report=xml
 
-      - name: Record PR metadata for the trusted scan workflow
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          printf '%s\n' "$PR_NUMBER" > pr_number.txt
-          printf '%s\n' "$HEAD_SHA" > pr_sha.txt
-          printf '%s\n' "$HEAD_REF" > pr_ref.txt
+      - name: Archive workspace for the manual scan workflow
+        run: tar -czf "$RUNNER_TEMP/workspace.tar.gz" -C "$GITHUB_WORKSPACE" .
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: sonar-fork-coverage
-          path: |
-            coverage.xml
-            pr_number.txt
-            pr_sha.txt
-            pr_ref.txt
-          retention-days: 1
+          name: sonar-fork-workspace
+          path: ${{ runner.temp }}/workspace.tar.gz
+          retention-days: 7

--- a/.github/workflows/sonar-fork-scan.yml
+++ b/.github/workflows/sonar-fork-scan.yml
@@ -1,83 +1,107 @@
-name: Sonar fork scan
+name: Sonar fork scan (manual)
 
-# Runs the real SonarCloud scan for fork PRs, using the coverage report and
-# PR metadata built by sonar-fork-coverage.yml. workflow_run executes this
-# file from the base branch in the base repo's trusted context, so
-# SONAR_TOKEN is available -- but nothing here ever runs code from the PR:
-# it only downloads a pre-built artifact and checks out the PR's source so
-# the scanner can read it statically. It must never install dependencies
-# from the fork or execute its test suite; that already happened, safely,
-# in the untrusted coverage workflow.
+# Automated SonarCloud analysis of arbitrary fork PRs doesn't have a safe
+# implementation: SONAR_TOKEN is needed to post results, but no matter how
+# fork source reaches a job holding SONAR_TOKEN, that job must not execute
+# anything derived from the fork. A previous version of this workflow chained
+# automatically off sonar-fork-coverage.yml via workflow_run and used
+# actions/checkout on the PR head -- actions/checkout itself refuses that
+# combination by default ("pwn request" protection), and a purpose-built
+# action for this exact problem (matrix-org/sonarcloud-workflow-action) was
+# archived with the stated reason: "there is [no] foolproof way to run
+# Sonarcloud against attacker-controlled PRs."
 #
-# workflow_run does not execute workflow files from the PR branch either --
-# only this file, as it exists on main -- so a fork PR cannot alter what
-# this workflow does.
+# So this is manual, mirroring the "ok-to-test" model GitHub already forces
+# on fork PRs (the "Approve and run workflows" click every fork PR needs
+# before anything executes at all): a maintainer reviews the diff, then runs
+# this with the PR number and the exact commit SHA reviewed. Only users with
+# write access can dispatch a workflow_dispatch run -- GitHub enforces that
+# natively -- and pinning the SHA closes the gap where new, unreviewed
+# commits land between review and running this.
+#
+# This job still never runs anything from the fork: it downloads the tar
+# archive sonar-fork-coverage.yml built (test suite already executed there,
+# safely, with no secrets) and extracts it with plain `tar`, never a git
+# operation against fork content. The scanner only reads the result
+# statically.
+#
+# Until a maintainer runs this, the required "SonarCloud Code Analysis"
+# check on a fork PR stays pending -- merge via admin override if a scan
+# isn't warranted (e.g. docs-only changes), rather than faking green.
 
-on:  # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: [ "Sonar fork coverage" ]
-    types: [ completed ]
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to scan"
+        required: true
+        type: string
+      expected_head_sha:
+        description: "Commit SHA you reviewed (see `gh pr view <pr_number> --json headRefOid`) -- fails if the PR has moved past this"
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: sonar-fork-scan-${{ github.event.workflow_run.id }}
+  group: sonar-fork-scan-${{ inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
   scan:
-    name: Sonar fork scan
+    name: Sonar fork scan (manual)
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     permissions:
-      contents: read
-      actions: read # needed by download-artifact to fetch an artifact from another run
+      pull-requests: read # needed by `gh pr view` to look up the PR's current head
+      actions: read # needed to find and download the matching coverage run's artifact
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      EXPECTED_SHA: ${{ inputs.expected_head_sha }}
     steps:
-      # The `runner` context isn't available in a job-level `env:` block (only
-      # in steps and later), so ARTIFACT_DIR is set per-step below instead.
-      - name: Download coverage artifact
-        env:
-          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
+      - name: Verify the PR hasn't moved since review
+        id: pr
+        run: |
+          ACTUAL_SHA=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid -q .headRefOid)
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::PR #$PR_NUMBER head is $ACTUAL_SHA, not the reviewed $EXPECTED_SHA -- re-review before scanning."
+            exit 1
+          fi
+          echo "head_ref=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName -q .headRefName)" >> "$GITHUB_OUTPUT"
+
+      - name: Find the matching coverage run
+        id: run
+        run: |
+          RUN_ID=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/sonar-fork-coverage.yml/runs?event=pull_request&status=success&per_page=20" \
+            --jq "[.workflow_runs[] | select(.head_sha == \"$EXPECTED_SHA\")][0].id")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error::No successful 'Sonar fork coverage' run found for $EXPECTED_SHA. Push a commit or re-run that workflow first."
+            exit 1
+          fi
+          echo "id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download coverage workspace
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: sonar-fork-coverage
-          path: ${{ runner.temp }}/sonar-fork-coverage
-          run-id: ${{ github.event.workflow_run.id }}
+          name: sonar-fork-workspace
+          path: ${{ runner.temp }}/sonar-fork-workspace
+          run-id: ${{ steps.run.outputs.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Downloaded outside GITHUB_WORKSPACE (above) so checkout's `git clean`
-      # below doesn't wipe it before it's copied into place.
-      - name: Read PR metadata
-        id: meta
+      - name: Extract workspace (plain tar, not a git operation)
         env:
-          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
+          ARCHIVE_DIR: ${{ runner.temp }}/sonar-fork-workspace
         run: |
-          {
-            echo "pr_number=$(cat "$ARTIFACT_DIR/pr_number.txt")"
-            echo "head_ref=$(cat "$ARTIFACT_DIR/pr_ref.txt")"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Checkout PR head (read-only; no PR code is executed)
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
-        with:
-          ref: refs/pull/${{ steps.meta.outputs.pr_number }}/head
-          fetch-depth: 0 # Sonar needs full history for new-code detection and blame
-          persist-credentials: false
-
-      - name: Place coverage report
-        env:
-          ARTIFACT_DIR: ${{ runner.temp }}/sonar-fork-coverage
-        run: cp "$ARTIFACT_DIR/coverage.xml" coverage.xml
+          mkdir -p workspace
+          tar -xzf "$ARCHIVE_DIR/workspace.tar.gz" -C workspace
 
       - name: SonarQube scan
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
-          # Not auto-detected: this runs under workflow_run, not the native
-          # pull_request event the scanner normally reads PR context from.
           args: >
-            -Dsonar.pullrequest.key=${{ steps.meta.outputs.pr_number }}
-            -Dsonar.pullrequest.branch=${{ steps.meta.outputs.head_ref }}
+            -Dsonar.projectBaseDir=workspace
+            -Dsonar.pullrequest.key=${{ inputs.pr_number }}
+            -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}
             -Dsonar.pullrequest.base=main

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,20 +30,9 @@ sonar.coverage.exclusions=addon/globalPlugins/sonata_tts_global_plugin/__init__.
 # MAJOR VULNERABILITY, so leaving it open would hold new_security_rating at C and
 # fail the required gate on any PR touching these files. Scoped to the workflows
 # so S8541, S7637 and S6573 stay enforced there.
-#
-# S7631 flags the `actions/checkout` of the PR head in sonar-fork-scan.yml as
-# executing untrusted fork code -- the generic pattern it's checking for, but
-# not what actually happens here: that job only checks out the PR's source
-# for the Sonar scanner to read statically and never installs dependencies
-# or runs anything from the fork (that already happened, safely, with no
-# secrets, in sonar-fork-coverage.yml). zizmor's equivalent dangerous-triggers
-# audit is suppressed inline in that file for the same reason. Scoped to that
-# one file so S7631 stays enforced everywhere else.
-sonar.issue.ignore.multicriteria=pipLock,forkCheckout
+sonar.issue.ignore.multicriteria=pipLock
 sonar.issue.ignore.multicriteria.pipLock.ruleKey=githubactions:S8544
 sonar.issue.ignore.multicriteria.pipLock.resourceKey=.github/workflows/**/*
-sonar.issue.ignore.multicriteria.forkCheckout.ruleKey=githubactions:S7631
-sonar.issue.ignore.multicriteria.forkCheckout.resourceKey=.github/workflows/sonar-fork-scan.yml
 
 sonar.python.version=3.13
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
## Summary
- The automatic `workflow_run`-chained fork scan (from #72/#74) turned out not to have a safe implementation. `actions/checkout` itself refuses to check out a PR head ref inside `workflow_run` by default (its own "pwn request" guard), and a purpose-built action for this exact problem, [matrix-org/sonarcloud-workflow-action](https://github.com/matrix-org/sonarcloud-workflow-action), is archived with the stated reason: *"there is [no] foolproof way to run Sonarcloud against attacker-controlled PRs."* SonarSource's own community forum has an unanswered thread raising the same concern; their docs don't cover fork PRs at all.
- Replaced the automatic chain with `sonar-fork-scan.yml` as a `workflow_dispatch` a maintainer runs manually after reviewing the diff, with `pr_number` and `expected_head_sha` inputs -- it fails if the PR has moved past the reviewed SHA. This mirrors the "ok-to-test" pattern used elsewhere in the ecosystem, and isn't really new friction: GitHub already forces a maintainer to click "Approve and run workflows" before *anything* executes on a fork PR.
- The trusted job still never runs anything from the fork: it downloads the tar archive `sonar-fork-coverage.yml` already built (tests already executed there, safely, with no secrets) and extracts it with plain `tar` -- never a git operation against fork content, so it doesn't need to override the checkout guard at all.
- Dropped the now-stale `S7631` suppression in `sonar-project.properties` along with the checkout step it was justifying.
- Until a maintainer runs the manual scan, the required `SonarCloud Code Analysis` check on a fork PR simply stays pending -- mergeable via admin override (already enabled on this repo) when a scan isn't warranted, rather than faking green like the original fallback did.

Validated with both `actionlint` and `zizmor --persona=pedantic` (both clean) -- actionlint is what caught the job-level `env: runner.temp` schema bug in the previous iteration, which a plain YAML parse and zizmor both missed.

## Test plan
- [ ] Merge this PR (same-repo, `sonar.yml` scans it directly)
- [ ] On PR #64 (or any open fork PR), manually run `Sonar fork scan (manual)` via `gh workflow run sonar-fork-scan.yml -f pr_number=64 -f expected_head_sha=<sha>` and confirm it posts a real `SonarCloud Code Analysis` status without ever checking out fork code

🤖 Generated with [Claude Code](https://claude.com/claude-code)