### PR TITLE
fix: extract a shared base for the two voice downloaders

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -223,7 +223,11 @@ def _stream_to_file(response, target_file, total_size, progress_callback, hasher
                 progress_callback(math.floor((downloaded_til_now / total_size) * 100))
 
 
-class PiperVoiceDownloader:
+class _VoiceInstallError(Exception):
+    """Raised by a downloader's `_install` hook to signal a failed install."""
+
+
+class _BaseVoiceDownloader:
     def __init__(self, voice: PiperVoice, success_callback):
         self.voice = voice
         self.success_callback = success_callback
@@ -237,6 +241,16 @@ class PiperVoiceDownloader:
             _("Downloaded: {progress}%").format(progress=progress),
         )
 
+    def download(self):
+        self.progress_dialog = wx.ProgressDialog(
+            title=self._progress_title(),
+            # Translators: message of a progress dialog
+            message=_("Retrieving download information..."),
+            parent=gui.mainFrame,
+        )
+        self.progress_dialog.CenterOnScreen()
+        THREAD_POOL_EXECUTOR.submit(self._download_work).add_done_callback(partial(self._done_callback_wrapper, self.done_callback))
+
     def done_callback(self, result):
         has_error = isinstance(result, Exception)
         if not has_error:
@@ -245,23 +259,10 @@ class PiperVoiceDownloader:
                 # Translators: message shown in the voice download progress dialog
                 _("Installing voice")
             )
-            hashes = {
-                file.name: (file.md5hash, md5hash)
-                for (file, __, md5hash) in result
-            }
-            if not all(expected == actual for expected, actual in hashes.values()):
+            try:
+                self._install(result)
+            except _VoiceInstallError:
                 has_error = True
-                log.error("File hashes do not match")
-            else:
-                voice_dir = Path(DENGJEN_VOICES_DIR).joinpath(self.voice.key)
-                voice_dir.mkdir(parents=True, exist_ok=True)
-                for file, src, __ in result:
-                    dst = os.path.join(voice_dir, file.name)
-                    try:
-                        shutil.copy(src, dst)
-                    except IOError:
-                        log.exception(f"Failed to copy file: {file}", exc_info=True)
-                        has_error = True
 
         self.progress_dialog.Hide()
         self.progress_dialog.Destroy()
@@ -270,16 +271,9 @@ class PiperVoiceDownloader:
         if not has_error:
             self.success_callback()
             retval = gui.messageBox(
-            # Translators: content of a message box
-            _(
-                "Successfully downloaded voice  {voice}.\n"
-                "To use this voice, you need to restart NVDA.\n"
-                "Do you want to restart NVDA now?"
-            ).format(
-                voice=self.voice.key
-            ),
-            # Translators: title of a message box
-            _("Voice downloaded"),
+                self._success_message(),
+                # Translators: title of a message box
+                _("Voice downloaded"),
                 wx.YES_NO | wx.ICON_WARNING,
                 parent=gui.mainFrame,
             )
@@ -288,9 +282,7 @@ class PiperVoiceDownloader:
         else:
             wx.CallAfter(
                 gui.messageBox,
-                _(
-                    "Cannot download voice {voice}.\nPlease check your connection and try again."
-                ).format(voice=self.voice.key),
+                self._failure_message(),
                 _("Download failed"),
                 style=wx.ICON_ERROR,
                 parent=gui.mainFrame,
@@ -299,18 +291,55 @@ class PiperVoiceDownloader:
                 f"Failed to download voice.\nException: {result}"
             )
 
