### PR TITLE
chore: merge the Windows legs' coverage into coverage.xml

### DIFF
--- a/.github/workflows/sonar-fork-coverage.yml
+++ b/.github/workflows/sonar-fork-coverage.yml
@@ -27,9 +27,61 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Mirrors sonar.yml's job of the same name: tests_contract/ and tests_gui/ are
+  # Windows-only, so without this the modules only they reach would land in the
+  # fork's report at 0% (#89). Runs the fork's own tests with no secrets, exactly
+  # as build_addon.yml's windows-latest leg already does for every fork PR.
+  windows_coverage:
+    name: Windows coverage for fork scan
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade --only-binary :all: -r requirements-bootstrap.txt
+          pip install --only-binary :all: -r requirements-test.txt
+          pip install --only-binary :all: -r requirements-test-gui.txt
+
+      # Each tree needs its own COVERAGE_FILE: a bare `pytest --cov` erases
+      # whatever data files it finds first.
+      - name: Run tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.tests
+        run: pytest --cov
+
+      - name: Run gRPC contract tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.contract
+        run: pytest tests_contract/ --cov -v
+
+      - name: Run GUI smoke tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.gui
+        run: pytest tests_gui/ --cov -v
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: sonar-fork-windows-coverage
+          path: .coverage.windows.*
+          include-hidden-files: true # coverage data files start with a dot
+          retention-days: 7
+
   coverage:
     name: Build coverage for fork scan
     runs-on: ubuntu-latest
+    needs: ["windows_coverage"]
     permissions:
       contents: read
     # Same-repo PRs are scanned directly by sonar.yml; only forks need this.
@@ -57,7 +109,21 @@ jobs:
           pip install --only-binary :all: -r requirements-test.txt
 
       - name: Run tests with coverage
-        run: pytest --cov --cov-report=xml
+        run: pytest --cov
+
+      # After the run above, never before: `pytest --cov` deletes any
+      # .coverage.* data files already sitting in the workspace.
+      - name: Download the Windows legs' coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: sonar-fork-windows-coverage
+
+      # relative_files in .coveragerc is what makes this work across OSes:
+      # combine remaps the Windows data's `addon\...` paths onto `addon/...`.
+      - name: Merge into one coverage report
+        run: |
+          python -m coverage combine --append
+          python -m coverage xml
 
       - name: Archive workspace for the manual scan workflow
         run: tar -czf "$RUNNER_TEMP/workspace.tar.gz" -C "$GITHUB_WORKSPACE" .

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,9 +14,64 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # tests_contract/ (real sonata-grpc.exe) and tests_gui/ (real wxPython) only
+  # run on Windows, so the modules they exercise are invisible to the ubuntu
+  # coverage run below. This job measures them and hands the raw data over as
+  # an artifact for the scan job to combine (#89).
+  windows_coverage:
+    name: Windows coverage
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    # Matches the scan job's guard: nothing consumes this artifact on fork PRs.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade --only-binary :all: -r requirements-bootstrap.txt
+          pip install --only-binary :all: -r requirements-test.txt
+          pip install --only-binary :all: -r requirements-test-gui.txt
+
+      # Three invocations for the reasons build_addon.yml spells out: each tree
+      # needs a different set of real-vs-stubbed modules, so they cannot share a
+      # process. Each writes its own COVERAGE_FILE because a bare `pytest --cov`
+      # erases whatever data files it finds first.
+      - name: Run tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.tests
+        run: pytest --cov
+
+      - name: Run gRPC contract tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.contract
+        run: pytest tests_contract/ --cov -v
+
+      - name: Run GUI smoke tests with coverage
+        env:
+          COVERAGE_FILE: .coverage.windows.gui
+        run: pytest tests_gui/ --cov -v
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: windows-coverage-data
+          path: .coverage.windows.*
+          include-hidden-files: true # coverage data files start with a dot
+          retention-days: 1
+
   sonar:
     name: Sonar
     runs-on: ubuntu-latest
+    needs: ["windows_coverage"]
     permissions:
       contents: read
     # Fork PRs are never given repository secrets, so SONAR_TOKEN would be empty
@@ -42,7 +97,22 @@ jobs:
           pip install --only-binary :all: -r requirements-test.txt
 
       - name: Run tests with coverage
-        run: pytest --cov --cov-report=xml
+        run: pytest --cov
+
+      # After the run above, never before: `pytest --cov` deletes any
+      # .coverage.* data files already sitting in the workspace.
+      - name: Download the Windows legs' coverage
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: windows-coverage-data
+
+      # relative_files in .coveragerc is what makes this work across OSes:
+      # combine remaps the Windows data's `addon\...` paths onto `addon/...`.
+      # Fails loudly with "No data to combine" if the artifact never arrived.
+      - name: Merge into one coverage report
+        run: |
+          python -m coverage combine --append
+          python -m coverage xml
 
       - name: SonarQube scan
         if: env.SONAR_TOKEN != ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Each of these cost a CI round or a review finding to nail down — read before w
 - **`gui.messageBox` returns `wx.YES` / `wx.NO` / `wx.OK` / `wx.CANCEL`, not `wx.ID_*`.** The `wx.ID_*` constants come from `wx.MessageDialog.ShowModal()`, a different API. The add-on compares `retval == wx.YES`, so a mock returning `wx.ID_YES` looks right but silently skips every confirm-then-act branch.
 - **Never call `ShowModal()`.** With no running event loop it blocks until the CI job times out. Construct the dialog, assert against it, `Destroy()` it.
 
