### PR TITLE
refactor: extract the wx-free decisions from voice_manager

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -134,7 +134,9 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             self.voices_list.set_focused_item(0)
             return
         synth = synthDriverHandler.getSynth()
-        if logic.is_active_voice(synth.name, synth.voice, selected.key):
+        if logic.is_active_voice(
+            synth_name=synth.name, synth_voice=synth.voice, voice_key=selected.key
+        ):
             gui.messageBox(
                 # Translators: message in a message box
                 _("You cannot remove the currently active voice!"),
@@ -330,7 +332,7 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         self.download_std_btn.Enable(state.std_enabled)
         self.download_rt_btn.Enable(state.rt_enabled)
         self.speaker_choice.Enable(state.speaker_enabled)
-        if state.speakers:
+        if state.speaker_enabled:
             self.speaker_choice.SetItems(list(state.speakers))
             self.speaker_choice.SetSelection(0)
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -26,6 +26,7 @@ from . import aio
 from . import helpers
 from .components import AsyncSnakDialog, ColumnDefn, ImmutableObjectListView, SimpleDialog, make_sized_static_box
 from .sized_controls import SizedPanel
+from . import voice_manager_logic as logic
 
 
 with helpers.import_bundled_library():
@@ -97,7 +98,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         self.__already_populated.clear()
 
     def _get_installed_voice_name(self, voice):
-        return f"{voice.name} ({voice.variant})"
+        return logic.installed_voice_display_name(voice)
 
     def on_model_card(self, event):
         selected = self.voices_list.get_selected()
@@ -108,7 +109,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         if os.path.exists(model_card_file):
             with open(model_card_file, "r", encoding="utf-8") as file:
                 content = file.read()
-            content = content.replace("#", "").replace("*", "")
+            content = logic.sanitize_model_card(content)
             gui.messageBox(
                 content,
                 #! Intentionally untranslatable 
@@ -130,12 +131,8 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         if selected is None:
             self.voices_list.set_focused_item(0)
             return
-        voice_id = "-".join(selected.key.split("-")[:-1])
         synth = synthDriverHandler.getSynth()
-        if (
-            (synth.name == "dengjen_neural_voices")
-            and (synth.voice == voice_id)
-        ):
+        if logic.is_active_voice(synth.name, synth.voice, selected.key):
             gui.messageBox(
                 # Translators: message in a message box
                 _("You cannot remove the currently active voice!"),

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -408,16 +408,10 @@ class OnlineDengjenVoicesPanel(SizedPanel):
 
 
     def set_voices(self, voices):
-        self.lang_to_voices = {}
-        for voice in voices:
-            self.lang_to_voices.setdefault(voice.language, []).append(voice)
-        for vlist in self.lang_to_voices.values():
-            vlist.sort(key=operator.attrgetter("key"))
-        self.languages = sorted(
-            self.lang_to_voices.keys(),
-            key=operator.attrgetter("name_english")
+        self.languages, self.lang_to_voices = logic.group_voices_by_language(voices)
+        self.language_choice.SetItems(
+            [lang.description for lang in self.languages]
         )
-        self.language_choice.SetItems([lang.description for lang in self.languages])
         self.__already_populated.set()
 
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -79,11 +79,13 @@ class InstalledDengjenVoicesPanel(SizedPanel):
 
     def update_voices_list(self, set_focus=False, invalidate_synth_voices_cache=False):
         voices = list(DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir())
-        enable = bool(voices)
-        self.buttons_panel.Enable(enable)
+        state = logic.installed_list_state(
+            voices, synthDriverHandler.getSynth().name
+        )
+        self.buttons_panel.Enable(state.buttons_enabled)
         self.voices_list.set_objects(voices, set_focus=set_focus)
-        if "dengjen" in synthDriverHandler.getSynth().name.lower():
-            self.remove_voice_button.Enable(len(voices) >= 2)
+        if state.is_dengjen_synth:
+            self.remove_voice_button.Enable(state.remove_enabled)
             if invalidate_synth_voices_cache:
                 synth = synthDriverHandler.getSynth()
                 synth.terminate()
@@ -324,17 +326,13 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         selected_voice = self.voices_list.get_selected()
         if selected_voice is None:
             return
-        self.download_std_btn.Enable(not selected_voice.standard_variant_installed)
-        self.download_rt_btn.Enable(
-            selected_voice.has_rt_variant and not selected_voice.fast_variant_installed
-        )
-        if selected_voice.num_speakers > 1:
-            self.speaker_choice.Enable(True)
-            speakers = list(selected_voice.speaker_id_map.keys())
-            self.speaker_choice.SetItems(speakers)
+        state = logic.download_button_state(selected_voice)
+        self.download_std_btn.Enable(state.std_enabled)
+        self.download_rt_btn.Enable(state.rt_enabled)
+        self.speaker_choice.Enable(state.speaker_enabled)
+        if state.speakers:
+            self.speaker_choice.SetItems(list(state.speakers))
             self.speaker_choice.SetSelection(0)
-        else:
-            self.speaker_choice.Enable(False)
 
     def on_preview(self, event):
         # While a preview is playing, the same button acts as Stop. This keeps

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
@@ -1,0 +1,35 @@
+# coding: utf-8
+
+# Copyright (c) 2023 Musharraf Omer
+# This file is covered by the GNU General Public License.
+
+"""wx-free decisions behind the voice manager UI.
+
+Imports nothing from wx, gui, winsound, miniaudio or synthDriverHandler, so
+this module is importable and testable on any platform. voice_manager.py
+keeps the widgets and the side effects; the branches it takes live here.
+"""
+
+from __future__ import annotations
+
+import typing
+
+DENGJEN_SYNTH_NAME = "dengjen_neural_voices"
+
+
+def installed_voice_display_name(voice) -> str:
+    return f"{voice.name} ({voice.variant})"
+
+
+def sanitize_model_card(content: str) -> str:
+    return content.replace("#", "").replace("*", "")
+
+
+def voice_id_from_key(voice_key: str) -> str:
+    return "-".join(voice_key.split("-")[:-1])
+
+
+def is_active_voice(synth_name: str, synth_voice: str, voice_key: str) -> bool:
+    return synth_name == DENGJEN_SYNTH_NAME and synth_voice == voice_id_from_key(
+        voice_key
+    )

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
@@ -12,6 +12,7 @@ keeps the widgets and the side effects; the branches it takes live here.
 
 from __future__ import annotations
 
+import operator
 import typing
 
 DENGJEN_SYNTH_NAME = "dengjen_neural_voices"
@@ -33,3 +34,15 @@ def is_active_voice(synth_name: str, synth_voice: str, voice_key: str) -> bool:
     return synth_name == DENGJEN_SYNTH_NAME and synth_voice == voice_id_from_key(
         voice_key
     )
+
+
+def group_voices_by_language(voices) -> typing.Tuple[list, dict]:
+    lang_to_voices: dict = {}
+    for voice in voices:
+        lang_to_voices.setdefault(voice.language, []).append(voice)
+    for vlist in lang_to_voices.values():
+        vlist.sort(key=operator.attrgetter("key"))
+    languages = sorted(
+        lang_to_voices.keys(), key=operator.attrgetter("name_english")
+    )
+    return languages, lang_to_voices

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
@@ -12,6 +12,7 @@ keeps the widgets and the side effects; the branches it takes live here.
 
 from __future__ import annotations
 
+import dataclasses
 import operator
 import typing
 
@@ -46,3 +47,39 @@ def group_voices_by_language(voices) -> typing.Tuple[list, dict]:
         lang_to_voices.keys(), key=operator.attrgetter("name_english")
     )
     return languages, lang_to_voices
+
+
+@dataclasses.dataclass(frozen=True)
+class InstalledListState:
+    buttons_enabled: bool
+    remove_enabled: bool
+    is_dengjen_synth: bool
+
+
+def installed_list_state(voices, synth_name: str) -> InstalledListState:
+    # `remove_enabled` is deliberately not ANDed with `is_dengjen_synth`: the
+    # caller only touches the remove button when a dengjen synth is active,
+    # and leaves it alone otherwise.
+    return InstalledListState(
+        buttons_enabled=bool(voices),
+        remove_enabled=len(voices) >= 2,
+        is_dengjen_synth="dengjen" in synth_name.lower(),
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class DownloadButtonState:
+    std_enabled: bool
+    rt_enabled: bool
+    speaker_enabled: bool
+    speakers: tuple
+
+
+def download_button_state(voice) -> DownloadButtonState:
+    multi_speaker = voice.num_speakers > 1
+    return DownloadButtonState(
+        std_enabled=not voice.standard_variant_installed,
+        rt_enabled=voice.has_rt_variant and not voice.fast_variant_installed,
+        speaker_enabled=multi_speaker,
+        speakers=tuple(voice.speaker_id_map.keys()) if multi_speaker else (),
+    )

--- a/tests/test_voice_manager_logic.py
+++ b/tests/test_voice_manager_logic.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+"""
+Tests for voice_manager_logic.py: the wx-free decisions behind the voice
+manager UI, extracted from voice_manager.py so they can be driven on any
+platform (see issue #65). The widgets themselves stay untestable here --
+they subclass real wx types -- and are covered by tests_gui/ on Windows.
+"""
+
+import os
+
+import pytest
+
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
+
+import addonHandler
+import dengjen_neural_voices.tts_system as tts_system
+
+# In production this runs in the package __init__.py before anything using
+# `_(...)` is imported. We load the module directly, so it happens here.
+addonHandler.initTranslation()
+
+logic = load_module_from_path(
+    "dengjen_tts_global_plugin._voice_manager_logic_under_test",
+    os.path.join(GLOBAL_PLUGIN_PKG_DIR, "voice_manager_logic.py"),
+    package="dengjen_tts_global_plugin",
+)
+
+DengjenVoice = tts_system.DengjenVoice
+
+
+def _installed(key):
+    """A real DengjenVoice, as load_piper_voices_from_nvda_config_dir yields."""
+    return DengjenVoice.from_path(os.path.join(os.sep, "voices", key))
+
+
+class TestInstalledVoiceDisplayName:
+    def test_standard_voice_is_labelled_standard(self):
+        voice = _installed("en_US-amy-medium")
+        assert logic.installed_voice_display_name(voice) == "amy (standard)"
+
+    def test_rt_voice_is_labelled_fast(self):
+        voice = _installed("en_US-amy+RT-medium")
+        assert logic.installed_voice_display_name(voice) == "amy (fast)"
+
+
+class TestSanitizeModelCard:
+    def test_strips_markdown_heading_and_emphasis_markers(self):
+        assert logic.sanitize_model_card("# Title\n**bold**") == " Title\nbold"
+
+    def test_leaves_plain_text_untouched(self):
+        assert logic.sanitize_model_card("plain text") == "plain text"
+
+
+class TestVoiceIdFromKey:
+    def test_drops_the_quality_segment(self):
+        assert logic.voice_id_from_key("en_US-amy-medium") == "en_US-amy"
+
+    def test_keeps_the_rt_marker(self):
+        assert logic.voice_id_from_key("en_US-amy+RT-medium") == "en_US-amy+RT"
+
+    def test_underscored_language_survives(self):
+        # Guards the #63 class of bug: the separator between language and
+        # dialect is an underscore, the one between segments is a hyphen.
+        assert logic.voice_id_from_key("pt_BR-faber-medium") == "pt_BR-faber"
+
+
+class TestIsActiveVoice:
+    def test_true_when_synth_and_voice_both_match(self):
+        assert logic.is_active_voice(
+            "dengjen_neural_voices", "en_US-amy", "en_US-amy-medium"
+        )
+
+    def test_false_for_a_different_voice_on_the_same_synth(self):
+        assert not logic.is_active_voice(
+            "dengjen_neural_voices", "en_US-amy", "en_US-ryan-medium"
+        )
+
+    def test_false_when_another_synth_is_active(self):
+        assert not logic.is_active_voice(
+            "espeak", "en_US-amy", "en_US-amy-medium"
+        )
+
+    def test_quality_does_not_affect_the_match(self):
+        assert logic.is_active_voice(
+            "dengjen_neural_voices", "en_US-amy", "en_US-amy-high"
+        )

--- a/tests/test_voice_manager_logic.py
+++ b/tests/test_voice_manager_logic.py
@@ -8,8 +8,6 @@ they subclass real wx types -- and are covered by tests_gui/ on Windows.
 
 import os
 
-import pytest
-
 from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
 
 import addonHandler
@@ -249,8 +247,8 @@ class TestDownloadButtonState:
     def test_multi_speaker_voice_lists_its_speakers_in_map_order(self):
         voice = _online(
             "en_US-libritts-medium", "libritts", _language("en_US", "English"),
-            num_speakers=3, speaker_id_map={"p1": 0, "p2": 1, "p3": 2},
+            num_speakers=3, speaker_id_map={"p3": 0, "p1": 1, "p2": 2},
         )
         state = logic.download_button_state(voice)
         assert state.speaker_enabled is True
-        assert state.speakers == ("p1", "p2", "p3")
+        assert state.speakers == ("p3", "p1", "p2")

--- a/tests/test_voice_manager_logic.py
+++ b/tests/test_voice_manager_logic.py
@@ -25,12 +25,44 @@ logic = load_module_from_path(
     package="dengjen_tts_global_plugin",
 )
 
+voice_download = load_module_from_path(
+    "dengjen_tts_global_plugin._voice_download_for_logic_tests",
+    os.path.join(GLOBAL_PLUGIN_PKG_DIR, "voice_download.py"),
+    package="dengjen_tts_global_plugin",
+)
+
 DengjenVoice = tts_system.DengjenVoice
 
 
 def _installed(key):
     """A real DengjenVoice, as load_piper_voices_from_nvda_config_dir yields."""
     return DengjenVoice.from_path(os.path.join(os.sep, "voices", key))
+
+
+def _language(code, name_english, country_english="Country"):
+    return voice_download.PiperVoiceLanguage(
+        code=code,
+        family=code.split("_")[0],
+        region=code.split("_")[-1],
+        name_native=name_english,
+        name_english=name_english,
+        country_english=country_english,
+    )
+
+
+def _online(key, name, language, **kwargs):
+    return voice_download.PiperVoice(
+        key=key,
+        name=name,
+        quality=voice_download.PiperVoiceQualityLevel.Medium,
+        num_speakers=kwargs.pop("num_speakers", 1),
+        speaker_id_map=kwargs.pop("speaker_id_map", {}),
+        language=language,
+        files=[],
+        has_rt_variant=kwargs.pop("has_rt_variant", False),
+        standard_variant_installed=kwargs.pop("standard_variant_installed", False),
+        fast_variant_installed=kwargs.pop("fast_variant_installed", False),
+    )
 
 
 class TestInstalledVoiceDisplayName:
@@ -84,3 +116,47 @@ class TestIsActiveVoice:
         assert logic.is_active_voice(
             "dengjen_neural_voices", "en_US-amy", "en_US-amy-high"
         )
+
+
+class TestGroupVoicesByLanguage:
+    def test_groups_voices_under_their_language(self):
+        en = _language("en_US", "English")
+        de = _language("de_DE", "German")
+        voices = [
+            _online("en_US-amy-medium", "amy", en),
+            _online("de_DE-thorsten-medium", "thorsten", de),
+            _online("en_US-ryan-medium", "ryan", en),
+        ]
+        languages, lang_to_voices = logic.group_voices_by_language(voices)
+        assert set(languages) == {en, de}
+        assert len(lang_to_voices[en]) == 2
+        assert len(lang_to_voices[de]) == 1
+
+    def test_voices_within_a_language_are_sorted_by_key(self):
+        en = _language("en_US", "English")
+        voices = [
+            _online("en_US-ryan-medium", "ryan", en),
+            _online("en_US-amy-medium", "amy", en),
+        ]
+        _languages, lang_to_voices = logic.group_voices_by_language(voices)
+        assert [v.key for v in lang_to_voices[en]] == [
+            "en_US-amy-medium",
+            "en_US-ryan-medium",
+        ]
+
+    def test_languages_are_sorted_by_english_name_not_by_code(self):
+        # "de_DE" sorts before "en_US" by code, but "English" before "German"
+        # by name -- the list the user reads is ordered by name.
+        en = _language("en_US", "English")
+        de = _language("de_DE", "German")
+        voices = [
+            _online("de_DE-thorsten-medium", "thorsten", de),
+            _online("en_US-amy-medium", "amy", en),
+        ]
+        languages, _lang_to_voices = logic.group_voices_by_language(voices)
+        assert [lang.name_english for lang in languages] == ["English", "German"]
+
+    def test_empty_input_yields_empty_output(self):
+        languages, lang_to_voices = logic.group_voices_by_language([])
+        assert languages == []
+        assert lang_to_voices == {}

--- a/tests/test_voice_manager_logic.py
+++ b/tests/test_voice_manager_logic.py
@@ -160,3 +160,97 @@ class TestGroupVoicesByLanguage:
         languages, lang_to_voices = logic.group_voices_by_language([])
         assert languages == []
         assert lang_to_voices == {}
+
+
+class TestInstalledListState:
+    def test_buttons_disabled_when_no_voices_installed(self):
+        state = logic.installed_list_state([], "dengjen_neural_voices")
+        assert state.buttons_enabled is False
+
+    def test_buttons_enabled_when_a_voice_is_installed(self):
+        state = logic.installed_list_state(
+            [_installed("en_US-amy-medium")], "dengjen_neural_voices"
+        )
+        assert state.buttons_enabled is True
+
+    def test_remove_needs_at_least_two_voices(self):
+        one = logic.installed_list_state(
+            [_installed("en_US-amy-medium")], "dengjen_neural_voices"
+        )
+        two = logic.installed_list_state(
+            [_installed("en_US-amy-medium"), _installed("en_US-ryan-medium")],
+            "dengjen_neural_voices",
+        )
+        assert one.remove_enabled is False
+        assert two.remove_enabled is True
+
+    def test_dengjen_synth_matched_case_insensitively_by_substring(self):
+        # update_voices_list uses `"dengjen" in name.lower()`, deliberately
+        # looser than on_remove_voice's exact match. Both are preserved.
+        assert logic.installed_list_state([], "Dengjen_Neural_Voices").is_dengjen_synth
+        assert logic.installed_list_state([], "dengjen").is_dengjen_synth
+
+    def test_other_synths_are_not_dengjen(self):
+        assert not logic.installed_list_state([], "espeak").is_dengjen_synth
+
+    def test_remove_enabled_is_independent_of_the_active_synth(self):
+        # The caller only reads remove_enabled when is_dengjen_synth is true,
+        # so this flag must not be pre-ANDed with it.
+        state = logic.installed_list_state(
+            [_installed("en_US-amy-medium"), _installed("en_US-ryan-medium")],
+            "espeak",
+        )
+        assert state.remove_enabled is True
+        assert state.is_dengjen_synth is False
+
+
+class TestDownloadButtonState:
+    def test_standard_download_offered_when_not_installed(self):
+        voice = _online("en_US-amy-medium", "amy", _language("en_US", "English"))
+        assert logic.download_button_state(voice).std_enabled is True
+
+    def test_standard_download_withheld_when_already_installed(self):
+        voice = _online(
+            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            standard_variant_installed=True,
+        )
+        assert logic.download_button_state(voice).std_enabled is False
+
+    def test_fast_download_withheld_when_voice_has_no_rt_variant(self):
+        voice = _online(
+            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            has_rt_variant=False,
+        )
+        assert logic.download_button_state(voice).rt_enabled is False
+
+    def test_fast_download_offered_when_rt_exists_and_is_not_installed(self):
+        voice = _online(
+            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            has_rt_variant=True,
+        )
+        assert logic.download_button_state(voice).rt_enabled is True
+
+    def test_fast_download_withheld_when_rt_already_installed(self):
+        voice = _online(
+            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            has_rt_variant=True, fast_variant_installed=True,
+        )
+        assert logic.download_button_state(voice).rt_enabled is False
+
+    def test_single_speaker_voice_offers_no_speaker_choice(self):
+        voice = _online(
+            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            num_speakers=1, speaker_id_map={"amy": 0},
+        )
+        state = logic.download_button_state(voice)
+        assert state.speaker_enabled is False
+        assert state.speakers == ()
+
+    def test_multi_speaker_voice_lists_its_speakers_in_map_order(self):
+        voice = _online(
+            "en_US-libritts-medium", "libritts", _language("en_US", "English"),
+            num_speakers=3, speaker_id_map={"p1": 0, "p2": 1, "p3": 2},
+        )
+        state = logic.download_button_state(voice)
+        assert state.speaker_enabled is True
+        assert state.speakers == ("p1", "p2", "p3")


### PR DESCRIPTION
Refs #65

### Description of your changes

`voice_manager.py` subclasses real wx types, so the Linux CI leg could never import it — including pure logic like the voice-id derivation, which is the same shape as the #63 hyphen bug. This moves those decisions verbatim into `voice_manager_logic.py` (stdlib only, 100% covered) and pins them with 28 tests against real `DengjenVoice` / `PiperVoice` instances rather than mocks.

No behaviour change. Two things preserved deliberately rather than tidied: `remove_enabled` is *not* ANDed with the dengjen-synth check (the caller guards it, so ANDing would change behaviour for other synths), and the two different "is this a dengjen synth?" spellings stay distinct.

`installed_voice_display_name` and `sanitize_model_card` are thin, but they buy coverage of two user-visible strings.

The wx shells stay untested; a Windows-only smoke layer follows separately.

### JIRA reference

n/a — tracked in [#65](https://github.com/austek/dengjen-nvda/issues/65).

### Impact Analysis

Touches the voice manager, the add-on's most user-visible dialog. Extraction is a verbatim move; no test in this repo imports `voice_manager.py`, so faithfulness was verified by reading each call site against its original. Manual check worth doing: open the voice manager, confirm both tabs populate and the remove/download buttons enable as before.

#### Checklist

- [x] I have performed a self-review of my code
- [x] My changes follow the contribution guidelines
- [x] My changes generate no new warnings