-    def download(self):
-        self.progress_dialog = wx.ProgressDialog(
-            # Translators: title of a progress dialog
-            title=_("Downloading voice {voice}").format(
-                voice=self.voice.key
-            ),
-            # Translators: message of a progress dialog
-            message=_("Retrieving download information..."),
-            parent=gui.mainFrame,
-        )
-        self.progress_dialog.CenterOnScreen()
-        THREAD_POOL_EXECUTOR.submit(self.download_voice_files).add_done_callback(partial(self._done_callback_wrapper, self.done_callback))
+    @staticmethod
+    def _done_callback_wrapper(done_callback, future):
+        if done_callback is None:
+            return
+        try:
+            result = future.result()
+        except Exception as e:
+            done_callback(e)
+        else:
+            done_callback(result)
+
+    # Hooks implemented by subclasses.
+
+    def _download_work(self):
+        raise NotImplementedError
+
+    def _install(self, result):
+        raise NotImplementedError
+
+    def _progress_title(self):
+        raise NotImplementedError
+
+    def _success_message(self):
+        raise NotImplementedError
+
+    def _failure_message(self):
+        raise NotImplementedError
+
+
+class PiperVoiceDownloader(_BaseVoiceDownloader):
+    def _progress_title(self):
+        # Translators: title of a progress dialog
+        return _("Downloading voice {voice}").format(voice=self.voice.key)
+
+    def _success_message(self):
+        # Translators: content of a message box
+        return _(
+            "Successfully downloaded voice  {voice}.\n"
+            "To use this voice, you need to restart NVDA.\n"
+            "Do you want to restart NVDA now?"
+        ).format(voice=self.voice.key)
+
+    def _failure_message(self):
+        return _(
+            "Cannot download voice {voice}.\nPlease check your connection and try again."
+        ).format(voice=self.voice.key)
+
+    def _download_work(self):
+        return self.download_voice_files()
 
     def download_voice_files(self):
         retvals = []
@@ -342,94 +371,53 @@ class PiperVoiceDownloader:
 
         return (file, target_file, hasher.hexdigest())
 
-    @staticmethod
-    def _done_callback_wrapper(done_callback, future):
-        if done_callback is None:
-            return
-        try:
-            result = future.result()
-        except Exception as e:
-            done_callback(e)
-        else:
-            done_callback(result)
+    def _install(self, result):
+        hashes = {
+            file.name: (file.md5hash, md5hash)
+            for (file, __, md5hash) in result
+        }
+        if not all(expected == actual for expected, actual in hashes.values()):
+            log.error("File hashes do not match")
+            raise _VoiceInstallError
 
-
-class PiperRTVoiceDownloader:
-    def __init__(self, voice: PiperVoice, success_callback):
-        self.voice = voice
-        self.success_callback = success_callback
-        self.rt_download_url = self.voice.get_rt_variant_download_url()
-        self.temp_download_dir = tempfile.TemporaryDirectory()
-        self.progress_dialog = None
-
-    def update_progress(self, progress):
-        self.progress_dialog.Update(
-            progress,
-            # Translators: message of a progress dialog
-            _("Downloaded: {progress}%").format(progress=progress),
-        )
-
-    def done_callback(self, result):
-        has_error = isinstance(result, Exception)
-        if not has_error:
-            self.progress_dialog.Update(
-                0,
-                # Translators: message shown in the voice download progress dialog
-                _("Installing voice")
-            )
+        voice_dir = Path(DENGJEN_VOICES_DIR).joinpath(self.voice.key)
+        voice_dir.mkdir(parents=True, exist_ok=True)
+        copy_failed = False
+        for file, src, __ in result:
+            dst = os.path.join(voice_dir, file.name)
             try:
-                install_voice_from_tar_archive(result, DENGJEN_VOICES_DIR)
-            except Exception:
-                log.exception("Failed to extract voice archive", exc_info=True)
-                has_error = True
-        self.progress_dialog.Hide()
-        self.progress_dialog.Destroy()
-        del self.progress_dialog
+                shutil.copy(src, dst)
+            except IOError:
+                log.exception(f"Failed to copy file: {file}", exc_info=True)
+                copy_failed = True
+        if copy_failed:
+            raise _VoiceInstallError
 
-        if not has_error:
-            self.success_callback()
-            retval = gui.messageBox(
-            # Translators: content of a message box
-            _(
-                "Successfully downloaded fast variant of the voice  {voice}.\n"
-                "To use this voice, you need to restart NVDA.\n"
-                "Do you want to restart NVDA now?"
-            ).format(
-                voice=self.voice.key
-            ),
-            # Translators: title of a message box
-            _("Voice downloaded"),
-                wx.YES_NO | wx.ICON_WARNING,
-                parent=gui.mainFrame,
-            )
-            if retval == wx.YES:
-                core.restart()
-        else:
-            wx.CallAfter(
-                gui.messageBox,
-                _(
-                    "Cannot download fast variant of the voice {voice}.\nPlease check your connection and try again."
-                ).format(voice=self.voice.key),
-                _("Download failed"),
-                style=wx.ICON_ERROR,
-                parent=gui.mainFrame,
-            )
-            log.exception(
-                f"Failed to download voice.\nException: {result}"
-            )
 
