### PR TITLE
fix: bring the catalogues back in line with the source

### DIFF
--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -425,22 +425,75 @@ msgstr ""
 msgid "Preview failed"
 msgstr "Prueba fallida"
 
-# Draft translation added by the fork maintainer; review welcome.
-#. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
-msgid ""
-"First stable release of the maintenance fork. Adds NVDA 2026.1 "
-"compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, "
-"miniaudio, and cffi binaries. Fixes voice list URL handling, voice install "
-"regex for names containing digits, voice list refresh after a successful "
-"download, install-from-local-file UX and error messages, and adds a Visual "
-"C++ Redistributable pre-flight check."
+#. Translators: the main label of the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
+msgid "Import voices from Sonata"
 msgstr ""
-"Primera versión estable del fork de mantenimiento. Añade compatibilidad "
-"con NVDA 2026.1 (Python 3.13, 64 bits) reconstruyendo los binarios "
-"incluidos de gRPC, miniaudio y cffi. Corrige el manejo de la URL de la "
-"lista de voces, la expresión regular de instalación para nombres que "
-"contienen dígitos, la actualización de la lista de voces tras una descarga "
-"correcta, la instalación desde un archivo local y sus mensajes de error, y "
-"añade una comprobación previa del Redistribuible de Visual C++."
+
+#. Translators: the note for the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
+msgid ""
+"Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+"The originals are left in place, so Sonata keeps working."
+msgstr ""
+
+#. Translators: message in a message box; {voices} is a list of voice names
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
+msgid ""
+"Copy the following voices from the Sonata Neural Voices add-on?\n"
+"{voices}\n"
+"\n"
+"The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
+msgid "Import voices from Sonata?"
+msgstr ""
+
+#. Translators: message telling the user that importing voices has failed
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
+msgid ""
+"Failed to import voices.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
+msgid "Import failed"
+msgstr ""
+
+#. Translators: message telling the user which voices were imported
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
+msgid ""
+"The following voices were imported:\n"
+"{voices}"
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
+msgid "Voices imported"
+msgstr ""
+
+#. Translators: shown after installing when the pre-rename add-on is still present
+#: addon\installTasks.py:77
+msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
+msgstr ""
+
+#. Translators: title of the message shown when the pre-rename add-on is still present
+#: addon\installTasks.py:85
+msgid "Old add-on still installed"
+msgstr ""
+
+#. Translators: reported when NVDA fails to switch to a Dengjen
+#: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
+msgid "Failed to load voice {voice}. Keeping the previous voice."
+msgstr ""
+
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
+msgstr ""

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -424,23 +424,75 @@ msgstr ""
 msgid "Preview failed"
 msgstr "Échec de l'aperçu"
 
-# Draft translation added by the fork maintainer; review welcome.
-#. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
-msgid ""
-"First stable release of the maintenance fork. Adds NVDA 2026.1 "
-"compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, "
-"miniaudio, and cffi binaries. Fixes voice list URL handling, voice install "
-"regex for names containing digits, voice list refresh after a successful "
-"download, install-from-local-file UX and error messages, and adds a Visual "
-"C++ Redistributable pre-flight check."
+#. Translators: the main label of the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
+msgid "Import voices from Sonata"
 msgstr ""
