### PR TITLE
feat: translate the twelve new strings into all five locales

### DIFF
--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -253,7 +253,7 @@ msgstr "La voz se ha eliminado con éxito."
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:179
 msgid "Done"
-msgstr "Echo"
+msgstr "Hecho"
 
 #. Translators: title for a dialog for opening a file
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:188
@@ -428,7 +428,7 @@ msgstr "Prueba fallida"
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
 msgid "Import voices from Sonata"
-msgstr ""
+msgstr "Importar voces desde Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
@@ -436,6 +436,8 @@ msgid ""
 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
 "The originals are left in place, so Sonata keeps working."
 msgstr ""
+"Copia las voces que descargaste con el complemento Voces Neuronales Sonata.\n"
+"Los originales se conservan en su sitio, por lo que Sonata sigue funcionando."
 
 #. Translators: message in a message box; {voices} is a list of voice names
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
@@ -445,11 +447,15 @@ msgid ""
 "\n"
 "The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
 msgstr ""
+"¿Copiar las siguientes voces del complemento Voces Neuronales Sonata?\n"
+"{voices}\n"
+"\n"
+"Los originales se conservan en su sitio, por lo que Sonata sigue funcionando. Esto necesita tanto espacio libre en disco como ocupen las voces."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
 msgid "Import voices from Sonata?"
-msgstr ""
+msgstr "¿Importar voces desde Sonata?"
 
 #. Translators: message telling the user that importing voices has failed
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
@@ -460,11 +466,16 @@ msgid ""
 "\n"
 "See NVDA's log for more details."
 msgstr ""
+"Se produjo un error al importar las voces.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Verifica el registro de NVDA para más detalles."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
 msgid "Import failed"
-msgstr ""
+msgstr "Importación fallida"
 
 #. Translators: message telling the user which voices were imported
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
@@ -472,28 +483,30 @@ msgid ""
 "The following voices were imported:\n"
 "{voices}"
 msgstr ""
+"Se importaron las siguientes voces:\n"
+"{voices}"
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
 msgid "Voices imported"
-msgstr ""
+msgstr "Voces importadas"
 
 #. Translators: shown after installing when the pre-rename add-on is still present
 #: addon\installTasks.py:77
 msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
-msgstr ""
+msgstr "El complemento Voces Neuronales Sonata sigue instalado, por lo que las voces que descargaste se han dejado donde estaban y Sonata sigue funcionando. Para usarlas con Voces Neuronales Dengjen, abre el administrador de voces Dengjen y elige \"Importar voces desde Sonata\". Eliminar el complemento Voces Neuronales Sonata también evita que aparezcan dos sintetizadores en las opciones de voz."
 
 #. Translators: title of the message shown when the pre-rename add-on is still present
 #: addon\installTasks.py:85
 msgid "Old add-on still installed"
-msgstr ""
+msgstr "El complemento antiguo sigue instalado"
 
 #. Translators: reported when NVDA fails to switch to a Dengjen
 #: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
 msgid "Failed to load voice {voice}. Keeping the previous voice."
-msgstr ""
+msgstr "Se produjo un error al cargar la voz {voice}. Se mantiene la voz anterior."
 
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:31
 msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
-msgstr ""
+msgstr "El complemento ha pasado a llamarse Voces Neuronales Dengjen a petición del autor original, como condición para aparecer en la Tienda de Complementos de NVDA. Después de actualizar debes volver a seleccionar el sintetizador en las opciones de voz de NVDA; tus voces instaladas, la velocidad, el tono y el volumen se conservan automáticamente. Elimina el antiguo complemento Voces Neuronales Sonata, que ya no tiene acceso a las voces descargadas."

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -427,7 +427,7 @@ msgstr "Échec de l'aperçu"
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
 msgid "Import voices from Sonata"
-msgstr ""
+msgstr "Importer les voix depuis Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
@@ -435,6 +435,8 @@ msgid ""
 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
 "The originals are left in place, so Sonata keeps working."
 msgstr ""