-    def download(self):
-        self.progress_dialog = wx.ProgressDialog(
-            # Translators: title of a progress dialog
-            title=_("Downloading fast variant of the voice {voice}").format(
-                voice=self.voice.key
-            ),
-            # Translators: message of a progress dialog
-            message=_("Retrieving download information..."),
-            parent=gui.mainFrame,
-        )
-        self.progress_dialog.CenterOnScreen()
-        THREAD_POOL_EXECUTOR.submit(self.download_voice_archive).add_done_callback(partial(self._done_callback_wrapper, self.done_callback))
+class PiperRTVoiceDownloader(_BaseVoiceDownloader):
+    def __init__(self, voice: PiperVoice, success_callback):
+        self.rt_download_url = voice.get_rt_variant_download_url()
+        super().__init__(voice, success_callback)
+
+    def _progress_title(self):
+        # Translators: title of a progress dialog
+        return _("Downloading fast variant of the voice {voice}").format(voice=self.voice.key)
+
+    def _success_message(self):
+        # Translators: content of a message box
+        return _(
+            "Successfully downloaded fast variant of the voice  {voice}.\n"
+            "To use this voice, you need to restart NVDA.\n"
+            "Do you want to restart NVDA now?"
+        ).format(voice=self.voice.key)
+
+    def _failure_message(self):
+        return _(
+            "Cannot download fast variant of the voice {voice}.\nPlease check your connection and try again."
+        ).format(voice=self.voice.key)
+
+    def _download_work(self):
+        return self.download_voice_archive()
 
     def download_voice_archive(self):
         voice_name = self.rt_download_url.split("/")[-1].strip()
@@ -454,16 +442,12 @@ class PiperRTVoiceDownloader:
 
         return target_file
 
-    @staticmethod
-    def _done_callback_wrapper(done_callback, future):
-        if done_callback is None:
-            return
+    def _install(self, result):
         try:
-            result = future.result()
-        except Exception as e:
-            done_callback(e)
-        else:
-            done_callback(result)
+            install_voice_from_tar_archive(result, DENGJEN_VOICES_DIR)
+        except Exception:
+            log.exception("Failed to extract voice archive", exc_info=True)
+            raise _VoiceInstallError
 
 
 def _voice_key_from_filename(stem):

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 import tarfile
+from concurrent.futures import Future
 from contextlib import contextmanager
 from unittest.mock import MagicMock
 
