### PR TITLE
fix: bind gettext in the three modules that never did

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -15,7 +15,10 @@ import wx.lib.mixins.listctrl as listmix
 from . import sized_controls as sc
 
 
+import addonHandler
 import gui
+
+addonHandler.initTranslation()
 
 
 ObjectCollection = typing.Iterable[typing.Any]

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -23,10 +23,13 @@ from http.client import HTTPException
 from io import BytesIO
 
 import wx
+import addonHandler
 import core
 import gui
 from languageHandler import normalizeLanguage
 from logHandler import log
+
+addonHandler.initTranslation()
 
 from . import DengjenTextToSpeechSystem, helpers, DENGJEN_VOICES_DIR
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -16,9 +16,12 @@ import winsound
 
 import wx
 from wx.adv import CommandLinkButton
+import addonHandler
 import gui
 import synthDriverHandler
 from logHandler import log
+
+addonHandler.initTranslation()
 
 from . import DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR
 from . import voice_migration

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -25,6 +25,7 @@ then drifts. Strategy, unchanged from before:
 """
 
 import builtins
+import inspect
 import sys
 import os
 import types
@@ -260,9 +261,16 @@ def install(*, stub_wx: bool = True) -> None:
     )
 
     # addonHandler
-    # initTranslation() installs gettext's `_`, which module-level `_("...")` needs at import.
+    # The real initTranslation() binds `_` on the calling module alone, so a
+    # module that skips it silently falls through to the builtin NVDA installs
+    # and misses the add-on's catalogue (issue #102). Bind the same way here,
+    # and keep the builtin fallback, so tests reproduce that silence rather
+    # than turning it into an import error.
+    builtins._ = lambda message: message
+
     def _init_translation():
-        builtins._ = lambda message: message
+        module = inspect.getmodule(inspect.currentframe().f_back)
+        module._ = lambda message: message
 
     _stub_module(
         "addonHandler",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,12 +1,16 @@
 # coding: utf-8
 """
-Catalogue-level checks. No NVDA, no wx -- these run on both CI legs.
+Catalogue-level checks, plus the source-level check that the catalogue is
+reached at all. No NVDA, no wx -- these run on both CI legs.
 
 Access keys are the reason this file exists. tests_gui/ only ever sees
 untranslated English, so a locale that drops the `&` from a button label takes
 that button's Alt shortcut away with no visible symptom, and nothing in the
 suite could catch it (#97). The .mo files NVDA actually loads are untracked
 SCons output, so the tracked .po is what there is to check.
+
+The initTranslation check below is the other half of the same blind spot: a
+complete catalogue is worth nothing to a module that never binds `_` to it.
 """
 
 import glob
@@ -21,6 +25,24 @@ _CATALOGUES = sorted(
     glob.glob(os.path.join(_REPO_ROOT, "addon", "locale", "*", "LC_MESSAGES", "nvda.po"))
 )
 _LOCALES = [path.split(os.sep)[-3] for path in _CATALOGUES]
+
+# The globs xgettext harvests msgids from -- buildVars.i18nSources, which the
+# SCons build reads. Only one directory level deep, so vendored lib/ and the
+# generated protos stay out.
+_I18N_SOURCES = sorted(
+    path
+    for pattern in (
+        "addon/globalPlugins/*/*.py",
+        "addon/synthDrivers/*/*.py",
+        "addon/installTasks.py",
+        "buildVars.py",
+    )
+    for path in glob.glob(os.path.join(_REPO_ROOT, pattern))
+)
+_I18N_SOURCE_IDS = [os.path.relpath(path, _REPO_ROOT) for path in _I18N_SOURCES]
+
+# `_(`, but not `foo_(`, `self._(` or `ngettext(`.
+_GETTEXT_CALL = re.compile(r"(?<![\w.])_\(")
 
 
 def _po_string(token):
@@ -98,3 +120,46 @@ def test_translations_neither_drop_nor_invent_access_keys(catalogue):
     ]
     assert not dropped, f"translations lost their access key: {dropped}"
     assert not invented, f"translations added an access key: {invented}"
+
+
+def _binds_gettext(source):
+    """Does the module give itself a `_`, rather than inheriting NVDA's?"""
+    return (
+        "addonHandler.initTranslation()" in source
+        or re.search(r"^from .+ import .*\b_\b", source, re.MULTILINE) is not None
+    )
+
+
+def test_the_i18n_sources_were_found():
+    # A bad glob would parametrize nothing below and pass by testing no files.
+    assert len(_I18N_SOURCES) >= 10, _I18N_SOURCE_IDS
+
+
+@pytest.mark.parametrize("source_path", _I18N_SOURCES, ids=_I18N_SOURCE_IDS)
+def test_every_module_with_translatable_strings_binds_its_own_gettext(source_path):
+    """Regression test for #102.
+
+    initTranslation() sets `_` on the calling module alone. Skip it and `_`
+    resolves to the builtin NVDA installs, so lookups go to NVDA's catalogue
+    instead of ours: our msgids are absent and the string stays English however
+    complete the .po is. Nothing fails, which is why this has to be checked
+    statically rather than waited for.
+    """
+    with open(source_path, encoding="utf-8") as handle:
+        source = handle.read()
+    if not _GETTEXT_CALL.search(source):
+        pytest.skip("no translatable strings")
+    assert _binds_gettext(source), (
+        f"{os.path.relpath(source_path, _REPO_ROOT)} calls _() without binding it; "
+        "add addonHandler.initTranslation()"
+    )
+
+
+def test_the_gettext_call_pattern_finds_real_calls_only():
+    # Positive and negative control for _GETTEXT_CALL: a pattern that matched
+    # nothing would skip every file above, and one that matched too much would
+    # demand initTranslation() in modules that never translate anything.
+    assert _GETTEXT_CALL.search('gui.messageBox(_("Error"))')
+    assert not _GETTEXT_CALL.search("ngettext(n)")
+    assert not _GETTEXT_CALL.search("self._(x)")
+    assert not _GETTEXT_CALL.search("_config_path()")


### PR DESCRIPTION
Closes #102.

## Summary

`addonHandler.initTranslation()` binds `_` on the calling module alone. `voice_manager.py`, `voice_download.py` and `components.py` never called it, so their 75 `_()` call sites looked our msgids up in NVDA's catalogue instead of the add-on's — most of the voice manager UI stayed English however complete the `.po` was.

## Changes

- One `addonHandler.initTranslation()` per module: `voice_manager.py`, `voice_download.py`, `components.py`.
- `tests/nvda_stubs.py:265` set `builtins._`, so one module calling `initTranslation()` made `_` resolve everywhere and a missing call was invisible to tests. It now binds on the caller's module as NVDA does, with the builtin fallback installed separately so a skipped call stays silently untranslated under test, as in production.
- `tests/test_translations.py`: a case parametrized over `buildVars.i18nSources` asserting any file calling `_()` binds its own `_`. `buildVars.py` passes on its imported fake `_`, so no exemption list.

## Test plan

- [x] 303 passed, 8 skipped.
- [x] Guard bites — deleting the line from `components.py` fails that case by name.
- [ ] CI build + test green.
- [ ] Windows check against a non-English NVDA, before and after, as #102 asks. Not possible here; `tests_gui/` only ever sees untranslated English.

Note: 12 source msgids are in no catalogue yet, so some of these strings stay English regardless — tracked separately.