### PR TITLE
test: add LoadVoice/SynthesizeUtterance contract test

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,10 @@ pytest-cov==7.1.0
 # a bare CI Python does. Only tests_contract/ (Windows-only) exercises the
 # real grpc package -- everywhere else it's a MagicMock stub.
 typing_extensions==4.16.0
+
+# sonata-grpc.exe needs real espeak-ng-data to phonemize text for synthesis.
+# Production gets this for free from NVDA's own bundled eSpeak NG driver;
+# this vendors the same data as a plain pip package so
+# tests_contract/test_grpc_contract.py's synthesis test has something to
+# point SONATA_ESPEAKNG_DATA_DIRECTORY at.
+espeakng-loader==0.2.4

--- a/tests_contract/test_grpc_contract.py
+++ b/tests_contract/test_grpc_contract.py
@@ -28,6 +28,7 @@ if sys.platform != "win32":
     pytest.skip("sonata-grpc.exe is a Windows binary", allow_module_level=True)
 
 import grpc
+import espeakng_loader
 
 import grpc_protos.sonata_grpc_pb2 as msgs
 import grpc_protos.sonata_grpc_pb2_grpc as pb2_grpc
@@ -51,12 +52,17 @@ def grpc_server():
     port = _find_free_port()
     log_path = os.path.join(tempfile.mkdtemp(), "sonata-grpc.log")
     env = os.environ.copy()
+    # The server needs real espeak-ng phonemization data to synthesize text
+    # (not just a valid directory), or SynthesizeUtterance aborts with
+    # "Failed to initialize eSpeak-ng". Production gets this for free from
+    # NVDA's own bundled eSpeak NG driver; espeakng-loader vendors the same
+    # data as a plain pip package for exactly this kind of standalone use.
+    # SONATA_ESPEAKNG_DATA_DIRECTORY must be the directory that *contains*
+    # an `espeak-ng-data` subfolder, not that subfolder itself.
+    espeakng_data_dir = os.path.dirname(espeakng_loader.get_data_path())
     env.update({
         "SONATA_GRPC_SERVER_PORT": str(port),
-        # Only needed for voice loading/synthesis, which this handshake-only
-        # test never exercises; an empty directory is enough for the server
-        # to start.
-        "SONATA_ESPEAKNG_DATA_DIRECTORY": tempfile.mkdtemp(),
+        "SONATA_ESPEAKNG_DATA_DIRECTORY": espeakng_data_dir,
         "SONATA_GRPC": "info",
     })
 

--- a/tests_contract/test_grpc_contract.py
+++ b/tests_contract/test_grpc_contract.py
@@ -5,12 +5,10 @@ engine binary and confirms it answers the GetSonataVersion handshake over a
 real gRPC channel — the same call grpc_client.check_grpc_server() makes
 during NVDA startup.
 
-Deliberately narrow (see issue #65): this only proves the process starts
-and speaks the expected protocol. It does not exercise LoadVoice/
-SynthesizeUtterance, since that needs a real trained voice model and none
-are vendored in this repo — a real HuggingFace download in CI is a bigger,
-flakier step planned as a separate follow-up once this handshake-level
-test is proven out.
+Also exercises LoadVoice + SynthesizeUtterance against a real trained
+voice model, downloaded from HuggingFace at test time (see
+TestVoiceSynthesis below) — the first test to touch actual speech
+synthesis rather than the mocked grpc_client used everywhere in tests/.
 """
 
 import os
@@ -19,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.request
 
 import pytest
 
@@ -117,3 +116,50 @@ class TestVersionHandshake:
         response = grpc_server.GetSonataVersion(msgs.Empty())
         assert isinstance(response.version, str)
         assert response.version.strip() != ""
+
+
+# vi_VN-vivos-x_low is deliberately the cheapest real Piper voice to test
+# against: x_low is the lowest quality tier and vivos is one of the smaller
+# datasets (~28MB total). Actual synthesis quality isn't the point here —
+# only that LoadVoice/SynthesizeUtterance work end-to-end against the real
+# engine, which the mocked grpc_client everywhere else in tests/ can't prove.
+VOICE_KEY = "vi_VN-vivos-x_low"
+VOICE_FILES_BASE_URL = (
+    "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/vi/vi_VN/vivos/x_low"
+)
+DOWNLOAD_TIMEOUT = 60
+CALL_TIMEOUT = 30
+
+
+def _download(url, target_path):
+    with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response, open(target_path, "wb") as f:
+        f.write(response.read())
+
+
+@pytest.fixture(scope="session")
+def downloaded_voice(tmp_path_factory):
+    """Download the voice once per session; returns the config (.onnx.json) path.
+
+    LoadVoice takes the config path and expects the matching .onnx file
+    alongside it (same naming convention SonataVoice.load() relies on in
+    production).
+    """
+    voice_dir = tmp_path_factory.mktemp("voice")
+    onnx_path = voice_dir / f"{VOICE_KEY}.onnx"
+    config_path = voice_dir / f"{VOICE_KEY}.onnx.json"
+    _download(f"{VOICE_FILES_BASE_URL}/{VOICE_KEY}.onnx", onnx_path)
+    _download(f"{VOICE_FILES_BASE_URL}/{VOICE_KEY}.onnx.json", config_path)
+    return str(config_path)
+
+
+class TestVoiceSynthesis:
+    def test_load_voice_and_synthesize_returns_non_empty_audio(self, grpc_server, downloaded_voice):
+        voice_info = grpc_server.LoadVoice(msgs.VoicePath(config_path=downloaded_voice), timeout=CALL_TIMEOUT)
+        assert voice_info.voice_id
+        assert voice_info.audio.sample_rate > 0
+
+        utterance = msgs.Utterance(voice_id=voice_info.voice_id, text="xin chào")
+        frames = list(grpc_server.SynthesizeUtterance(utterance, timeout=CALL_TIMEOUT))
+
+        assert frames, "expected at least one audio frame from SynthesizeUtterance"
+        assert sum(len(frame.wav_samples) for frame in frames) > 0


### PR DESCRIPTION
## Summary
- Extends the Layer 2 gRPC contract test from #75 past the version handshake into actual synthesis: `TestVoiceSynthesis` downloads `vi_VN-vivos-x_low` (~28MB — the cheapest real Piper voice: lowest quality tier, one of the smaller datasets) from HuggingFace once per session, `LoadVoice`'s it against the real `sonata-grpc.exe`, then `SynthesizeUtterance`'s a short phrase and asserts non-empty audio frames come back.
- First test anywhere in the suite that exercises real speech synthesis end-to-end; every other test mocks `grpc_client`.
- No CI wiring changes — reuses the existing Windows-only `pytest tests_contract/ -v` step from #75.
- Verified locally on Linux that the module still skips cleanly and the main suite (208 tests) is unaffected.

Part of #65.

## Test plan
- [x] `pytest tests_contract/` on Linux — skips cleanly.
- [x] `pytest` (main suite) — 208 passed, unaffected.
- [ ] `pytest tests_contract/` on `windows-latest` — the real check, including a live HuggingFace download; CI on this PR is the first real verification (I can't run this locally, and network flakiness against HuggingFace is a real risk worth watching for on the first few runs).