+"Copier les voix que vous avez téléchargées avec l'extension Voix neuronales de Sonata.\n"
+"Les originaux restent en place, Sonata continue donc de fonctionner."
 
 #. Translators: message in a message box; {voices} is a list of voice names
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
@@ -444,11 +446,15 @@ msgid ""
 "\n"
 "The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
 msgstr ""
+"Copier les voix suivantes depuis l'extension Voix neuronales de Sonata ?\n"
+"{voices}\n"
+"\n"
+"Les originaux restent en place, Sonata continue donc de fonctionner. Cela nécessite autant d'espace disque libre que les voix occupent."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
 msgid "Import voices from Sonata?"
-msgstr ""
+msgstr "Importer les voix depuis Sonata ?"
 
 #. Translators: message telling the user that importing voices has failed
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
@@ -459,11 +465,16 @@ msgid ""
 "\n"
 "See NVDA's log for more details."
 msgstr ""
+"Échec de l'importation des voix.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Voir le journal de NVDA pour plus de détails."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
 msgid "Import failed"
-msgstr ""
+msgstr "Échec de l'importation"
 
 #. Translators: message telling the user which voices were imported
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
@@ -471,28 +482,30 @@ msgid ""
 "The following voices were imported:\n"
 "{voices}"
 msgstr ""
+"Les voix suivantes ont été importées :\n"
+"{voices}"
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
 msgid "Voices imported"
-msgstr ""
+msgstr "Voix importées"
 
 #. Translators: shown after installing when the pre-rename add-on is still present
 #: addon\installTasks.py:77
 msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
-msgstr ""
+msgstr "L'extension Voix neuronales de Sonata est toujours installée : vos voix téléchargées ont donc été laissées où elles étaient et Sonata continue de fonctionner. Pour les utiliser avec Voix neuronales de Dengjen, ouvrez le gestionnaire de voix Dengjen et choisissez \"Importer les voix depuis Sonata\". Supprimer l'extension Voix neuronales de Sonata évite en outre que deux synthétiseurs apparaissent dans vos paramètres de parole."
 
 #. Translators: title of the message shown when the pre-rename add-on is still present
 #: addon\installTasks.py:85
 msgid "Old add-on still installed"
-msgstr ""
+msgstr "L'ancienne extension est toujours installée"
 
 #. Translators: reported when NVDA fails to switch to a Dengjen
 #: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
 msgid "Failed to load voice {voice}. Keeping the previous voice."
-msgstr ""
+msgstr "Échec du chargement de la voix {voice}. La voix précédente est conservée."
 
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:31
 msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
-msgstr ""
+msgstr "L'extension a été renommée Voix neuronales de Dengjen à la demande de l'auteur original, comme condition pour figurer dans l'Add-on Store de NVDA. Après la mise à jour, vous devez sélectionner à nouveau le synthétiseur dans les paramètres de parole de NVDA ; vos voix installées, le débit, la hauteur et le volume sont conservés automatiquement. Supprimez l'ancienne extension Voix neuronales de Sonata, qui n'a plus accès aux voix téléchargées."

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -423,7 +423,7 @@ msgstr ""
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
 msgid "Import voices from Sonata"
-msgstr ""
+msgstr "Dengan ji Sonata veguhezîne"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
@@ -431,6 +431,8 @@ msgid ""
 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
 "The originals are left in place, so Sonata keeps working."
 msgstr ""
+"Dengên ku te bi pêveka Dengên Neuronî yên Sonata daxistine kopî bike.\n"
+"Yên orîjînal li cihê xwe dimînin, loma Sonata hê jî dixebite."
 
 #. Translators: message in a message box; {voices} is a list of voice names
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
@@ -440,11 +442,15 @@ msgid ""
 "\n"
 "The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
 msgstr ""
+"Dengên li jêr ji pêveka Dengên Neuronî yên Sonata bên kopîkirin?\n"
+"{voices}\n"
+"\n"
+"Yên orîjînal li cihê xwe dimînin, loma Sonata hê jî dixebite. Divê bi qasî cihê ku deng digirin, cihê vala yê dîskê hebe."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
 msgid "Import voices from Sonata?"