-"Première version stable de ce fork de maintenance. Ajoute la compatibilité "
-"avec NVDA 2026.1 (Python 3.13, 64 bits) en reconstruisant les binaires "
-"gRPC, miniaudio et cffi fournis. Corrige la gestion de l'URL de la liste "
-"des voix, l'expression régulière d'installation pour les noms contenant "
-"des chiffres, le rafraîchissement de la liste des voix après un "
-"téléchargement réussi, l'installation à partir d'un fichier local et ses "
-"messages d'erreur, et ajoute une vérification préalable du Redistribuable "
-"Visual C++."
+
+#. Translators: the note for the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
+msgid ""
+"Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+"The originals are left in place, so Sonata keeps working."
+msgstr ""
+
+#. Translators: message in a message box; {voices} is a list of voice names
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
+msgid ""
+"Copy the following voices from the Sonata Neural Voices add-on?\n"
+"{voices}\n"
+"\n"
+"The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
+msgid "Import voices from Sonata?"
+msgstr ""
+
+#. Translators: message telling the user that importing voices has failed
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
+msgid ""
+"Failed to import voices.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
+msgid "Import failed"
+msgstr ""
+
+#. Translators: message telling the user which voices were imported
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
+msgid ""
+"The following voices were imported:\n"
+"{voices}"
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
+msgid "Voices imported"
+msgstr ""
+
+#. Translators: shown after installing when the pre-rename add-on is still present
+#: addon\installTasks.py:77
+msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
+msgstr ""
+
+#. Translators: title of the message shown when the pre-rename add-on is still present
+#: addon\installTasks.py:85
+msgid "Old add-on still installed"
+msgstr ""
+
+#. Translators: reported when NVDA fails to switch to a Dengjen
+#: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
+msgid "Failed to load voice {voice}. Keeping the previous voice."
+msgstr ""
+
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
+msgstr ""

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -420,9 +420,75 @@ msgstr ""
 "bo modelên dengî yên Piper bi rêya motora Sonata ajokarek sentezker, û ji bo "
 "daxistin û sazkirina dengan rêveberek dengan pêşkêş dike."
 
-#. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
-msgid "First stable release of the maintenance fork. Adds NVDA 2026.1 compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, miniaudio, and cffi binaries. Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
-msgstr "Berdana yekem a stabîl a vê çapa lênêrînê. Bi ji nû ve avakirina pelên binary ên gRPC, miniaudio û cffi yên pêçayî, lihevhatina bi NVDA 2026.1 re (Python 3.13, 64-bit) hat zêdekirin. Birêvebirina URL-ya lîsteya dengan, şêweya sazkirina dengan ji bo navên bi hejmar, nûkirina lîsteya dengan piştî daxistineke serkeftî, ezmûna sazkirinê ji pelê herêmî û peyamên çewtiyê hatin rastkirin; her wiha kontroleke pêşîn a Visual C++ Redistributable hat zêdekirin."
+#. Translators: the main label of the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
+msgid "Import voices from Sonata"
+msgstr ""
 
+#. Translators: the note for the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
+msgid ""
+"Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+"The originals are left in place, so Sonata keeps working."
+msgstr ""
+
+#. Translators: message in a message box; {voices} is a list of voice names
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
+msgid ""
+"Copy the following voices from the Sonata Neural Voices add-on?\n"
+"{voices}\n"
+"\n"
+"The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
+msgid "Import voices from Sonata?"
+msgstr ""
+
+#. Translators: message telling the user that importing voices has failed
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
+msgid ""
+"Failed to import voices.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
+msgid "Import failed"
+msgstr ""
+
+#. Translators: message telling the user which voices were imported
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
+msgid ""
+"The following voices were imported:\n"
+"{voices}"
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
+msgid "Voices imported"
+msgstr ""
+
+#. Translators: shown after installing when the pre-rename add-on is still present
+#: addon\installTasks.py:77
+msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
+msgstr ""
+
+#. Translators: title of the message shown when the pre-rename add-on is still present
+#: addon\installTasks.py:85
+msgid "Old add-on still installed"
+msgstr ""
+
+#. Translators: reported when NVDA fails to switch to a Dengjen
+#: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
+msgid "Failed to load voice {voice}. Keeping the previous voice."
+msgstr ""
+
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
+msgstr ""

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -427,22 +427,75 @@ msgstr ""
 msgid "Preview failed"
 msgstr "Сбой воспроизведения образца"
 
-# Draft translation added by the fork maintainer; review welcome.
-#. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
-msgid ""
-"First stable release of the maintenance fork. Adds NVDA 2026.1 "
-"compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, "
-"miniaudio, and cffi binaries. Fixes voice list URL handling, voice install "
-"regex for names containing digits, voice list refresh after a successful "
-"download, install-from-local-file UX and error messages, and adds a Visual "
-"C++ Redistributable pre-flight check."
+#. Translators: the main label of the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
+msgid "Import voices from Sonata"
 msgstr ""
