### PR TITLE
fix: make AsyncSnakDialog.future hold the submitted Future

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -155,9 +155,8 @@ class AsyncSnakDialog:
     ):
         self.snak_dg = SnakDialog(*sdg_args, **sdg_kwargs)
         self.done_callback = done_callback
-        self.future = executor.submit(func).add_done_callback(
-            self.on_future_completed
-        )
+        self.future = executor.submit(func)
+        self.future.add_done_callback(self.on_future_completed)
         self.snak_dg.CenterOnScreen()
         gui.runScriptModalDialog(self.snak_dg)
 

--- a/tests_gui/test_components_contracts.py
+++ b/tests_gui/test_components_contracts.py
@@ -29,6 +29,19 @@ def components(gui_plugin_package):
     return components
 
 
+class _PendingExecutor:
+    """Hands back a Future that is still pending, like a real thread pool
+    would. An already-settled one fires the done-callback -- and so destroys
+    the dialog -- partway through AsyncSnakDialog.__init__, which then trips
+    over its own CenterOnScreen call."""
+
+    def __init__(self):
+        self.future = Future()
+
+    def submit(self, func, *args, **kwargs):
+        return self.future
+
+
 def _as_function(obj):
     if isinstance(obj, property):
         obj = obj.fget
@@ -86,3 +99,26 @@ class TestAsyncSnakDialog:
         # result. voice_manager's callback calls .result() on what it gets.
         assert received == [future]
         assert received[0].result() == "voices"
+
+    def test_future_is_the_submitted_future_and_stays_wired(
+        self, components, nvda_gui
+    ):
+        executor = _PendingExecutor()
+        received = []
+        dialog = components.AsyncSnakDialog(
+            executor=executor,
+            func=lambda: "voices",
+            done_callback=received.append,
+            parent=nvda_gui,
+            message="Retrieving voices list. Please wait...",
+        )
+
+        # add_done_callback returns None, so assigning its result left this
+        # attribute permanently None (#94).
+        assert dialog.future is executor.future
+        assert not received
+
+        # Splitting that call must not cost the callback: settling the future
+        # still has to reach done_callback through the real constructor.
+        executor.future.set_result("voices")
+        assert received == [executor.future]


### PR DESCRIPTION
### Description of your changes

Closes #94

`self.future = executor.submit(func).add_done_callback(...)` stored what `add_done_callback` returns — always `None` — so the attribute never held the Future its name promised.

Split the call rather than dropping the attribute: the name is worth making true, since a caller holding an `AsyncSnakDialog` reasonably wants to ask whether the work is still running.

### JIRA reference

n/a — tracked as #94.

### Impact Analysis

Nothing read `self.future`, in the add-on or the tests, so no behaviour changes — it goes from permanently `None` to the real Future.

The actual risk is losing the done-callback while moving the call, so the new test drives the **real constructor** and then settles the future, asserting it still reaches `done_callback`. It submits a *pending* Future deliberately: an already-settled one runs the done-callback — and so destroys the dialog — partway through `__init__`, which then trips over its own `CenterOnScreen` call. That ordering is worth pinning down, since it is the one way this class can break under a fast executor.

Windows-only test; a Linux `pytest` is unchanged at 276 passed.

#### Checklist

- [x] I have performed a self-review of my code
- [x] My changes follow the contribution guidelines
- [x] My changes generate no new warnings