### PR TITLE
fix: make the Sonata voice migration repeatable and add a manual import

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -24,6 +24,7 @@ _TTS_MODULE_DIR = os.path.join(_ADDON_ROOT, "synthDrivers")
 sys.path.insert(0, _TTS_MODULE_DIR)
 from dengjen_neural_voices import helpers
 from dengjen_neural_voices import aio
+from dengjen_neural_voices import voice_migration
 from dengjen_neural_voices.tts_system import (
     DengjenTextToSpeechSystem,
     DENGJEN_VOICES_DIR,

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -21,6 +21,7 @@ import synthDriverHandler
 from logHandler import log
 
 from . import DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR
+from . import voice_migration
 from . import voice_download
 from . import aio
 from . import helpers
@@ -73,15 +74,30 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                 "The archive should have a (.tar.gz) file extension."
             )
         )
+        self.import_voices_button = CommandLinkButton(
+            self,
+            -1,
+            # Translators: the main label of the button for importing pre-rename voices
+            _("Import voices from Sonata"),
+            # Translators: the note for the button for importing pre-rename voices
+            _(
+                "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+                "The originals are left in place, so Sonata keeps working."
+            )
+        )
+        self.import_voices_button.Hide()
         self.Bind(wx.EVT_BUTTON, self.on_model_card, self.model_card_button)
         self.Bind(wx.EVT_BUTTON, self.on_remove_voice, self.remove_voice_button)
         self.Bind(wx.EVT_BUTTON, self._on_install_voice_from_tar, add_voice_button)
+        self.Bind(wx.EVT_BUTTON, self._on_import_voices, self.import_voices_button)
 
     def update_voices_list(self, set_focus=False, invalidate_synth_voices_cache=False):
         voices = list(DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir())
         state = logic.installed_list_state(
             voices, synthDriverHandler.getSynth().name
         )
+        self.import_voices_button.Show(bool(voice_migration.importable_voice_keys()))
+        self.Layout()
         self.buttons_panel.Enable(state.buttons_enabled)
         self.voices_list.set_objects(voices, set_focus=set_focus)
         if state.is_dengjen_synth:
@@ -176,6 +192,52 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                     style=wx.ICON_INFORMATION
                 )
                 self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
