### PR TITLE
fix: define the DoneCallback alias AsyncSnakDialog annotates with

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import dataclasses
 import contextlib
 import typing
+from concurrent.futures import Future
 
 import wx
 import wx.lib.mixins.listctrl as listmix
@@ -18,6 +19,7 @@ import gui
 
 
 ObjectCollection = typing.Iterable[typing.Any]
+DoneCallback = typing.Callable[[Future], None]
 
 
 def make_sized_static_box(parent, title):

--- a/tests_gui/test_components_contracts.py
+++ b/tests_gui/test_components_contracts.py
@@ -1,0 +1,88 @@
+# coding: utf-8
+"""
+Contract tests for components.py that are not about a specific widget:
+AsyncSnakDialog's done-callback protocol, and a sweep proving every
+annotation in the module names something that actually exists.
+
+The sweep is the general net for a bug class this module has hit twice --
+#86 (`t.Union`) and #88 (`DoneCallback`) were both names that did not exist,
+kept invisible by `from __future__ import annotations`.
+"""
+
+import inspect
+import sys
+import typing
+from concurrent.futures import Future
+
+import pytest
+
+if sys.platform != "win32":
+    # A skipif marker is not enough: pytest imports the module during
+    # collection, and `import wx` fails outright without a Windows wheel.
+    pytest.skip("real wxPython is Windows-only here", allow_module_level=True)
+
+
+@pytest.fixture
+def components(gui_plugin_package):
+    from dengjen_tts_global_plugin import components
+
+    return components
+
+
+def _as_function(obj):
+    if isinstance(obj, property):
+        obj = obj.fget
+    elif isinstance(obj, (staticmethod, classmethod)):
+        obj = obj.__func__
+    if inspect.isfunction(obj):
+        yield obj
+
+
+def _annotatable(module):
+    """Everything defined in `module` that can carry an annotation: its own
+    classes (where the class body itself annotates something), their methods
+    and property getters, and its module-level functions."""
+    for obj in vars(module).values():
+        if getattr(obj, "__module__", None) != module.__name__:
+            continue
+        if inspect.isclass(obj):
+            if "__annotations__" in vars(obj):
+                yield obj
+            for member in vars(obj).values():
+                yield from _as_function(member)
+        else:
+            yield from _as_function(obj)
+
+
+def test_every_annotation_in_components_resolves(components):
+    swept = list(_annotatable(components))
+    # positive control: an empty or mis-filtered sweep would pass vacuously.
+    assert {"ColumnDefn", "AsyncSnakDialog.__init__"} <= {o.__qualname__ for o in swept}
+
+    unresolvable = {}
+    for obj in swept:
+        try:
+            typing.get_type_hints(obj)
+        except NameError as exc:
+            unresolvable[obj.__qualname__] = str(exc)
+    assert not unresolvable
+
+
+class TestAsyncSnakDialog:
+    def test_done_callback_receives_the_completed_future(self, components):
+        # __init__ needs a real dialog and a live executor; the callback path
+        # needs neither. snak_dg=None makes the real dismiss() a no-op, so
+        # nothing here is stubbed -- on_future_completed and dismiss both run.
+        dialog = components.AsyncSnakDialog.__new__(components.AsyncSnakDialog)
+        dialog.snak_dg = None
+        received = []
+        dialog.done_callback = received.append
+
+        future = Future()
+        future.set_result("voices")
+        dialog.on_future_completed(future)
+
+        # This is what DoneCallback annotates: the Future itself, not its
+        # result. voice_manager's callback calls .result() on what it gets.
+        assert received == [future]
+        assert received[0].result() == "voices"


### PR DESCRIPTION
### Description of your changes

Closes #88

`AsyncSnakDialog.__init__` annotated `done_callback` as `DoneCallback` — a name defined nowhere in the add-on. `from __future__ import annotations` kept it a string, so it only surfaced as a `NameError` once something resolved the signature.

Defined rather than dropped, because the parameter has a real contract: `on_future_completed` passes the completed `Future` straight through, and the sole caller (`voice_manager._voice_list_retrieved_callback`) calls `.result()` on what it gets. So `DoneCallback = typing.Callable[[Future], None]` — the Future, not the result.

New `tests_gui/test_components_contracts.py` adds a sweep that resolves *every* annotation in `components.py` (classes, methods, property getters, functions). That is the general net for a bug class this module has now hit twice — #86 (`t.Union`) and this one.

### JIRA reference

n/a — tracked as #88.

### Impact Analysis

Annotation-only for production code, plus one stdlib import; no runtime behaviour changes. The sweep is verified *sensitive*, not just green: run against a module of the same shape with the alias missing, it reports `name 'DoneCallback' is not defined`, and it carries a positive control so a mis-filtered sweep cannot pass vacuously.

New tests are in a separate file rather than `test_list_view.py` to avoid conflicting with #92, which is still open on that file. Both are Windows-only; a Linux `pytest` is unchanged at 276 passed.

#### Checklist

- [x] I have performed a self-review of my code
- [x] My changes follow the contribution guidelines
- [x] My changes generate no new warnings