### PR TITLE
fix: stop the immutable list view offering in-place label edits

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -36,11 +36,9 @@ class DialogListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
         id,
         pos=wx.DefaultPosition,
         size=wx.DefaultSize,
-        style=wx.BORDER_SUNKEN
-        | wx.LC_SINGLE_SEL
-        | wx.LC_REPORT
-        | wx.LC_EDIT_LABELS
-        | wx.LC_VRULES,
+        # No LC_EDIT_LABELS: the only subclass is ImmutableObjectListView, and
+        # in-place label editing rewrites a row behind self._objects' back.
+        style=wx.BORDER_SUNKEN | wx.LC_SINGLE_SEL | wx.LC_REPORT | wx.LC_VRULES,
     ):
         wx.ListCtrl.__init__(self, parent, id, pos, size, style)
         listmix.ListCtrlAutoWidthMixin.__init__(self)
@@ -279,3 +277,7 @@ class ImmutableObjectListView(DialogListCtrl):
     def ClearAll(self):
         self.prevent_mutations()
         return super().ClearAll()
+
+    def EditLabel(self, item, *args, **kwargs):
+        self.prevent_mutations()
+        return super().EditLabel(item, *args, **kwargs)

--- a/tests_gui/test_list_view.py
+++ b/tests_gui/test_list_view.py
@@ -138,6 +138,16 @@ class TestImmutableObjectListView:
         with pytest.raises(RuntimeError, match="List is immutable"):
             list_view.DeleteAllItems()
 
+    def test_labels_cannot_be_edited_in_place(self, list_view):
+        # LC_EDIT_LABELS let a click on an already-selected row rewrite its text
+        # without going through any of the guarded row mutators, leaving the
+        # displayed name out of step with the object get_selected returns (#97).
+        assert not list_view.GetWindowStyleFlag() & wx.LC_EDIT_LABELS
+        list_view.set_objects([_Row("amy", "medium")])
+        with pytest.raises(RuntimeError, match="List is immutable"):
+            list_view.EditLabel(0)
+        assert list_view.GetItemText(0, 0) == "amy"
+
     def test_set_focused_item_past_the_end_is_a_no_op(self, list_view):
         list_view.set_objects([_Row("amy", "medium")], set_focus=False)
         assert list_view.GetFocusedItem() == wx.NOT_FOUND


### PR DESCRIPTION
Refs #97 (item 1 of four; the keyboard-test items follow separately)

`DialogListCtrl` asked for `wx.LC_EDIT_LABELS`, and its only subclass is `ImmutableObjectListView`, whose two instances in `voice_manager.py` both take that default. A click on an already-selected row therefore opened an edit box on a list whose own error message reads `List is immutable`.

The edit rewrites the text through the native control, so none of the row mutators #87 guards sees it — `GetItemText` then disagrees with the object `get_selected()` still returns for that row. For a screen reader user, an edit box opening on a read-only list is worse than cosmetic.

Drops the style and guards `EditLabel` alongside the other mutators, so putting the style back cannot silently reopen the path from add-on code. Nothing calls `EditLabel` today.

**Correction to #97:** the trigger is a click on a selected row, not F2 — neither `src/msw/listctrl.cpp` nor `src/generic/listctrl.cpp` handles `WXK_F2`. So this one was never keyboard-reachable. The genuine keyboard gaps in #97 are untouched here.