### PR TITLE
fix: guard the two sys.path mutations with try/finally

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -22,14 +22,16 @@ _DIR = os.path.abspath(os.path.dirname(__file__))
 _ADDON_ROOT = os.path.abspath(os.path.join(_DIR, os.pardir, os.pardir))
 _TTS_MODULE_DIR = os.path.join(_ADDON_ROOT, "synthDrivers")
 sys.path.insert(0, _TTS_MODULE_DIR)
-from dengjen_neural_voices import helpers
-from dengjen_neural_voices import aio
-from dengjen_neural_voices import voice_migration
-from dengjen_neural_voices.tts_system import (
-    DengjenTextToSpeechSystem,
-    DENGJEN_VOICES_DIR,
-)
-sys.path.remove(_TTS_MODULE_DIR)
+try:
+    from dengjen_neural_voices import helpers
+    from dengjen_neural_voices import aio
+    from dengjen_neural_voices import voice_migration
+    from dengjen_neural_voices.tts_system import (
+        DengjenTextToSpeechSystem,
+        DENGJEN_VOICES_DIR,
+    )
+finally:
+    sys.path.remove(_TTS_MODULE_DIR)
 del _DIR, _ADDON_ROOT, _TTS_MODULE_DIR
 
 from .voice_manager import DengjenVoiceManagerDialog

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -133,8 +133,10 @@ def _temporary_import_psutil():
     dst = os.path.join(temp_import_dir.name, "psutil")
     shutil.copytree(src, dst)
     sys.path.insert(0, temp_import_dir.name)
-    import psutil
-    yield psutil
-    sys.path.remove(temp_import_dir.name)
-    with contextlib.suppress(Exception):
-        temp_import_dir.cleanup()
+    try:
+        import psutil
+        yield psutil
+    finally:
+        sys.path.remove(temp_import_dir.name)
+        with contextlib.suppress(Exception):
+            temp_import_dir.cleanup()


### PR DESCRIPTION
Closes #113 (partial — the two sys.path items; rest of that issue is separate follow-up work).

## Summary

`installTasks.py::_temporary_import_psutil` and the synthDrivers import block in the global plugin's `__init__.py` both insert a path entry, run an import, then remove it unconditionally. If the import raised (or, for psutil, the caller's `with`-body raised), the path entry leaked for the process lifetime.

## Changes

- `addon/installTasks.py:129-141` — wrap `import psutil` + `yield psutil` in `try/finally` so `sys.path.remove` and `temp_import_dir.cleanup()` always run.
- `addon/globalPlugins/dengjen_tts_global_plugin/__init__.py:24-34` — wrap the `dengjen_neural_voices` submodule imports in `try/finally` so `sys.path.remove(_TTS_MODULE_DIR)` always runs.

## Test plan

- [x] Syntax check passes (`python3 -m py_compile` on both files).
- [x] `tests/test_install_tasks.py` (9 tests) passes unchanged.
- [ ] CI build + test green.
- Neither context exercises the leak path directly under plain pytest: `_temporary_import_psutil` needs the vendored Windows psutil binary, and the global plugin `__init__.py` imports NVDA-only modules (`core`, `globalPluginHandler`, `wx`).