+
+    def _on_import_voices(self, event):
+        voice_keys = voice_migration.importable_voice_keys()
+        if not voice_keys:
+            self.update_voices_list()
+            return
+        retval = gui.messageBox(
+            # Translators: message in a message box; {voices} is a list of voice names
+            _(
+                "Copy the following voices from the Sonata Neural Voices add-on?\n"
+                "{voices}\n\n"
+                "The originals are left in place, so Sonata keeps working. This "
+                "needs as much free disk space as the voices take up."
+            ).format(voices="\n".join(voice_keys)),
+            # Translators: title of a message box
+            _("Import voices from Sonata?"),
+            style=wx.YES_NO | wx.ICON_QUESTION,
+        )
+        if retval != wx.YES:
+            return
+        try:
+            copied = voice_migration.copy_voices_from_old_dir()
+        except OSError as exc:
+            log.exception("Failed to import voices from the Sonata add-on")
+            gui.messageBox(
+                # Translators: message telling the user that importing voices has failed
+                _(
+                    "Failed to import voices.\n\n{detail}\n\n"
+                    "See NVDA's log for more details."
+                ).format(detail=str(exc) or type(exc).__name__),
+                # Translators: title of a message box
+                _("Import failed"),
+                style=wx.ICON_ERROR,
+                parent=gui.mainFrame,
+            )
+        else:
+            gui.messageBox(
+                # Translators: message telling the user which voices were imported
+                _("The following voices were imported:\n{voices}").format(
+                    voices="\n".join(copied)
+                ),
+                # Translators: title of a message box
+                _("Voices imported"),
+                style=wx.ICON_INFORMATION,
+            )
+        self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
 
     def _on_install_voice_from_tar(self, event):
         open_file_dialog = wx.FileDialog(

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -5,6 +5,7 @@
 
 
 import contextlib
+import importlib.util
 import os
 import shutil
 import sys
@@ -12,7 +13,6 @@ import tempfile
 
 import addonHandler
 import config
-import globalVars
 import gui
 import wx
 from logHandler import log
@@ -24,35 +24,25 @@ _DIR = os.path.abspath(os.path.dirname(__file__))
 _PIPER_SYNTH_DIR = os.path.join(_DIR, "synthDrivers", "dengjen_neural_voices")
 LIB_DIR = os.path.join(_PIPER_SYNTH_DIR, "lib")
 BIN_DIR = os.path.join(_PIPER_SYNTH_DIR, "bin")
+
+
+def _load_voice_migration():
+    """By file path, not import: the synth package pulls in grpc and the
+    bundled Windows libraries at import time, which install must not need."""
+    spec = importlib.util.spec_from_file_location(
+        "_dengjen_voice_migration",
+        os.path.join(_PIPER_SYNTH_DIR, "voice_migration.py"),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+voice_migration = _load_voice_migration()
 del _DIR, _PIPER_SYNTH_DIR
 
-OLD_ADDON_NAME = "sonata_neural_voices"
-OLD_VOICES_DIR_NAME = "sonata"
-VOICES_DIR_NAME = "dengjen"
+OLD_ADDON_NAME = voice_migration.OLD_ADDON_NAME
 CONFIG_SECTION = "dengjen_neural_voices"
-
-
-def migrate_voices_directory(config_path=None):
-    """Move downloaded voices from the pre-4.0.0 location. Same volume, so this
-    is a rename rather than a copy however many GB of models are present."""
-    if config_path is None:
-        config_path = globalVars.appArgs.configPath
-    old_dir = os.path.join(config_path, OLD_VOICES_DIR_NAME)
-    new_dir = os.path.join(config_path, VOICES_DIR_NAME)
-    if os.path.exists(new_dir):
-        log.info(f"Skipping voices migration: {new_dir} already exists")
-        return False
-    if not os.path.isdir(old_dir):
-        log.info(f"Skipping voices migration: {old_dir} not found")
-        return False
-    try:
-        os.rename(old_dir, new_dir)
-    except OSError:
-        log.exception(f"Could not migrate voices from {old_dir} to {new_dir}")
-        _warn_voices_migration_failed(old_dir)
-        return False
-    log.info(f"Migrated voices from {old_dir} to {new_dir}")
-    return True
 
 
 def _as_plain_dict(section):
@@ -75,14 +65,7 @@ def migrate_speech_config(conf=None):
     return True
 
 
-def is_old_addon_installed(addons=None):
-    if addons is None:
-        addons = addonHandler.getAvailableAddons()
-    return any(
-        getattr(addon, "name", None) == OLD_ADDON_NAME
-        and not getattr(addon, "isPendingRemove", False)
-        for addon in addons
-    )
+is_old_addon_installed = voice_migration.is_old_addon_installed
 
 
 def warn_if_old_addon_installed(addons=None):
@@ -92,38 +75,21 @@ def warn_if_old_addon_installed(addons=None):
         gui.messageBox,
         # Translators: shown after installing when the pre-rename add-on is still present
         _(
-            "The Sonata Neural Voices add-on is still installed. Dengjen Neural Voices "
-            "has taken over its downloaded voices, so Sonata can no longer find them. "
-            "Remove the Sonata Neural Voices add-on to avoid two synthesizers appearing "
-            "in your speech settings."
+            "The Sonata Neural Voices add-on is still installed, so your downloaded "
+            "voices have been left where they are and Sonata keeps working. To use "
+            "them with Dengjen Neural Voices, open the Dengjen voice manager and "
+            "choose \"Import voices from Sonata\". Removing the Sonata Neural Voices "
+            "add-on also avoids two synthesizers appearing in your speech settings."
         ),
         # Translators: title of the message shown when the pre-rename add-on is still present
         _("Old add-on still installed"),
-        wx.OK | wx.ICON_WARNING,
-    )
-
-
-def _warn_voices_migration_failed(old_dir):
-    wx.CallAfter(
-        gui.messageBox,
-        # Translators: shown after installing when downloaded voices could not be moved automatically; {old_dir} is a folder path
-        _(
-            "Dengjen Neural Voices could not move your downloaded voices from "
-            "{old_dir} because those files are still in use, most likely by the "
-            "Sonata Neural Voices add-on. Close NVDA completely, remove the Sonata "
-            "Neural Voices add-on, then move that folder into the Dengjen Neural "
-            "Voices configuration folder yourself."
-        ).format(old_dir=old_dir),
-        # Translators: title of the message shown when migrating downloaded voices fails
-        _("Could not move existing voices"),
-        wx.OK | wx.ICON_WARNING,
+        wx.OK | wx.ICON_INFORMATION,
     )
 
 
 def onInstall():
     for step in (
         warn_if_old_addon_installed,
-        migrate_voices_directory,
         migrate_speech_config,
     ):
         try:

--- a/addon/synthDrivers/dengjen_neural_voices/tts_system.py
+++ b/addon/synthDrivers/dengjen_neural_voices/tts_system.py
@@ -26,6 +26,7 @@ from .const import (
     DENGJEN_VOICES_DIR,
 )
 from .helpers import import_bundled_library, LIB_DIRECTORY
+from .voice_migration import migrate_voices_directory
 
 
 class VoiceNotFoundError(LookupError):
@@ -392,6 +393,7 @@ class DengjenTextToSpeechSystem:
 
     @classmethod
     def load_piper_voices_from_nvda_config_dir(cls):
+        migrate_voices_directory()
         Path(DENGJEN_VOICES_DIR).mkdir(parents=True, exist_ok=True)
         return sorted(
             cls.load_voices_from_directory(DENGJEN_VOICES_DIR),

--- a/addon/synthDrivers/dengjen_neural_voices/voice_migration.py
+++ b/addon/synthDrivers/dengjen_neural_voices/voice_migration.py
@@ -1,0 +1,146 @@
+# coding: utf-8
+
+# Copyright (c) 2023 Musharraf Omer
+# This file is covered by the GNU General Public License.
+
+"""Carrying downloaded voices across the 4.0.0 rename.
+
+Two paths, because moving the folder is only safe when nobody else wants it:
+
+  - Sonata is gone. The voices are ours; move them, retrying on every voice
+    enumeration until it works (issue #83 -- the one-shot attempt from
+    onInstall ran at the one moment the files were still open).
+  - Sonata is still installed. Moving would break a working add-on, so leave
+    the folder alone and let the voice manager copy from it on request.
+
+Deliberately imports nothing from this package: installTasks.py loads it by
+file path, which only works while it stays a leaf module.
+"""
+
+import os
+import shutil
+
+import addonHandler
+import globalVars
+from logHandler import log
+
+
+__all__ = [
+    "OLD_ADDON_NAME",
+    "copy_voices_from_old_dir",
+    "importable_voice_keys",
+    "is_old_addon_installed",
+    "migrate_voices_directory",
+    "old_voices_dir",
+]
+
+
+OLD_ADDON_NAME = "sonata_neural_voices"
+OLD_VOICES_DIR_NAME = "sonata"
+VOICES_DIR_NAME = "dengjen"
+_VOICES_SUBPATH = ("voices", "piper")
+
+
+def _config_path(config_path=None):
+    if config_path is None:
+        return globalVars.appArgs.configPath
+    return config_path
+
+
+def old_voices_dir(config_path=None):
+    return os.path.join(_config_path(config_path), OLD_VOICES_DIR_NAME)
+
+
+def _voices_subdir(base_dir):
+    return os.path.join(base_dir, *_VOICES_SUBPATH)
+
+
+def _holds_any_file(directory):
+    return any(files for _root, _dirs, files in os.walk(directory))
+
+
+def is_old_addon_installed(addons=None):
+    if addons is None:
+        addons = addonHandler.getAvailableAddons()
+    return any(
+        getattr(addon, "name", None) == OLD_ADDON_NAME
+        and not getattr(addon, "isPendingRemove", False)
+        for addon in addons
+    )
+
+
+def importable_voice_keys(config_path=None):
+    """Voices sitting in the pre-4.0.0 location that we do not already have."""
+    old_voices = _voices_subdir(old_voices_dir(config_path))
+    if not os.path.isdir(old_voices):
+        return []
+    new_voices = _voices_subdir(
+        os.path.join(_config_path(config_path), VOICES_DIR_NAME)
+    )
+    return sorted(
+        name
+        for name in os.listdir(old_voices)
+        if os.path.isdir(os.path.join(old_voices, name))
+        and not os.path.isdir(os.path.join(new_voices, name))
+    )
+
+
+def copy_voices_from_old_dir(config_path=None):
+    """Copy voices across, leaving the originals for the old add-on to use.
+
+    Raises OSError; the caller is a dialog that reports the failure.
+    """
+    old_voices = _voices_subdir(old_voices_dir(config_path))
+    new_voices = _voices_subdir(
+        os.path.join(_config_path(config_path), VOICES_DIR_NAME)
+    )
+    copied = []
+    for key in importable_voice_keys(config_path):
+        shutil.copytree(
+            os.path.join(old_voices, key), os.path.join(new_voices, key)
+        )
+        copied.append(key)
+    if copied:
+        log.info(f"Copied {len(copied)} voice(s) from {old_voices}")
+    return copied
+
+
+def _move_tree(src, dst):
+    os.makedirs(dst, exist_ok=True)
+    for name in os.listdir(src):
+        src_path = os.path.join(src, name)
+        dst_path = os.path.join(dst, name)
+        if os.path.isdir(src_path) and os.path.isdir(dst_path):
+            _move_tree(src_path, dst_path)
+        else:
+            os.rename(src_path, dst_path)
+    os.rmdir(src)
+
+
+def migrate_voices_directory(config_path=None, addons=None):
+    """Move downloaded voices from the pre-4.0.0 location.
+
+    Same volume, so this renames rather than copies however many GB of models
+    are present.
+    """
+    old_dir = old_voices_dir(config_path)
+    new_dir = os.path.join(_config_path(config_path), VOICES_DIR_NAME)
+    if not os.path.isdir(old_dir):
+        return False
+    if is_old_addon_installed(addons):
+        log.debug(
+            f"Skipping voices migration: {OLD_ADDON_NAME} is still installed"
+        )
+        return False
+    # Not os.path.exists: the synth driver creates an empty tree here on every
+    # load, so existence alone would refuse the migration for good.
+    if _holds_any_file(new_dir):
+        log.debug(f"Skipping voices migration: {new_dir} already holds voices")
+        return False
+    try:
+        _move_tree(old_dir, new_dir)
+    except OSError:
+        log.exception(f"Could not migrate voices from {old_dir} to {new_dir}")
+        return False
+    log.info(f"Migrated voices from {old_dir} to {new_dir}")
+    return True

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ The `Installed voices` list shows each installed voice with its variant, quality
 - `Voice model card...` displays the `MODEL_CARD` file shipped with the voice, which records where its training data came from and how it is licensed. Not every voice includes one.
 - `Remove voice...` deletes the selected voice after asking you to confirm. It stays disabled unless you have at least two voices installed, and it will not remove the voice that is currently in use.
 - `Install from local file` installs a voice from a `.tar.gz` or `.tgz` archive you already have.
+- `Import voices from Sonata` copies voices you downloaded with the older Sonata Neural Voices add-on. It only appears while that add-on's voices are still present and have not been imported yet. The originals are left in place, so Sonata keeps working.
 
 After installing from a local archive or removing a voice, the add-on reloads the synthesizer for you, so the change applies immediately. After a download the new voice shows up in the voice manager right away; if NVDA's own voice list has not picked it up, restart NVDA.
 

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -379,6 +379,7 @@ def install(*, stub_wx: bool = True) -> None:
 
     _load_real_module("dengjen_neural_voices.const", "const.py")
     _load_real_module("dengjen_neural_voices.helpers", "helpers.py")
+    _load_real_module("dengjen_neural_voices.voice_migration", "voice_migration.py")
     _load_real_module("dengjen_neural_voices.tts_system", "tts_system.py")
 
 
@@ -403,5 +404,6 @@ def install(*, stub_wx: bool = True) -> None:
         _gui_plugin_pkg.DengjenTextToSpeechSystem = sys.modules["dengjen_neural_voices.tts_system"].DengjenTextToSpeechSystem
         _gui_plugin_pkg.DENGJEN_VOICES_DIR = sys.modules["dengjen_neural_voices.tts_system"].DENGJEN_VOICES_DIR
         _gui_plugin_pkg.helpers = sys.modules["dengjen_neural_voices.helpers"]
+        _gui_plugin_pkg.voice_migration = sys.modules["dengjen_neural_voices.voice_migration"]
         _gui_plugin_pkg.aio = _aio
         sys.modules["dengjen_tts_global_plugin"] = _gui_plugin_pkg

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -29,74 +29,6 @@ def fresh_log(monkeypatch):
     return fake_log
 
 
-class TestMigrateVoicesDirectory:
-    def test_moves_the_old_directory_when_the_new_one_is_absent(self, tmp_path):
-        (tmp_path / "sonata" / "voices" / "piper").mkdir(parents=True)
-        assert install_tasks.migrate_voices_directory(str(tmp_path)) is True
-        assert (tmp_path / "dengjen" / "voices" / "piper").is_dir()
-        assert not (tmp_path / "sonata").exists()
-
-    def test_leaves_both_alone_when_the_new_directory_already_exists(self, tmp_path):
-        (tmp_path / "sonata" / "voices").mkdir(parents=True)
-        (tmp_path / "dengjen" / "voices").mkdir(parents=True)
-        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
-        assert (tmp_path / "sonata" / "voices").is_dir()
-
-    def test_is_a_noop_when_there_is_nothing_to_migrate(self, tmp_path):
-        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
-        assert not (tmp_path / "dengjen").exists()
-
-    def test_ignores_a_file_named_like_the_old_directory(self, tmp_path):
-        (tmp_path / "sonata").write_text("not a directory")
-        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
-        assert not (tmp_path / "dengjen").exists()
-
-    def test_logs_why_it_skipped_when_the_new_directory_already_exists(
-        self, tmp_path, fresh_log
-    ):
-        (tmp_path / "sonata" / "voices").mkdir(parents=True)
-        (tmp_path / "dengjen" / "voices").mkdir(parents=True)
-        install_tasks.migrate_voices_directory(str(tmp_path))
-        assert fresh_log.info.call_count == 1
-        assert str(tmp_path / "dengjen") in fresh_log.info.call_args[0][0]
-
-    def test_logs_why_it_skipped_when_there_is_nothing_to_migrate(
-        self, tmp_path, fresh_log
-    ):
-        install_tasks.migrate_voices_directory(str(tmp_path))
-        assert fresh_log.info.call_count == 1
-        assert str(tmp_path / "sonata") in fresh_log.info.call_args[0][0]
-
-    def test_warns_the_user_and_logs_when_the_move_raises(
-        self, tmp_path, fresh_log, monkeypatch
-    ):
-        (tmp_path / "sonata" / "voices").mkdir(parents=True)
-
-        def _boom(src, dst):
-            raise PermissionError("file in use")
-
-        monkeypatch.setattr(install_tasks.os, "rename", _boom)
-        shown = []
-        monkeypatch.setattr(
-            install_tasks.gui, "messageBox", lambda *a, **kw: shown.append((a, kw))
-        )
-        assert install_tasks.migrate_voices_directory(str(tmp_path)) is False
-        assert fresh_log.exception.call_count == 1
-        assert len(shown) == 1
-        message_text = shown[0][0][0]
-        assert str(tmp_path / "sonata") in message_text
-
-    def test_does_not_raise_when_the_move_fails(self, tmp_path, monkeypatch):
-        (tmp_path / "sonata" / "voices").mkdir(parents=True)
-
-        def _boom(src, dst):
-            raise PermissionError("file in use")
-
-        monkeypatch.setattr(install_tasks.os, "rename", _boom)
-        monkeypatch.setattr(install_tasks.gui, "messageBox", lambda *a, **kw: None)
-        install_tasks.migrate_voices_directory(str(tmp_path))
-
-
 class _FakeSection(dict):
     """Stands in for NVDA's ConfigObj section, which has isSet()."""
 
@@ -341,13 +273,10 @@ class TestOnInstall:
             install_tasks, "warn_if_old_addon_installed", lambda: ran.append("warn")
         )
         monkeypatch.setattr(
-            install_tasks, "migrate_voices_directory", lambda: ran.append("voices")
-        )
-        monkeypatch.setattr(
             install_tasks, "migrate_speech_config", lambda: ran.append("config")
         )
         install_tasks.onInstall()
-        assert ran == ["warn", "voices", "config"]
+        assert ran == ["warn", "config"]
 
     def test_a_failing_step_does_not_abort_the_install(self, monkeypatch):
         ran = []
@@ -357,17 +286,13 @@ class TestOnInstall:
 
         monkeypatch.setattr(install_tasks, "warn_if_old_addon_installed", _boom)
         monkeypatch.setattr(
-            install_tasks, "migrate_voices_directory", lambda: ran.append("voices")
-        )
-        monkeypatch.setattr(
             install_tasks, "migrate_speech_config", lambda: ran.append("config")
         )
         install_tasks.onInstall()
-        assert ran == ["voices", "config"]
+        assert ran == ["config"]
 
     def test_saves_config_when_the_speech_migration_succeeds(self, monkeypatch):
         monkeypatch.setattr(install_tasks, "warn_if_old_addon_installed", lambda: None)
-        monkeypatch.setattr(install_tasks, "migrate_voices_directory", lambda: False)
         monkeypatch.setattr(install_tasks, "migrate_speech_config", lambda: True)
         fake_conf = MagicMock()
         monkeypatch.setattr(install_tasks.config, "conf", fake_conf)
@@ -378,7 +303,6 @@ class TestOnInstall:
         self, monkeypatch
     ):
         monkeypatch.setattr(install_tasks, "warn_if_old_addon_installed", lambda: None)
