### PR TITLE
chore: keep the Windows-only test trees out of the coverage metric

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,8 @@ source = .
 omit =
     .venv/*
     tests/*
+    tests_contract/*
+    tests_gui/*
     site_scons/*
     update_*.py
     addon/synthDrivers/dengjen_neural_voices/lib/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,25 +2,29 @@ sonar.projectKey=austek_dengjen-nvda
 sonar.organization=austek
 
 sonar.sources=addon/globalPlugins,addon/synthDrivers/dengjen_neural_voices,addon/installTasks.py,buildVars.py,.github/workflows
-sonar.tests=tests
+sonar.tests=tests,tests_contract,tests_gui
 
 # Vendored third-party (cffi, pycparser, psutil, miniaudio, mureq, and wxPython's
 # sized_controls), generated gRPC stubs, and the shipped engine binaries.
 sonar.exclusions=addon/synthDrivers/dengjen_neural_voices/lib/**,addon/synthDrivers/dengjen_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/dengjen_neural_voices/bin/**,addon/globalPlugins/dengjen_tts_global_plugin/sized_controls.py
 
-# Not exercised by CI, so Sonar's Zero Coverage Sensor would otherwise report
-# these at 0% and drag every new-code coverage measurement down. They stay in
-# sonar.sources: they are still analysed for issues, they are only removed from
-# the coverage metric.
+# Absent from coverage.xml, so Sonar's Zero Coverage Sensor would otherwise
+# report these at 0% and drag every new-code measurement down. They stay in
+# sonar.sources: still analysed for issues, only removed from the coverage
+# metric.
 #   __init__.py / voice_manager.py / components.py (globalPlugins)
-#                     subclass real wx widgets (wx.ListCtrl, the vendored
-#                     sized_controls.SizedDialog); a MagicMock `wx` can't
-#                     stand in for those as a base class (see #65).
-#   grpc_client/**    needs the bundled grpc extension and sonata-grpc.exe
-# synthDrivers/dengjen_neural_voices/__init__.py (the SynthDriver itself) is
-# covered by tests/test_synth_driver.py as of #65 and no longer needs excluding.
-# globalPlugins/dengjen_tts_global_plugin/voice_download.py is covered by
-# tests/test_voice_download.py as of #65 and no longer needs excluding.
+#                     subclass real wx types (wx.ListCtrl, the vendored
+#                     sized_controls.SizedDialog), which a module stub cannot
+#                     stand in for as a base class. Covered by tests_gui/ on
+#                     the Windows leg, which runs as a pass/fail gate and
+#                     reports no coverage. Their wx-free decisions were
+#                     extracted to voice_manager_logic.py, which IS measured.
+#   grpc_client/**    needs the bundled grpc extension and sonata-grpc.exe.
+#                     Covered by tests_contract/ since #77 -- same story: a
+#                     Windows-only gate that reports no coverage.
+# Merging the Windows legs' coverage into coverage.xml would let both come off
+# this list. That needs an artifact hand-off between jobs and must keep paths
+# repo-root-relative for Sonar (see .coveragerc). Tracked separately.
 sonar.coverage.exclusions=addon/globalPlugins/dengjen_tts_global_plugin/__init__.py,addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py,addon/globalPlugins/dengjen_tts_global_plugin/components.py,addon/synthDrivers/dengjen_neural_voices/grpc_client/**
 
 # S8544 wants pip installs to resolve against a lock file. Our direct CI tooling


### PR DESCRIPTION
Closes #65

Stacked on #86 — base will retarget to `main` once that merges.

### Description of your changes

`tests_contract/` is never imported on the Linux leg, so it reported at 0% and
dragged the coverage total down; `tests_gui/` was doing the same as of #86. Both
are pass/fail gates that report no coverage by design, so both are now omitted.
Linux TOTAL goes 62% → 85% purely by dropping 8 never-imported test files —
verified per-module that no add-on file’s percentage moved.

Registers both trees with `sonar.tests` — neither was visible to Sonar — and
rewrites the `sonar.coverage.exclusions` comment, which still described the
SynthDriver import-time problem #65 disproved and predated `tests_contract/`
existing.

Remaining coverage-metric work (merging the Windows legs into `coverage.xml`,
which would let all four exclusions go) is split out to #89.

### JIRA reference

n/a — tracked in #65.

### Impact Analysis

Configuration only; no code changes. Reported coverage rises because two
never-imported test trees stop being counted, not because anything new is
covered. Registering the two trees with `sonar.tests` means Sonar now analyses
them for test-specific rules, so new findings there are possible.

#### Checklist

- [x] I have performed a self-review of my code
- [x] My changes follow the contribution guidelines
- [x] My changes generate no new warnings