### PR TITLE
feat: upgrade path from Sonata Neural Voices

### DIFF
--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -94,6 +94,18 @@ def warn_if_old_addon_installed(addons=None):
     )
 
 
+def onInstall():
+    for step in (
+        warn_if_old_addon_installed,
+        migrate_voices_directory,
+        migrate_speech_config,
+    ):
+        try:
+            step()
+        except Exception:
+            log.exception(f"Upgrade step {step.__name__} failed")
+
+
 def onUninstall():
     with _temporary_import_psutil() as psutil:
         force_kill_sonata_grpc_server(psutil)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import tempfile
 
+import config
 import globalVars
 from logHandler import log
 
@@ -23,20 +24,41 @@ del _DIR, _PIPER_SYNTH_DIR
 OLD_ADDON_NAME = "sonata_neural_voices"
 OLD_VOICES_DIR_NAME = "sonata"
 VOICES_DIR_NAME = "dengjen"
+CONFIG_SECTION = "dengjen_neural_voices"
 
 
 def migrate_voices_directory(config_path=None):
-	"""Move downloaded voices from the pre-4.0.0 location. Same volume, so this
-	is a rename rather than a copy however many GB of models are present."""
-	if config_path is None:
-		config_path = globalVars.appArgs.configPath
-	old_dir = os.path.join(config_path, OLD_VOICES_DIR_NAME)
-	new_dir = os.path.join(config_path, VOICES_DIR_NAME)
-	if os.path.exists(new_dir) or not os.path.isdir(old_dir):
-		return False
-	os.rename(old_dir, new_dir)
-	log.info(f"Migrated voices from {old_dir} to {new_dir}")
-	return True
+    """Move downloaded voices from the pre-4.0.0 location. Same volume, so this
+    is a rename rather than a copy however many GB of models are present."""
+    if config_path is None:
+        config_path = globalVars.appArgs.configPath
+    old_dir = os.path.join(config_path, OLD_VOICES_DIR_NAME)
+    new_dir = os.path.join(config_path, VOICES_DIR_NAME)
+    if os.path.exists(new_dir) or not os.path.isdir(old_dir):
+        return False
+    os.rename(old_dir, new_dir)
+    log.info(f"Migrated voices from {old_dir} to {new_dir}")
+    return True
+
+
+def _as_plain_dict(section):
+    return {
+        key: _as_plain_dict(value) if hasattr(value, "keys") else value
+        for key, value in section.items()
+    }
+
+
+def migrate_speech_config(conf=None):
+    """Carry rate, pitch, volume and per-language voice choices across to the
+    renamed config section. The old section is left in place."""
+    if conf is None:
+        conf = config.conf
+    speech = conf["speech"]
+    if not speech.isSet(OLD_ADDON_NAME) or speech.isSet(CONFIG_SECTION):
+        return False
+    speech[CONFIG_SECTION] = _as_plain_dict(speech[OLD_ADDON_NAME])
+    log.info(f"Migrated speech settings from {OLD_ADDON_NAME} to {CONFIG_SECTION}")
+    return True
 
 
 def onUninstall():

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -10,9 +10,14 @@ import shutil
 import sys
 import tempfile
 
+import addonHandler
 import config
 import globalVars
+import gui
+import wx
 from logHandler import log
+
+addonHandler.initTranslation()
 
 
 _DIR = os.path.abspath(os.path.dirname(__file__))
@@ -59,6 +64,34 @@ def migrate_speech_config(conf=None):
     speech[CONFIG_SECTION] = _as_plain_dict(speech[OLD_ADDON_NAME])
     log.info(f"Migrated speech settings from {OLD_ADDON_NAME} to {CONFIG_SECTION}")
     return True
+
+
+def is_old_addon_installed(addons=None):
+    if addons is None:
+        addons = addonHandler.getAvailableAddons()
+    return any(
+        getattr(addon, "name", None) == OLD_ADDON_NAME
+        and not getattr(addon, "isPendingRemove", False)
+        for addon in addons
+    )
+
+
+def warn_if_old_addon_installed(addons=None):
+    if not is_old_addon_installed(addons):
+        return
+    wx.CallAfter(
+        gui.messageBox,
+        # Translators: shown after installing when the pre-rename add-on is still present
+        _(
+            "The Sonata Neural Voices add-on is still installed. Dengjen Neural Voices "
+            "has taken over its downloaded voices, so Sonata can no longer find them. "
+            "Remove the Sonata Neural Voices add-on to avoid two synthesizers appearing "
+            "in your speech settings."
+        ),
+        # Translators: title of the message shown when the pre-rename add-on is still present
+        _("Old add-on still installed"),
+        wx.OK | wx.ICON_WARNING,
+    )
 
 
 def onUninstall():

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import tempfile
 