-msgstr ""
+msgstr "Deng ji Sonata bên veguhaztin?"
 
 #. Translators: message telling the user that importing voices has failed
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
@@ -455,11 +461,16 @@ msgid ""
 "\n"
 "See NVDA's log for more details."
 msgstr ""
+"Deng nehatin veguhaztin.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Ji bo hûrgiliyan li tomara NVDA binêre."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
 msgid "Import failed"
-msgstr ""
+msgstr "Veguhaztin bi ser neket"
 
 #. Translators: message telling the user which voices were imported
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
@@ -467,28 +478,30 @@ msgid ""
 "The following voices were imported:\n"
 "{voices}"
 msgstr ""
+"Dengên li jêr hatin veguhaztin:\n"
+"{voices}"
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
 msgid "Voices imported"
-msgstr ""
+msgstr "Deng hatin veguhaztin"
 
 #. Translators: shown after installing when the pre-rename add-on is still present
 #: addon\installTasks.py:77
 msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
-msgstr ""
+msgstr "Pêveka Dengên Neuronî yên Sonata hê jî sazkirî ye, loma dengên ku te daxistine li cihê xwe hatin hiştin û Sonata hê jî dixebite. Ji bo bikaranîna wan bi Dengên Neuronî yên Dengjen re, rêveberê dengên Dengjen veke û \"Dengan ji Sonata veguhezîne\" hilbijêre. Rakirina pêveka Dengên Neuronî yên Sonata her wiha nahêle ku du sentezker di mîhengên axaftinê yên te de xuya bibin."
 
 #. Translators: title of the message shown when the pre-rename add-on is still present
 #: addon\installTasks.py:85
 msgid "Old add-on still installed"
-msgstr ""
+msgstr "Pêveka kevn hê jî sazkirî ye"
 
 #. Translators: reported when NVDA fails to switch to a Dengjen
 #: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
 msgid "Failed to load voice {voice}. Keeping the previous voice."
-msgstr ""
+msgstr "Dengê {voice} nehat barkirin. Dengê berê tê bikaranîn."
 
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:31
 msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
-msgstr ""
+msgstr "Li ser daxwaza nivîskarê bingehîn û wek şertekî ji bo cihgirtina di Dikana Pêvekan a NVDA de, navê pêvekê wek Dengên Neuronî yên Dengjen hate guherandin. Piştî bilindkirinê divê tu di mîhengên axaftinê yên NVDA de sentezker ji nû ve hilbijêrî; dengên te yên sazkirî, rêje, bilindahiya deng û piledeng bixweber derbas dibin. Pêveka kevn a Dengên Neuronî yên Sonata rake — ew êdî nikare bigihîje dengên daxistî."

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -430,7 +430,7 @@ msgstr "Сбой воспроизведения образца"
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
 msgid "Import voices from Sonata"
-msgstr ""
+msgstr "Импортировать голоса из Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
@@ -438,6 +438,8 @@ msgid ""
 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
 "The originals are left in place, so Sonata keeps working."
 msgstr ""
+"Скопировать голоса, загруженные с помощью дополнения Нейронные голоса Sonata.\n"
+"Оригиналы остаются на месте, поэтому Sonata продолжает работать."
 
 #. Translators: message in a message box; {voices} is a list of voice names
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
@@ -447,11 +449,15 @@ msgid ""
 "\n"
 "The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
 msgstr ""
+"Скопировать следующие голоса из дополнения Нейронные голоса Sonata?\n"
+"{voices}\n"
+"\n"
+"Оригиналы остаются на месте, поэтому Sonata продолжает работать. Для этого потребуется столько свободного места на диске, сколько занимают голоса."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
 msgid "Import voices from Sonata?"
-msgstr ""
+msgstr "Импортировать голоса из Sonata?"
 
 #. Translators: message telling the user that importing voices has failed
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
@@ -462,11 +468,16 @@ msgid ""
 "\n"
 "See NVDA's log for more details."
 msgstr ""
+"Не удалось импортировать голоса.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Более подробную информацию см. в журнале NVDA."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
 msgid "Import failed"
