### PR TITLE
fix: use the attested Kurmanji term for Add-on Store

### DIFF
--- a/addon/doc/kmr/readme.md
+++ b/addon/doc/kmr/readme.md
@@ -7,7 +7,7 @@
 > Dibe ku ev werger li paş [benioku ya îngilîzî](https://github.com/austek/dengjen-nvda/blob/main/readme.md) bimîne.
 >
 > Navê vê pêvekê di guhertoya v4.0.0 de, li gorî daxwaza nivîskarê resen,
-> wekî mercekî ji bo cih girtina di firotgeha pêvekên NVDA-yê de, ji Sonata
+> wekî mercekî ji bo cih girtina di Dikana Pêvekên NVDA-yê de, ji Sonata
 > Neural Voices hate guhertin. Heman pêvek e, heman lênêr e, heman lîsansa
 > GPL v2 ye.
 


### PR DESCRIPTION
## Summary

The v4.0.0 rename banner in the Kurmanji readme called the Add-on Store `firotgeha pêvekên NVDA-yê`. `firotgeh` is a coinage with no attestation in the Kurmanji localisation corpus. NVDA core's own kmr catalogue renders "Add-on Store" as `Dikana Pêvekan` seven times, against a single outlier (`Stora Pêveka NVDA-yê`). The banner refers to NVDA's own store, so NVDA's own term applies.

## Changes

- `addon/doc/kmr/readme.md:10` — `firotgeha pêvekên NVDA-yê` → `Dikana Pêvekên NVDA-yê`

## Test plan

- [x] Syntax check passes (Markdown only, no code touched).
- [ ] CI build + test green.

Two related items are deliberately **not** in this PR, both predating the rename:

- `lênêr` ("maintainer") is also unattested, but `lênêrîn` is already used twice in the pre-existing fork banner and once in the kmr changelog. Changing one instance would leave two renderings in one paragraph; changing all three is a translation decision.
- `addon/doc/kmr/readme.md:7` says `benioku`, which is Turkish, copy-pasted from the `tr` readme. The kmr corpus has no entry for "readme", so replacing it would mean coining a term.