+import globalVars
 from logHandler import log
 
 
@@ -18,6 +19,24 @@ _PIPER_SYNTH_DIR = os.path.join(_DIR, "synthDrivers", "dengjen_neural_voices")
 LIB_DIR = os.path.join(_PIPER_SYNTH_DIR, "lib")
 BIN_DIR = os.path.join(_PIPER_SYNTH_DIR, "bin")
 del _DIR, _PIPER_SYNTH_DIR
+
+OLD_ADDON_NAME = "sonata_neural_voices"
+OLD_VOICES_DIR_NAME = "sonata"
+VOICES_DIR_NAME = "dengjen"
+
+
+def migrate_voices_directory(config_path=None):
+	"""Move downloaded voices from the pre-4.0.0 location. Same volume, so this
+	is a rename rather than a copy however many GB of models are present."""
+	if config_path is None:
+		config_path = globalVars.appArgs.configPath
+	old_dir = os.path.join(config_path, OLD_VOICES_DIR_NAME)
+	new_dir = os.path.join(config_path, VOICES_DIR_NAME)
+	if os.path.exists(new_dir) or not os.path.isdir(old_dir):
+		return False
+	os.rename(old_dir, new_dir)
+	log.info(f"Migrated voices from {old_dir} to {new_dir}")
+	return True
 
 
 def onUninstall():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,7 +242,10 @@ _stub_module(
 # assert on its effects immediately instead of needing to pump wx's queue.
 _stub_module(
     "wx",
-    ID_ANY=0, YES=1, NO=2, YES_NO=3, OK=7, ICON_WARNING=4, ICON_ERROR=5, ICON_INFORMATION=6,
+    # Distinct bit flags, as in real wx, so bitwise-OR combinations (e.g.
+    # wx.YES_NO | wx.ICON_WARNING) can't collide with any other stubbed
+    # constant, including ones ORed together elsewhere (e.g. wx.OK).
+    ID_ANY=0, YES=1, NO=2, YES_NO=3, OK=4, ICON_WARNING=8, ICON_ERROR=16, ICON_INFORMATION=32,
     EVT_MENU=MagicMock(),
     CallAfter=MagicMock(side_effect=lambda func, *a, **kw: func(*a, **kw)),
     ProgressDialog=MagicMock(return_value=MagicMock()),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,14 +231,18 @@ _stub_module(
 def _init_translation():
     builtins._ = lambda message: message
 
-_stub_module("addonHandler", initTranslation=_init_translation)
+_stub_module(
+    "addonHandler",
+    initTranslation=_init_translation,
+    getAvailableAddons=lambda: [],
+)
 
 # wx / gui
 # CallAfter runs synchronously (no real event loop under test) so callers can
 # assert on its effects immediately instead of needing to pump wx's queue.
 _stub_module(
     "wx",
-    ID_ANY=0, YES=1, NO=2, YES_NO=3, ICON_WARNING=4, ICON_ERROR=5, ICON_INFORMATION=6,
+    ID_ANY=0, YES=1, NO=2, YES_NO=3, OK=7, ICON_WARNING=4, ICON_ERROR=5, ICON_INFORMATION=6,
     EVT_MENU=MagicMock(),
     CallAfter=MagicMock(side_effect=lambda func, *a, **kw: func(*a, **kw)),
     ProgressDialog=MagicMock(return_value=MagicMock()),

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+"""Tests for the 4.0.0 upgrade path in installTasks.py.
+
+The real upgrade runs inside NVDA on Windows. These exercise the decision
+logic against a temporary directory and fake config objects; the NVDA-side
+behaviour still needs an end-user check on the built artifact.
+"""
+
+import os
+
+from tests.conftest import REPO_ROOT, load_module_from_path
+
+install_tasks = load_module_from_path(
+    "_install_migrations_under_test",
+    os.path.join(REPO_ROOT, "addon", "installTasks.py"),
+)
+
+
+class TestMigrateVoicesDirectory:
+    def test_moves_the_old_directory_when_the_new_one_is_absent(self, tmp_path):
+        (tmp_path / "sonata" / "voices" / "piper").mkdir(parents=True)
+        assert install_tasks.migrate_voices_directory(str(tmp_path)) is True
+        assert (tmp_path / "dengjen" / "voices" / "piper").is_dir()
+        assert not (tmp_path / "sonata").exists()
+
+    def test_leaves_both_alone_when_the_new_directory_already_exists(self, tmp_path):
+        (tmp_path / "sonata" / "voices").mkdir(parents=True)
+        (tmp_path / "dengjen" / "voices").mkdir(parents=True)
+        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
+        assert (tmp_path / "sonata" / "voices").is_dir()
+
+    def test_is_a_noop_when_there_is_nothing_to_migrate(self, tmp_path):
+        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
+        assert not (tmp_path / "dengjen").exists()
+
+    def test_ignores_a_file_named_like_the_old_directory(self, tmp_path):
+        (tmp_path / "sonata").write_text("not a directory")
+        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
+        assert not (tmp_path / "dengjen").exists()

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -37,3 +37,63 @@ class TestMigrateVoicesDirectory:
         (tmp_path / "sonata").write_text("not a directory")
         assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
         assert not (tmp_path / "dengjen").exists()
+
+
+class _FakeSection(dict):
+    """Stands in for NVDA's ConfigObj section, which has isSet()."""
+
+    def isSet(self, key):
+        return key in self
+
+
+def _speech_conf(**sections):
+    speech = _FakeSection()
+    speech.update(sections)
+    return {"speech": speech}
+
+
+class TestMigrateSpeechConfig:
+    def test_copies_the_old_section_when_the_new_one_is_absent(self):
+        conf = _speech_conf(
+            sonata_neural_voices={
+                "rate": 55,
+                "voices": {"en_US-amy-medium": {"speaker": "amy"}},
+            }
+        )
+        assert install_tasks.migrate_speech_config(conf) is True
+        assert conf["speech"]["dengjen_neural_voices"] == {
+            "rate": 55,
+            "voices": {"en_US-amy-medium": {"speaker": "amy"}},
+        }
+
+    def test_copies_rather_than_aliases_nested_sections(self):
+        conf = _speech_conf(
+            sonata_neural_voices={"voices": {"en_US-amy-medium": {"speaker": "amy"}}}
+        )
+        install_tasks.migrate_speech_config(conf)
+        conf["speech"]["dengjen_neural_voices"]["voices"]["en_US-amy-medium"][
+            "speaker"
+        ] = "changed"
+        assert (
+            conf["speech"]["sonata_neural_voices"]["voices"]["en_US-amy-medium"][
+                "speaker"
+            ]
+            == "amy"
+        )
+
+    def test_leaves_the_old_section_in_place(self):
+        conf = _speech_conf(sonata_neural_voices={"rate": 55})
+        install_tasks.migrate_speech_config(conf)
+        assert conf["speech"]["sonata_neural_voices"] == {"rate": 55}
+
+    def test_leaves_an_existing_new_section_alone(self):
+        conf = _speech_conf(
+            sonata_neural_voices={"rate": 55}, dengjen_neural_voices={"rate": 80}
+        )
+        assert install_tasks.migrate_speech_config(conf) is False
+        assert conf["speech"]["dengjen_neural_voices"] == {"rate": 80}
+
+    def test_is_a_noop_when_there_is_no_old_section(self):
+        conf = _speech_conf()
+        assert install_tasks.migrate_speech_config(conf) is False
+        assert "dengjen_neural_voices" not in conf["speech"]

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -140,6 +140,27 @@ class TestWarnIfOldAddonInstalled:
         assert len(shown) == 1
         assert "Sonata" in shown[0][0][0]
 
+    def test_shows_the_warning_via_wx_CallAfter_not_directly(self, monkeypatch):
+        # gui.messageBox must be deferred through wx.CallAfter rather than
+        # called directly, or it would stack a modal dialog on top of NVDA's
+        # add-on installation dialog.
+        call_after_calls = []
+        monkeypatch.setattr(
+            install_tasks.wx,
+            "CallAfter",
+            lambda func, *a, **kw: call_after_calls.append((func, a, kw)),
+        )
+        message_box_calls = []
+        monkeypatch.setattr(
+            install_tasks.gui,
+            "messageBox",
+            lambda *a, **kw: message_box_calls.append((a, kw)),
+        )
+        install_tasks.warn_if_old_addon_installed([_FakeAddon("sonata_neural_voices")])
+        assert len(call_after_calls) == 1
+        assert call_after_calls[0][0] is install_tasks.gui.messageBox
+        assert message_box_calls == []
+
     def test_stays_quiet_when_it_is_absent(self, monkeypatch):
         shown = []
         monkeypatch.setattr(
@@ -147,3 +168,35 @@ class TestWarnIfOldAddonInstalled:
         )
         install_tasks.warn_if_old_addon_installed([])
         assert shown == []
+
+
+class TestOnInstall:
+    def test_runs_every_step_in_order(self, monkeypatch):
+        ran = []
+        monkeypatch.setattr(
+            install_tasks, "warn_if_old_addon_installed", lambda: ran.append("warn")
+        )
+        monkeypatch.setattr(
+            install_tasks, "migrate_voices_directory", lambda: ran.append("voices")
+        )
+        monkeypatch.setattr(
+            install_tasks, "migrate_speech_config", lambda: ran.append("config")
+        )
+        install_tasks.onInstall()
+        assert ran == ["warn", "voices", "config"]
+
+    def test_a_failing_step_does_not_abort_the_install(self, monkeypatch):
+        ran = []
+
+        def _boom():
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(install_tasks, "warn_if_old_addon_installed", _boom)
+        monkeypatch.setattr(
+            install_tasks, "migrate_voices_directory", lambda: ran.append("voices")
+        )
+        monkeypatch.setattr(
+            install_tasks, "migrate_speech_config", lambda: ran.append("config")
+        )
+        install_tasks.onInstall()
+        assert ran == ["voices", "config"]

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -42,6 +42,11 @@ class TestMigrateVoicesDirectory:
 class _FakeSection(dict):
     """Stands in for NVDA's ConfigObj section, which has isSet()."""
 
+    def __missing__(self, key):
+        val = _FakeSection()
+        self[key] = val
+        return val
+
     def isSet(self, key):
         return key in self
 
@@ -97,3 +102,48 @@ class TestMigrateSpeechConfig:
         conf = _speech_conf()
         assert install_tasks.migrate_speech_config(conf) is False
         assert "dengjen_neural_voices" not in conf["speech"]
+
+
+class _FakeAddon:
+    def __init__(self, name, pending_remove=False):
+        self.name = name
+        self.isPendingRemove = pending_remove
+
+
+class TestIsOldAddonInstalled:
+    def test_detects_the_old_addon(self):
+        assert install_tasks.is_old_addon_installed(
+            [_FakeAddon("sonata_neural_voices")]
+        ) is True
+
+    def test_ignores_the_new_addon(self):
+        assert install_tasks.is_old_addon_installed(
+            [_FakeAddon("dengjen_neural_voices")]
+        ) is False
+
+    def test_ignores_an_addon_already_pending_removal(self):
+        assert install_tasks.is_old_addon_installed(
+            [_FakeAddon("sonata_neural_voices", pending_remove=True)]
+        ) is False
+
+    def test_handles_an_empty_addon_list(self):
+        assert install_tasks.is_old_addon_installed([]) is False
+
+
+class TestWarnIfOldAddonInstalled:
+    def test_warns_when_the_old_addon_is_present(self, monkeypatch):
+        shown = []
+        monkeypatch.setattr(
+            install_tasks.gui, "messageBox", lambda *a, **kw: shown.append((a, kw))
+        )
+        install_tasks.warn_if_old_addon_installed([_FakeAddon("sonata_neural_voices")])
+        assert len(shown) == 1
+        assert "Sonata" in shown[0][0][0]
+
+    def test_stays_quiet_when_it_is_absent(self, monkeypatch):
+        shown = []
+        monkeypatch.setattr(
+            install_tasks.gui, "messageBox", lambda *a, **kw: shown.append((a, kw))
+        )
+        install_tasks.warn_if_old_addon_installed([])
+        assert shown == []


### PR DESCRIPTION
Follow-up to the rename. Makes upgrading from 3.2.x seamless apart from reselecting the synthesizer.

On install:
1. If the old Sonata add-on is still installed, warn — do not block. It will no longer find the voices.
2. Move `<configPath>/sonata` to `<configPath>/dengjen`. Same volume, so it's a rename, not a copy of however many GB of models.
3. Copy the `sonata_neural_voices` speech-settings section to `dengjen_neural_voices`, so rate, pitch, volume and per-language voice choices survive. The old section is left in place.

A step that throws is logged and the install continues — a half-migrated profile is recoverable, a failed install is not.

18 tests cover the decision logic, including the target-already-exists guard and the nested-section deep copy. Not verified: the real upgrade on NVDA — no Windows machine here, so this needs an end-user check on the built artifact before the store submission goes in.