### PR TITLE
fix: give the two install buttons an access key

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -69,7 +69,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             self,
             -1,
             # Translators: the main label of the install button
-            _("Install from local file"),
+            _("&Install from local file"),
             # Translators: the note for this button
             _(
                 "Install a voice from a local archive.\n"
@@ -81,7 +81,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             self,
             -1,
             # Translators: the main label of the button for importing pre-rename voices
-            _("Import voices from Sonata"),
+            _("Import voices from &Sonata"),
             # Translators: the note for the button for importing pre-rename voices
             _(
                 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -177,8 +177,8 @@ msgstr "&Eliminar voz..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:67
-msgid "Install from local file"
-msgstr "Instalar desde un archivo local"
+msgid "&Install from local file"
+msgstr "&Instalar desde un archivo local"
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:70
 msgid ""
@@ -427,8 +427,8 @@ msgstr "Prueba fallida"
 
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
-msgid "Import voices from Sonata"
-msgstr "Importar voces desde Sonata"
+msgid "Import voices from &Sonata"
+msgstr "Importar voces desde &Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -179,8 +179,8 @@ msgstr "&Supprimer la voix..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:67
-msgid "Install from local file"
-msgstr "Installer à partir d'un fichier local"
+msgid "&Install from local file"
+msgstr "&Installer à partir d'un fichier local"
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:70
 msgid ""
@@ -426,8 +426,8 @@ msgstr "Échec de l'aperçu"
 
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
-msgid "Import voices from Sonata"
-msgstr "Importer les voix depuis Sonata"
+msgid "Import voices from &Sonata"
+msgstr "Importer les &voix depuis Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -178,8 +178,8 @@ msgstr "Dengî &rake..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:67
-msgid "Install from local file"
-msgstr "Ji pelê herêmî saz bike"
+msgid "&Install from local file"
+msgstr "&Ji pelê herêmî saz bike"
 
 #. Translators: the note for this button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:69
@@ -422,8 +422,8 @@ msgstr ""
 
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
-msgid "Import voices from Sonata"
-msgstr "Dengan ji Sonata veguhezîne"
+msgid "Import voices from &Sonata"
+msgstr "Dengan ji &Sonata veguhezîne"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -178,8 +178,8 @@ msgstr "&Удалить голос..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:67
-msgid "Install from local file"
-msgstr "Установить из локального файла"
+msgid "&Install from local file"
+msgstr "Установить из &локального файла"
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:70
 msgid ""
@@ -429,8 +429,8 @@ msgstr "Сбой воспроизведения образца"
 
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
-msgid "Import voices from Sonata"
-msgstr "Импортировать голоса из Sonata"
+msgid "Import voices from &Sonata"
+msgstr "&Импортировать голоса из Sonata"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -180,8 +180,8 @@ msgstr "Sesi kal&dır..."
 
 #. Translators: the main label of the install button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:67
-msgid "Install from local file"
-msgstr "Yerel dosyadan yükle"
+msgid "&Install from local file"
+msgstr "&Yerel dosyadan yükle"
 
 #. Translators: the note for this button
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:69
@@ -422,8 +422,8 @@ msgstr ""
 
 #. Translators: the main label of the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:84
-msgid "Import voices from Sonata"
-msgstr "Sonata'dan sesleri içe aktar"
+msgid "Import voices from &Sonata"
+msgstr "Sonata'dan sesleri &içe aktar"
 
 #. Translators: the note for the button for importing pre-rename voices
 #: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:86

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -123,6 +123,40 @@ def test_translations_neither_drop_nor_invent_access_keys(catalogue):
     assert not invented, f"translations added an access key: {invented}"
 
 
+# The Installed tab's buttons plus the dialog's own Close button: the set a
+# user sees at once, so a letter reused inside it makes Alt ambiguous. The
+# Download tab is a separate page and free to reuse the same letters.
+_INSTALLED_TAB_LABELS = (
+    "&Voice model card...",
+    "&Remove voice...",
+    "&Install from local file",
+    "Import voices from &Sonata",
+    "&Close",
+)
+
+
+@pytest.mark.parametrize("catalogue", _CATALOGUES, ids=_LOCALES)
+def test_translated_access_keys_do_not_collide_on_the_installed_tab(catalogue):
+    """tests_gui/ only ever sees English, so a collision a translator
+    introduces is invisible to it -- and finding a free letter is not the same
+    problem in every language. French cannot mirror the English `&Sonata`:
+    `&Supprimer la voix...` already claims its `s` (#108).
+    """
+    entries = dict(_po_entries(catalogue))
+    drifted = [label for label in _INSTALLED_TAB_LABELS if label not in entries]
+    assert not drifted, f"this list no longer matches the catalogue: {drifted}"
+
+    claimed = {}
+    for label in _INSTALLED_TAB_LABELS:
+        key = _access_key(entries[label])
+        if key is not None:  # a string no translator has reached yet
+            claimed.setdefault(key, []).append(entries[label])
+    # positive control: an empty or near-empty tally cannot collide.
+    assert len(claimed) >= 3, claimed
+    collisions = {key: labels for key, labels in claimed.items() if len(labels) > 1}
+    assert not collisions, f"Alt is ambiguous: {collisions}"
+
+
 def _binds_gettext(source):
     """Does the module give itself a `_`, rather than inheriting NVDA's?"""
     return (

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -328,6 +328,21 @@ class TestKeyboardAccess:
     straight at the binding, so it fires a handler whether or not a user could
     ever have reached the control (#97)."""
 
+    def test_every_button_carries_an_access_key(self, dialog):
+        # tests/test_translations.py catches a locale that drops an `&`; this is
+        # the other half, a button that never had one to drop. Two of the
+        # CommandLinkButtons did not, so Alt reached neither (#108).
+        buttons = list(_buttons(dialog))
+        # positive control: a _buttons that walked nothing would pass below.
+        assert len(buttons) >= 9
+        assert [
+            # The main label only: a CommandLinkButton's GetLabel() returns the
+            # note too, and no note carries a mnemonic.
+            button.GetLabel().splitlines()[0]
+            for button in buttons
+            if _access_key(button) is None
+        ] == []
+
     @pytest.mark.parametrize("page", [0, 1])
     def test_access_keys_do_not_collide_on_a_page(self, dialog, page):
         # Only one notebook page is ever visible, so a letter reused across the


### PR DESCRIPTION
Closes #108.

## Summary

Every other button in the voice manager carries an `&` mnemonic; the two `CommandLinkButton`s on the Installed tab never did, so Alt reached neither. Both are Tab-reachable, which is why nothing flagged it — but the button a new user needs first was the one Alt could not get to.

`&I` and `&S` in English. Translations move the marker, not the words, so no locale loses a string; three place it off the first letter because the obvious one was taken — `&Supprimer`, `&Удалить` and `&Ses model kartı...`.

## Changes

- `voice_manager.py:72,84`: the two labels.
- The five catalogues: both msgids, and the `&` placed in all ten translations. Rebased on #110, so its new `Import voices from Sonata` strings carry the marker too.
- `tests_gui/`: every button has a key. `tests/test_translations.py`: the translated keys on that tab do not collide — which `tests_gui/` can never see, rendering only English.

## Test plan

- [x] 313 passed on Linux; the collision test verified to fail on a planted French collision.
- [ ] CI green, with the new `tests_gui/` test running on the Windows leg.
- [ ] Alt+I / Alt+S on a real NVDA install — CI can check the string, not the native `BS_COMMANDLINK` mnemonic.