-msgstr ""
+msgstr "Не удалось импортировать"
 
 #. Translators: message telling the user which voices were imported
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
@@ -474,28 +485,30 @@ msgid ""
 "The following voices were imported:\n"
 "{voices}"
 msgstr ""
+"Импортированы следующие голоса:\n"
+"{voices}"
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
 msgid "Voices imported"
-msgstr ""
+msgstr "Голоса импортированы"
 
 #. Translators: shown after installing when the pre-rename add-on is still present
 #: addon\installTasks.py:77
 msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
-msgstr ""
+msgstr "Дополнение Нейронные голоса Sonata всё ещё установлено, поэтому загруженные голоса оставлены на своих местах и Sonata продолжает работать. Чтобы использовать их с Нейронными голосами Dengjen, откройте менеджер голосов Dengjen и выберите \"Импортировать голоса из Sonata\". Удаление дополнения Нейронные голоса Sonata также избавит вас от двух синтезаторов в настройках речи."
 
 #. Translators: title of the message shown when the pre-rename add-on is still present
 #: addon\installTasks.py:85
 msgid "Old add-on still installed"
-msgstr ""
+msgstr "Старое дополнение всё ещё установлено"
 
 #. Translators: reported when NVDA fails to switch to a Dengjen
 #: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
 msgid "Failed to load voice {voice}. Keeping the previous voice."
-msgstr ""
+msgstr "Не удалось загрузить голос {voice}. Сохранён предыдущий голос."
 
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:31
 msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
-msgstr ""
+msgstr "Дополнение переименовано в Нейронные голоса Dengjen по просьбе первоначального автора, как условие размещения в Магазине дополнений NVDA. После обновления необходимо заново выбрать синтезатор в настройках речи NVDA; установленные голоса, скорость, высота и громкость переносятся автоматически. Удалите старое дополнение Нейронные голоса Sonata — у него больше нет доступа к загруженным голосам."

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -423,7 +423,7 @@ msgstr ""
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
 msgid "Import voices from Sonata"
-msgstr ""
+msgstr "Sonata'dan sesleri içe aktar"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86
@@ -431,6 +431,8 @@ msgid ""
 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
 "The originals are left in place, so Sonata keeps working."
 msgstr ""
+"Sonata Sinir Ağı Sesleri eklentisiyle indirdiğiniz sesleri kopyalayın.\n"
+"Asıl dosyalar yerinde bırakılır, böylece Sonata çalışmaya devam eder."
 
 #. Translators: message in a message box; {voices} is a list of voice names
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:206
@@ -440,11 +442,15 @@ msgid ""
 "\n"
 "The originals are left in place, so Sonata keeps working. This needs as much free disk space as the voices take up."
 msgstr ""
+"Aşağıdaki sesler Sonata Sinir Ağı Sesleri eklentisinden kopyalansın mı?\n"
+"{voices}\n"
+"\n"
+"Asıl dosyalar yerinde bırakılır, böylece Sonata çalışmaya devam eder. Bunun için seslerin kapladığı kadar boş disk alanı gerekir."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:213
 msgid "Import voices from Sonata?"
-msgstr ""
+msgstr "Sesler Sonata'dan içe aktarılsın mı?"
 
 #. Translators: message telling the user that importing voices has failed
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:224
@@ -455,11 +461,16 @@ msgid ""
 "\n"
 "See NVDA's log for more details."
 msgstr ""
+"Sesler içe aktarılamadı.\n"
+"\n"
+"{detail}\n"
+"\n"
+"Ayrıntılar için NVDA günlüğüne bakın."
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:229
 msgid "Import failed"
-msgstr ""
+msgstr "İçe aktarma başarısız"
 
 #. Translators: message telling the user which voices were imported
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:236
@@ -467,28 +478,30 @@ msgid ""
 "The following voices were imported:\n"
 "{voices}"
 msgstr ""
+"Aşağıdaki sesler içe aktarıldı:\n"
+"{voices}"
 
 #. Translators: title of a message box
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:240
 msgid "Voices imported"