-"Первый стабильный выпуск сопровождаемой ветки. Добавлена совместимость с "
-"NVDA 2026.1 (Python 3.13, 64-битная версия) за счёт пересборки включённых "
-"двоичных файлов gRPC, miniaudio и cffi. Исправлены обработка URL списка "
-"голосов, регулярное выражение установки для имён с цифрами, обновление "
-"списка голосов после успешной загрузки, установка из локального файла и "
-"сообщения об ошибках, а также добавлена предварительная проверка "
-"распространяемого пакета Visual C++."
+
+#. Translators: the note for the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
+msgid ""
+"Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+"The originals are left in place, so Sonata keeps working."
+msgstr ""
+
+#. Translators: message in a message box; {voices} is a list of voice names
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
+msgid ""
+"Copy the following voices from the Sonata Neural Voices add-on?\n"
+"{voices}\n"
+"\n"
+"The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
+msgid "Import voices from Sonata?"
+msgstr ""
+
+#. Translators: message telling the user that importing voices has failed
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
+msgid ""
+"Failed to import voices.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
+msgid "Import failed"
+msgstr ""
+
+#. Translators: message telling the user which voices were imported
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
+msgid ""
+"The following voices were imported:\n"
+"{voices}"
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
+msgid "Voices imported"
+msgstr ""
+
+#. Translators: shown after installing when the pre-rename add-on is still present
+#: addon\installTasks.py:77
+msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
+msgstr ""
+
+#. Translators: title of the message shown when the pre-rename add-on is still present
+#: addon\installTasks.py:85
+msgid "Old add-on still installed"
+msgstr ""
+
+#. Translators: reported when NVDA fails to switch to a Dengjen
+#: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
+msgid "Failed to load voice {voice}. Keeping the previous voice."
+msgstr ""
+
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
+msgstr ""

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -420,9 +420,75 @@ msgstr ""
 "motoru aracılığıyla Piper ses modelleri için bir sentezleyici sürücüsü ve "
 "sesleri indirip kurmak için bir ses yöneticisi sağlar."
 
-#. Brief changelog for this version
-#. Translators: what's new content for the add-on version to be shown in the add-on store
-#: buildVars.py:29
-msgid "First stable release of the maintenance fork. Adds NVDA 2026.1 compatibility (Python 3.13, 64-bit) by rebuilding the bundled gRPC, miniaudio, and cffi binaries. Fixes voice list URL handling, voice install regex for names containing digits, voice list refresh after a successful download, install-from-local-file UX and error messages, and adds a Visual C++ Redistributable pre-flight check."
-msgstr "Bakım çatalının ilk kararlı sürümü. Paketlenmiş gRPC, miniaudio ve cffi ikili dosyaları yeniden derlenerek NVDA 2026.1 uyumluluğu (Python 3.13, 64 bit) eklendi. Ses listesi URL işleme, rakam içeren adlar için ses yükleme kalıbı, başarılı indirmenin ardından ses listesinin yenilenmesi, yerel dosyadan yükleme deneyimi ve hata iletileri düzeltildi; ayrıca bir Visual C++ Yeniden Dağıtılabilir Paketi ön denetimi eklendi."
+#. Translators: the main label of the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
+msgid "Import voices from Sonata"
+msgstr ""
 