@@ -694,3 +695,116 @@ class TestPiperRTVoiceDownloader:
 
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
+
+
+class _SyncExecutor:
+    """Stand-in for THREAD_POOL_EXECUTOR that runs work inline, so `.download()`
+    can be tested without waiting on a real background thread."""
+
+    def submit(self, fn, *args, **kwargs):
+        future = Future()
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(result)
+        return future
+
+
+class TestDownloadWiresProgressDialogToInstall:
+    """`.download()`, `_progress_title`, `_success_message`, and
+    `_failure_message` are the shared _BaseVoiceDownloader machinery neither
+    class's other tests exercise -- those go through done_callback()/
+    download_voice_files()/download_voice_archive() directly instead."""
+
+    @pytest.fixture
+    def sync_executor(self, monkeypatch):
+        monkeypatch.setattr(voice_download, "THREAD_POOL_EXECUTOR", _SyncExecutor())
+
+    @pytest.fixture
+    def progress_dialog(self, monkeypatch):
+        instance = MagicMock()
+        dialog_cls = MagicMock(return_value=instance)
+        monkeypatch.setattr(voice_download.wx, "ProgressDialog", dialog_cls)
+        return dialog_cls, instance
+
+    def test_standard_download_uses_the_voice_progress_title_and_installs(
+        self, tmp_path, monkeypatch, sync_executor, progress_dialog
+    ):
+        dialog_cls, __ = progress_dialog
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        body = b"model-bytes"
+        file = PiperVoiceFile(
+            file_path="en/en_US-lessac-medium.onnx",
+            size_in_bytes=len(body),
+            md5hash=hashlib.md5(body).hexdigest(),
+        )
+        fake_request = _FakeMureq(stream_responses=[
+            _FakeResponse(status=200, headers={"Content-Type": "application/octet-stream"}, body=body),
+        ])
+        monkeypatch.setattr(voice_download, "request", fake_request)
+        voice = _piper_voice(key="en_US-lessac-medium", files=[file])
+        downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
+
+        downloader.download()
+
+        assert dialog_cls.call_args.kwargs["title"] == "Downloading voice en_US-lessac-medium"
+        installed = voices_dir / "en_US-lessac-medium" / file.name
+        assert installed.read_bytes() == body
+        downloader.success_callback.assert_called_once()
+
+    def test_rt_download_uses_the_fast_variant_progress_title_and_installs(
+        self, tmp_path, monkeypatch, sync_executor, progress_dialog
+    ):
+        dialog_cls, __ = progress_dialog
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        tar_path = _make_tar(tmp_path, "en_US-lessac-medium.tar.gz", {
+            "en_US-lessac+RT-medium.onnx": b"rt-model",
+            "en_US-lessac+RT-medium.onnx.json": b"{}",
+        })
+        body = tar_path.read_bytes()
+        fake_request = _FakeMureq(stream_responses=[
+            _FakeResponse(status=200, headers={"Content-Length": str(len(body))}, body=body),
+        ])
+        monkeypatch.setattr(voice_download, "request", fake_request)
+        voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
+        downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
+
+        downloader.download()
+
+        assert dialog_cls.call_args.kwargs["title"] == "Downloading fast variant of the voice en_US-lessac-medium"
+        installed = voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
+        assert installed.read_bytes() == b"rt-model"
+        downloader.success_callback.assert_called_once()
+
+    def test_standard_and_rt_failure_messages_differ(
+        self, tmp_path, monkeypatch, sync_executor, progress_dialog
+    ):
+        # Both go through the same _BaseVoiceDownloader.done_callback -- this
+        # guards against the two subclasses' _failure_message hooks getting
+        # mixed up.
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        messagebox_mock = MagicMock()
+        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        fake_request = _FakeMureq(stream_responses=[_FakeResponse(status=404)])
+        monkeypatch.setattr(voice_download, "request", fake_request)
+
+        voice = _piper_voice(key="en_US-lessac-medium", files=[
+            PiperVoiceFile(file_path="en/f.onnx", size_in_bytes=1, md5hash="x"),
+        ])
+        PiperVoiceDownloader(voice, success_callback=MagicMock()).download()
+        std_message = messagebox_mock.call_args.args[0]
+
+        messagebox_mock.reset_mock()
+        fake_request._stream_responses.append(_FakeResponse(status=404))
+        rt_voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
+        PiperRTVoiceDownloader(rt_voice, success_callback=MagicMock()).download()
+        rt_message = messagebox_mock.call_args.args[0]
+
+        assert std_message != rt_message
+        assert "fast variant" not in std_message
+        assert "fast variant" in rt_message


### PR DESCRIPTION
Closes #113 (partial — the downloader duplication item; rest of that issue is separate follow-up work).

## Summary

`PiperVoiceDownloader` and `PiperRTVoiceDownloader` duplicated `update_progress`, `done_callback`, `download`, and `_done_callback_wrapper` almost verbatim (~90% identical), differing only in the install step and a handful of message strings.

## Changes

- `addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py` — extract `_BaseVoiceDownloader` holding the shared `__init__`, `update_progress`, `download`, `done_callback`, and `_done_callback_wrapper`. Each subclass now only implements small hooks: `_install`, `_progress_title`, `_success_message`, `_failure_message`, `_download_work`.
- Public API unchanged: `PiperVoiceDownloader.download_voice_files`/`_do_download_file` and `PiperRTVoiceDownloader.download_voice_archive`/`_do_download_archive` keep their names and signatures. Behavior on hash mismatch, copy failure, and archive-extraction failure is preserved exactly (verified by existing tests).

## Test plan

- [x] `python3 -m pytest tests/test_voice_download.py -q` — 71 passed.
- [x] `python3 -m pytest tests/ -q` — full suite: 313 passed, 8 skipped (pre-existing), unchanged.
- [ ] CI build + test green.