-msgstr ""
+msgstr "Sesler içe aktarıldı"
 
 #. Translators: shown after installing when the pre-rename add-on is still present
 #: addon\installTasks.py:77
 msgid "The Sonata Neural Voices add-on is still installed, so your downloaded voices have been left where they are and Sonata keeps working. To use them with Dengjen Neural Voices, open the Dengjen voice manager and choose \"Import voices from Sonata\". Removing the Sonata Neural Voices add-on also avoids two synthesizers appearing in your speech settings."
-msgstr ""
+msgstr "Sonata Sinir Ağı Sesleri eklentisi hâlâ kurulu, bu yüzden indirdiğiniz sesler bulundukları yerde bırakıldı ve Sonata çalışmaya devam ediyor. Bunları Dengjen Sinir Ağı Sesleri ile kullanmak için Dengjen ses yöneticisini açın ve \"Sonata'dan sesleri içe aktar\" seçeneğini seçin. Sonata Sinir Ağı Sesleri eklentisini kaldırmak ayrıca konuşma ayarlarınızda iki sentezleyici görünmesini önler."
 
 #. Translators: title of the message shown when the pre-rename add-on is still present
 #: addon\installTasks.py:85
 msgid "Old add-on still installed"
-msgstr ""
+msgstr "Eski eklenti hâlâ kurulu"
 
 #. Translators: reported when NVDA fails to switch to a Dengjen
 #: addon\synthDrivers\dengjen_neural_voices\__init__.py:454
 msgid "Failed to load voice {voice}. Keeping the previous voice."
-msgstr ""
+msgstr "{voice} sesi yüklenemedi. Önceki ses korunuyor."
 
 #. Translators: what's new content for the add-on version to be shown in the add-on store
 #: buildVars.py:31
 msgid "The add-on has been renamed to Dengjen Neural Voices at the request of the original author, as a condition of listing in the NVDA Add-on Store. After upgrading you must reselect the synthesizer in NVDA's speech settings; your installed voices, rate, pitch and volume carry over automatically. Remove the old Sonata Neural Voices add-on, which no longer has access to the downloaded voices."
-msgstr ""
+msgstr "Eklentinin adı, özgün yazarın isteği üzerine ve NVDA Eklenti mağazasında yer alma koşulu olarak Dengjen Sinir Ağı Sesleri olarak değiştirildi. Güncellemeden sonra NVDA konuşma ayarlarından sentezleyiciyi yeniden seçmeniz gerekir; kurulu sesleriniz, hız, ses perdesi ve ses seviyesi otomatik olarak korunur. Artık indirilen seslere erişemeyen eski Sonata Sinir Ağı Sesleri eklentisini kaldırın."


### PR DESCRIPTION
Follows #107, which added the 12 missing msgids untranslated. Every catalogue now reads 77/77.

## Changes

- **kmr** — the locale this fork maintains directly. Terms taken from the Kurmanji TM: `pêvek` (add-on), `kopî bike` (copy, NVDA core ×6), `sentezker`, `rêje` for rate (NVDA core's `nirxandin` means "evaluation"), `piledeng` for volume (NVDA core's `deng` collides with Voice). "Import" has no attestation in NVDA core and no majority anywhere, so I picked the `veguhaztin` family, which inflects into the catalogue's existing frames.
- **es, fr, ru, tr** — terminology checked against `nvaccess/nvda` `source/locale/<lang>` rather than guessed. Worth noting French keeps **Add-on Store** in English; "Logithèque" looks right and isn't.
- Sentence frames reuse each catalogue's own existing entries, so es stays informal, fr keeps its space before `?`, and the error wording matches what is already there.

## Test plan

- [x] 308 passed, 8 skipped.
- [x] All five compile and resolve, 0 fuzzy, 0 untranslated.
- [x] Placeholders, embedded quotes and line counts identical to their msgids.
- [x] The button label quoted inside the install-time message matches that locale's own button string.
- [x] kmr: `check_consistency.py` reports 0 terminology issues.
- [ ] CI build + test green.

Native review welcome on all five — these are drafts by a non-native writer for four of them.