+#. Translators: the note for the button for importing pre-rename voices
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
+msgid ""
+"Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
+"The originals are left in place, so Sonata keeps working."
+msgstr ""
+
+#. Translators: message in a message box; {voices} is a list of voice names
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
+msgid ""
+"Copy the following voices from the Sonata Neural Voices add-on?\n"
+"{voices}\n"
+"\n"
+"The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
+msgid "Import voices from Sonata?"
+msgstr ""
+
+#. Translators: message telling the user that importing voices has failed
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
+msgid ""
+"Failed to import voices.\n"
+"\n"
+"{detail}\n"
+"\n"
+"See NVDA's log for more details."
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
+msgid "Import failed"
+msgstr ""
+
+#. Translators: message telling the user which voices were imported
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
+msgid ""
+"The following voices were imported:\n"
+"{voices}"
+msgstr ""
+
+#. Translators: title of a message box
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
+msgid "Voices imported"
+msgstr ""
+
+#. Translators: shown after installing when the pre-rename add-on is still present
+#: addon\installTasks.py:77
+msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
+msgstr ""
+
+#. Translators: title of the message shown when the pre-rename add-on is still present
+#: addon\installTasks.py:85
+msgid "Old add-on still installed"
+msgstr ""
+
+#. Translators: reported when NVDA fails to switch to a Dengjen
+#: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
+msgid "Failed to load voice {voice}. Keeping the previous voice."
+msgstr ""
+
+#. Translators: what's new content for the add-on version to be shown in the add-on store
+#: buildVars.py:31
+msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
+msgstr ""

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -13,6 +13,7 @@ The initTranslation check below is the other half of the same blind spot: a
 complete catalogue is worth nothing to a module that never binds `_` to it.
 """
 
+import ast
 import glob
 import os
 import re
@@ -153,6 +154,64 @@ def test_every_module_with_translatable_strings_binds_its_own_gettext(source_pat
         f"{os.path.relpath(source_path, _REPO_ROOT)} calls _() without binding it; "
         "add addonHandler.initTranslation()"
     )
+
+
+_PO_ESCAPES = {"n": "\n", "t": "\t", '"': '"', "\\": "\\"}
+
+
+def _unescape(text):
+    """po escapes -> the real string, so it can be compared to the source.
+
+    Unknown escapes raise rather than pass through: silently mangling one
+    would show up as a spurious drift failure with no clue why.
+    """
+    out, index = [], 0
+    while index < len(text):
+        char = text[index]
+        if char == "\\":
+            out.append(_PO_ESCAPES[text[index + 1]])
+            index += 2
+        else:
+            out.append(char)
+            index += 1
+    return "".join(out)
+
+
+def _source_msgids(path):
+    """Every `_("literal")` in `path`. Not `_(variable)` -- xgettext cannot see
+    those either, so they are a separate bug from the one checked here."""
+    with open(path, encoding="utf-8") as handle:
+        tree = ast.parse(handle.read())
+    return {
+        node.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[0].value, str)
+    }
+
+
+_SOURCE_MSGIDS = set().union(*(_source_msgids(path) for path in _I18N_SOURCES))
+
+
+@pytest.mark.parametrize("catalogue", _CATALOGUES, ids=_LOCALES)
+def test_catalogues_carry_exactly_the_msgids_the_source_uses(catalogue):
+    """Regression test for #105.
+
+    `scons pot` regenerates the .pot but nothing merges it into the tracked
+    .po files, so strings added since a locale was last touched were never
+    offered to its translator and rendered in English. Eleven had built up,
+    plus a changelog entry still describing 3.x.
+    """
+    assert len(_SOURCE_MSGIDS) >= 50, "the source extractor found almost nothing"
+    catalogued = {_unescape(msgid) for msgid, _ in _po_entries(catalogue) if msgid}
+    missing = sorted(_SOURCE_MSGIDS - catalogued)
+    orphaned = sorted(catalogued - _SOURCE_MSGIDS)
+    assert not missing, f"strings no translator has been offered: {missing}"
+    assert not orphaned, f"catalogued strings the source no longer uses: {orphaned}"
 
 
 def test_the_gettext_call_pattern_finds_real_calls_only():


### PR DESCRIPTION
Closes #105.

## Summary

All five locales carried 65 msgids while the source uses 77. The same 12 were missing everywhere, so no translator has ever been offered them and they render in English whatever the locale.

## Changes

- 12 msgids added to `es`, `fr`, `kmr`, `ru`, `tr`, each with its source reference, Translators comment and an empty `msgstr` — the state `msgmerge` would leave them in. Ten came from #103, one from 81b1aa9.
- The 3.x add-on store changelog is dropped: `buildVars.py` was rewritten for 4.0.0, so the store would have shown a translated changelog for the wrong release. Its text is version-specific and unreachable.
- Existing entries untouched, stale line references included — refreshing those is mechanical churn that would bury the additions.
- `tests/test_translations.py`: each catalogue's msgids must match the source set exactly, so a new string and a deleted one both fail.

## Test plan

- [x] 308 passed, 8 skipped.
- [x] Guard bites — altering one msgid fails that locale by name.
- [x] Each catalogue compiles and lookups resolve: 77 entries, 65 translated, 12 untranslated, 0 fuzzy everywhere. Merged by script, as gettext is not installed locally.
- [ ] CI build + test green.

The 12 new strings are untranslated in every locale and will render in English until translators supply them.