### PR TITLE
fix: pin PR head SHA and self-report the real Sonar status

### DIFF
--- a/.github/workflows/sonar-fork-coverage.yml
+++ b/.github/workflows/sonar-fork-coverage.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
+          # Pinned to the actual PR head, not actions/checkout's default
+          # ephemeral merge commit -- otherwise the scanner analyzes a
+          # commit SHA that doesn't match the PR, and SonarCloud can't
+          # attach its status to the commit branch protection actually
+          # checks.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Sonar needs full history for new-code detection and blame
           persist-credentials: false
 

--- a/.github/workflows/sonar-fork-scan.yml
+++ b/.github/workflows/sonar-fork-scan.yml
@@ -54,6 +54,7 @@ jobs:
     permissions:
       pull-requests: read # needed by `gh pr view` to look up the PR's current head
       actions: read # needed to find and download the matching coverage run's artifact
+      statuses: write # needed to post the real result to the PR's head commit ourselves (see below)
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,7 +97,16 @@ jobs:
           mkdir -p workspace
           tar -xzf "$ARCHIVE_DIR/workspace.tar.gz" -C workspace
 
+      # SonarCloud's GitHub integration normally posts the
+      # "SonarCloud Code Analysis" status itself, but it attaches to
+      # whatever commit the Actions *run* is associated with -- main's tip,
+      # since this is workflow_dispatch, not the PR's head. It has no way to
+      # know to target the PR from sonar.pullrequest.key alone. So this
+      # waits for the real quality gate result and posts the status to the
+      # actual head SHA itself, rather than relying on that automatic
+      # posting.
       - name: SonarQube scan
+        id: sonar
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         with:
@@ -105,3 +115,24 @@ jobs:
             -Dsonar.pullrequest.key=${{ inputs.pr_number }}
             -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}
             -Dsonar.pullrequest.base=main
+            -Dsonar.qualitygate.wait=true
+            -Dsonar.qualitygate.timeout=300
+
+      - name: Post the real result to the PR's head commit
+        if: always() && env.SONAR_TOKEN != ''
+        env:
+          SCAN_OUTCOME: ${{ steps.sonar.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ "$SCAN_OUTCOME" = "success" ]; then
+            STATE=success
+            DESC="Quality gate passed"
+          else
+            STATE=failure
+            DESC="Quality gate failed or scan errored -- see the SonarCloud dashboard"
+          fi
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$EXPECTED_SHA" \
+            -f state="$STATE" \
+            -f context='SonarCloud Code Analysis' \
+            -f description="$DESC" \
+            -f target_url="https://sonarcloud.io/dashboard?id=austek_sonata-nvda&pullRequest=$PR_NUMBER"


### PR DESCRIPTION
## Summary
Testing #76's manual scan against PR #64 end-to-end surfaced two real bugs:

1. **Wrong commit analyzed.** `sonar-fork-coverage.yml`'s checkout had no `ref:`, so it defaulted to `actions/checkout`'s ephemeral merge-commit ref for `pull_request` events (confirmed in the run log: `HEAD is now at 3b116fa Merge 78403c0... into bc70259...`), not the PR's actual head SHA. Fixed by pinning `ref: ${{ github.event.pull_request.head.sha }}`.
2. **Status attached to the wrong commit.** Even with (1) fixed, SonarCloud's automatic "SonarCloud Code Analysis" status posting attaches to whatever commit the Actions *run* is associated with -- `main`'s tip, since `sonar-fork-scan.yml` runs via `workflow_dispatch` against `main`, not the PR. Confirmed live: a real "Quality Gate passed" PR comment landed correctly on PR #64 (keyed by `sonar.pullrequest.key`), but the commit status landed on `main`'s HEAD instead of the PR's head SHA -- so it would never actually satisfy branch protection. Fixed by waiting for the real quality gate result (`sonar.qualitygate.wait=true`) and posting our own commit status to the reviewed SHA.

Both changes validated with `actionlint` and `zizmor --persona=pedantic` (clean).

## Test plan
- [ ] Merge this PR
- [ ] Re-run the manual scan against PR #64 and confirm `SonarCloud Code Analysis` lands on the PR's actual head commit this time, with a real pass/fail result
🤖 Generated with [Claude Code](https://claude.com/claude-code)