-        monkeypatch.setattr(install_tasks, "migrate_voices_directory", lambda: False)
         monkeypatch.setattr(install_tasks, "migrate_speech_config", lambda: False)
         fake_conf = MagicMock()
         monkeypatch.setattr(install_tasks.config, "conf", fake_conf)
@@ -389,7 +313,6 @@ class TestOnInstall:
         self, monkeypatch, fresh_log
     ):
         monkeypatch.setattr(install_tasks, "warn_if_old_addon_installed", lambda: None)
-        monkeypatch.setattr(install_tasks, "migrate_voices_directory", lambda: False)
         monkeypatch.setattr(install_tasks, "migrate_speech_config", lambda: True)
         fake_conf = MagicMock()
         fake_conf.save.side_effect = OSError("disk full")

--- a/tests/test_voice_migration.py
+++ b/tests/test_voice_migration.py
@@ -1,0 +1,246 @@
+# coding: utf-8
+"""Tests for the 4.0.0 voices-directory migration
+(addon/synthDrivers/dengjen_neural_voices/voice_migration.py).
+
+The migration used to run once, from installTasks.onInstall. Issue #83 showed
+why that cannot work: at install time the old Sonata add-on still holds its
+.onnx files open, so the move fails, and the synth driver then creates an
+empty tree at the destination on its next load. An exists() guard reads that
+empty tree as "already migrated", so the voices were stranded for good and
+the reporter had to redownload them.
+
+It now runs before every voice enumeration instead, and skips only when the
+destination genuinely holds voices.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+import dengjen_neural_voices.tts_system as tts_system
+import dengjen_neural_voices.voice_migration as voice_migration
+
+
+@pytest.fixture
+def fresh_log(monkeypatch):
+    """A MagicMock scoped to a single test — logHandler.log is a session-wide
+    stub shared with every other test module."""
+    fake_log = MagicMock()
+    monkeypatch.setattr(voice_migration, "log", fake_log)
+    return fake_log
+
+
+def _write_voice(base_dir, key="en_US-amy-medium", payload=b"model"):
+    """Lay down a downloaded voice the way voice_download.py does."""
+    voice_dir = base_dir / "voices" / "piper" / key
+    voice_dir.mkdir(parents=True)
+    (voice_dir / f"{key}.onnx").write_bytes(payload)
+    (voice_dir / "config.json").write_text("{}", encoding="utf-8")
+    return voice_dir
+
+
+class TestMigrateVoicesDirectory:
+    def test_moves_the_old_directory_when_the_new_one_is_absent(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is True
+        migrated = tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        assert (migrated / "en_US-amy-medium.onnx").read_bytes() == b"model"
+        assert not (tmp_path / "sonata").exists()
+
+    def test_is_a_noop_when_there_is_nothing_to_migrate(self, tmp_path):
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+        assert not (tmp_path / "dengjen").exists()
+
+    def test_ignores_a_file_named_like_the_old_directory(self, tmp_path):
+        (tmp_path / "sonata").write_text("not a directory")
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+        assert not (tmp_path / "dengjen").exists()
+
+    def test_logs_and_does_not_raise_when_the_move_fails(
+        self, tmp_path, fresh_log, monkeypatch
+    ):
+        _write_voice(tmp_path / "sonata")
+
+        def _in_use(src, dst):
+            raise PermissionError("file in use")
+
+        monkeypatch.setattr(voice_migration.os, "rename", _in_use)
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+        assert fresh_log.exception.call_count == 1
+        assert str(tmp_path / "sonata") in fresh_log.exception.call_args[0][0]
+
+    def test_stays_quiet_when_there_is_nothing_to_do(self, tmp_path, fresh_log):
+        voice_migration.migrate_voices_directory(str(tmp_path))
+        assert fresh_log.info.call_count == 0
+
+
+class TestMigrateVoicesDirectoryRetry:
+    """Regression tests for issue #83."""
+
+    def test_migrates_when_the_new_tree_exists_but_holds_no_voices(self, tmp_path):
+        (tmp_path / "dengjen" / "voices" / "piper").mkdir(parents=True)
+        _write_voice(tmp_path / "sonata")
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is True
+        migrated = tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        assert (migrated / "en_US-amy-medium.onnx").read_bytes() == b"model"
+        assert not (tmp_path / "sonata").exists()
+
+    def test_leaves_voices_already_present_in_the_new_tree_untouched(self, tmp_path):
+        new_voice = _write_voice(tmp_path / "dengjen", payload=b"newer model")
+        _write_voice(tmp_path / "sonata")
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+        assert (
+            new_voice / "en_US-amy-medium.onnx"
+        ).read_bytes() == b"newer model"
+        assert (tmp_path / "sonata" / "voices" / "piper").is_dir()
+
+    def test_a_move_blocked_by_open_files_can_succeed_on_a_later_attempt(
+        self, tmp_path, monkeypatch
+    ):
+        _write_voice(tmp_path / "sonata")
+
+        with monkeypatch.context() as locked:
+            def _in_use(src, dst):
+                raise PermissionError("file in use")
+
+            locked.setattr(voice_migration.os, "rename", _in_use)
+            assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+
+        (tmp_path / "dengjen" / "voices" / "piper").mkdir(parents=True)
+
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is True
+        migrated = tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        assert (migrated / "en_US-amy-medium.onnx").read_bytes() == b"model"
+
+    def test_a_partly_migrated_tree_is_not_re_migrated_over(self, tmp_path):
+        _write_voice(tmp_path / "dengjen", key="en_GB-alan-medium")
+        _write_voice(tmp_path / "sonata", key="en_US-amy-medium")
+        assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
+        assert not (
+            tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        ).exists()
+
+
+class _FakeAddon:
+    def __init__(self, name, pending_remove=False):
+        self.name = name
+        self.isPendingRemove = pending_remove
+
+
+class TestCoexistenceWithTheOldAddon:
+    """Moving the folder would break a Sonata install that still works, so
+    while the old add-on is present the voices are left alone and the voice
+    manager copies them on request instead."""
+
+    def test_does_not_move_anything_while_the_old_addon_is_installed(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        assert (
+            voice_migration.migrate_voices_directory(
+                str(tmp_path), addons=[_FakeAddon("sonata_neural_voices")]
+            )
+            is False
+        )
+        assert (tmp_path / "sonata" / "voices" / "piper" / "en_US-amy-medium").is_dir()
+        assert not (tmp_path / "dengjen").exists()
+
+    def test_moves_once_the_old_addon_is_pending_removal(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        assert (
+            voice_migration.migrate_voices_directory(
+                str(tmp_path),
+                addons=[_FakeAddon("sonata_neural_voices", pending_remove=True)],
+            )
+            is True
+        )
+
+    def test_an_unrelated_addon_does_not_block_the_move(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        assert (
+            voice_migration.migrate_voices_directory(
+                str(tmp_path), addons=[_FakeAddon("some_other_addon")]
+            )
+            is True
+        )
+
+
+class TestImportableVoiceKeys:
+    def test_lists_voices_only_present_in_the_old_tree(self, tmp_path):
+        _write_voice(tmp_path / "sonata", key="en_US-amy-medium")
+        _write_voice(tmp_path / "sonata", key="en_GB-alan-medium")
+        _write_voice(tmp_path / "dengjen", key="en_GB-alan-medium")
+        assert voice_migration.importable_voice_keys(str(tmp_path)) == [
+            "en_US-amy-medium"
+        ]
+
+    def test_is_empty_when_there_is_no_old_tree(self, tmp_path):
+        assert voice_migration.importable_voice_keys(str(tmp_path)) == []
+
+    def test_is_empty_when_everything_is_already_imported(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        _write_voice(tmp_path / "dengjen")
+        assert voice_migration.importable_voice_keys(str(tmp_path)) == []
+
+
+class TestCopyVoicesFromOldDir:
+    def test_copies_and_leaves_the_originals_in_place(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        assert voice_migration.copy_voices_from_old_dir(str(tmp_path)) == [
+            "en_US-amy-medium"
+        ]
+        original = tmp_path / "sonata" / "voices" / "piper" / "en_US-amy-medium"
+        copy = tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        assert (original / "en_US-amy-medium.onnx").read_bytes() == b"model"
+        assert (copy / "en_US-amy-medium.onnx").read_bytes() == b"model"
+
+    def test_does_not_overwrite_a_voice_already_imported(self, tmp_path):
+        _write_voice(tmp_path / "sonata")
+        _write_voice(tmp_path / "dengjen", payload=b"newer model")
+        assert voice_migration.copy_voices_from_old_dir(str(tmp_path)) == []
+        copy = tmp_path / "dengjen" / "voices" / "piper" / "en_US-amy-medium"
+        assert (copy / "en_US-amy-medium.onnx").read_bytes() == b"newer model"
+
+    def test_is_a_noop_when_there_is_no_old_tree(self, tmp_path):
+        assert voice_migration.copy_voices_from_old_dir(str(tmp_path)) == []
+
+
+class TestMigrationRunsOnVoiceEnumeration:
+    """The trigger issue #83 was missing: onInstall was the only caller, so a
+    move that failed once was never retried."""
+
+    @pytest.fixture
+    def config_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            voice_migration.globalVars.appArgs, "configPath", str(tmp_path)
+        )
+        monkeypatch.setattr(
+            tts_system,
+            "DENGJEN_VOICES_DIR",
+            str(tmp_path / "dengjen" / "voices" / "piper"),
+        )
+        return tmp_path
+
+    def test_enumerating_voices_migrates_the_old_directory(self, config_dir):
+        _write_voice(config_dir / "sonata")
+        voices = tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
+        assert [v.key for v in voices] == ["en_US-amy-medium"]
+        assert not (config_dir / "sonata").exists()
+
+    def test_enumerating_voices_after_a_failed_move_retries_it(
+        self, config_dir, monkeypatch
+    ):
+        _write_voice(config_dir / "sonata")
+
+        with monkeypatch.context() as locked:
+            def _in_use(src, dst):
+                raise PermissionError("file in use")
+
+            locked.setattr(voice_migration.os, "rename", _in_use)
+            assert (
+                tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
+                == []
+            )
+            assert os.path.isdir(config_dir / "dengjen" / "voices" / "piper")
+
+        voices = tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir()
+        assert [v.key for v in voices] == ["en_US-amy-medium"]


### PR DESCRIPTION
Refs #83 — that issue stays open until a Windows tester verifies the rebuilt artifact.

## Summary

The 4.0.0 voice migration ran once, from `onInstall`, and skipped whenever the destination directory merely existed. It runs while Sonata still holds its `.onnx` files open, so the move fails; the synth driver then creates an empty tree there on its next load, and the `exists()` guard reads that as "already migrated". No second attempt was possible, so the reporter on #83 lost their voices and redownloaded.

## Changes

- New `addon/synthDrivers/dengjen_neural_voices/voice_migration.py`. Guards on whether the destination actually holds voices, and merges into an existing tree instead of a single top-level `os.rename`. Still renames, never copies.
- Called from `tts_system.py:396`, before every enumeration — the choke point all four callers share, so migrate-then-enumerate is ordered correctly. Install time is dropped: NVDA requires a restart before the add-on runs either way.
- It declines to move anything while Sonata is still installed, which would break a working add-on. `addonHandler.initialize()` is `core.py:746`, before `speech.initialize()` at `:783`, so the check is safe there.
- For that case, `Import voices from Sonata` in the voice manager copies and leaves the originals. Hidden unless there is something to import, so it never appears for users who never had Sonata.
- The install dialog claimed Dengjen "has taken over" the voices. No longer true, so it points at the import button and drops to `ICON_INFORMATION`.
- `installTasks.py` loads `voice_migration.py` by file path rather than importing the synth package, which would pull grpc and the bundled Windows libraries into install. Beats duplicating `is_old_addon_installed` and the `sonata_neural_voices` constant.

## Test plan

- [x] Syntax check passes.
- [ ] CI build + test green.
- [x] 288 tests pass. `tests/test_voice_migration.py` is 21 tests, including two that fail against the old guard and two driving the real enumeration path end to end.
- [ ] Windows: upgrade from 3.2.x with Sonata removed — voices survive. With Sonata still installed — voices stay put, `Import voices from Sonata` appears and copies them, Sonata keeps working.

The wx layer is only exercised by `tests_gui/`, which is Windows-only, so the button itself is unverified here. Removal of all this is tracked in #99.