-Coverage note: `tests_contract/` and `tests_gui/` are pass/fail gates and contribute nothing to `coverage.xml`, so the modules only they reach stay in `sonar.coverage.exclusions` in `sonar-project.properties`.
+Coverage note: all three trees feed one `coverage.xml`. `sonar.yml` runs a `windows_coverage` job that measures `tests/`, `tests_contract/` and `tests_gui/` — each into its own `COVERAGE_FILE`, because a bare `pytest --cov` erases the data files it finds — and the scan job `coverage combine`s them with its own ubuntu run. `relative_files` in `.coveragerc` is what lets that work across OSes: combine remaps the Windows data's `addon\...` paths onto `addon/...`. Only `grpc_client/**` stays in `sonar.coverage.exclusions`, because no tree executes it (`tests_contract/` talks to the generated stubs directly).
 
 ## Refreshing the bundled binaries
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,23 +9,18 @@ sonar.tests=tests,tests_contract,tests_gui
 sonar.exclusions=addon/synthDrivers/dengjen_neural_voices/lib/**,addon/synthDrivers/dengjen_neural_voices/grpc_client/grpc_protos/**,addon/synthDrivers/dengjen_neural_voices/bin/**,addon/globalPlugins/dengjen_tts_global_plugin/sized_controls.py
 
 # Absent from coverage.xml, so Sonar's Zero Coverage Sensor would otherwise
-# report these at 0% and drag every new-code measurement down. They stay in
+# report it at 0% and drag every new-code measurement down. It stays in
 # sonar.sources: still analysed for issues, only removed from the coverage
 # metric.
-#   __init__.py / voice_manager.py / components.py (globalPlugins)
-#                     subclass real wx types (wx.ListCtrl, the vendored
-#                     sized_controls.SizedDialog), which a module stub cannot
-#                     stand in for as a base class. Covered by tests_gui/ on
-#                     the Windows leg, which runs as a pass/fail gate and
-#                     reports no coverage. Their wx-free decisions were
-#                     extracted to voice_manager_logic.py, which IS measured.
-#   grpc_client/**    needs the bundled grpc extension and sonata-grpc.exe.
-#                     Covered by tests_contract/ since #77 -- same story: a
-#                     Windows-only gate that reports no coverage.
-# Merging the Windows legs' coverage into coverage.xml would let both come off
-# this list. That needs an artifact hand-off between jobs and must keep paths
-# repo-root-relative for Sonar (see .coveragerc). Tracked separately.
-sonar.coverage.exclusions=addon/globalPlugins/dengjen_tts_global_plugin/__init__.py,addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py,addon/globalPlugins/dengjen_tts_global_plugin/components.py,addon/synthDrivers/dengjen_neural_voices/grpc_client/**
+#
+# grpc_client/__init__.py is reached by no test tree. tests_contract/ runs the
+# real sonata-grpc.exe but deliberately talks to the generated grpc_protos stubs
+# directly, bypassing this module, because it pulls in globalVars, logHandler and
+# NVDA's subprocess lifecycle (see tests_contract/conftest.py). tests/ replaces
+# it with a MagicMock. So merging the Windows legs' coverage in (#89) does not
+# cover it -- that took __init__.py, voice_manager.py and components.py off this
+# list, but not this one.
+sonar.coverage.exclusions=addon/synthDrivers/dengjen_neural_voices/grpc_client/**
 
 # S8544 wants pip installs to resolve against a lock file. Our direct CI tooling
 # is already ==-pinned in requirements-bootstrap/-build/-test.txt; going further


### PR DESCRIPTION
Closes #89

`tests_contract/` (real `sonata-grpc.exe`) and `tests_gui/` (real wxPython) only run on `windows-latest`, so everything they exercise was invisible to Sonar and sat in `sonar.coverage.exclusions`.

Both Sonar workflows gain a `windows_coverage` job that runs all three trees with `--cov` and uploads the raw data files; the ubuntu job `coverage combine`s them with its own run before emitting `coverage.xml`. `__init__.py`, `voice_manager.py` and `components.py` come off the exclusion list.

Three silent-failure traps, each commented in place: every Windows invocation needs its own `COVERAGE_FILE` (a bare `pytest --cov` erases the data files it finds, which is also why the artifact downloads *after* the ubuntu run); `relative_files` in `.coveragerc` is what remaps the Windows data's `addon\...` paths; `upload-artifact` needs `include-hidden-files` for dotfiles.

`grpc_client/**` stays excluded — contrary to the issue, `tests_contract/` deliberately bypasses it and drives the generated stubs directly.