### PR TITLE
chore: update repo URLs for zirekhq org migration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
           stale-issue-message: |
             This issue has been waiting on a reproducer for 30 days with no activity, so it's been marked as `stale`.
 
-            If you can still reproduce on the latest [release](https://github.com/austek/dengjen-nvda/releases/latest), please reply with:
+            If you can still reproduce on the latest [release](https://github.com/zirekhq/dengjen-nvda/releases/latest), please reply with:
             - The exact NVDA version and add-on version
             - A minimal reproducer (steps, expected vs. actual behavior)
             - The relevant NVDA log slice
@@ -40,4 +40,4 @@ jobs:
           close-issue-message: |
             Closing as stale — no reproducer was received in 44 days.
 
-            If you hit this on a recent release, please open a fresh issue using the [bug report template](https://github.com/austek/dengjen-nvda/issues/new/choose), which collects the diagnostic info up-front. Thanks for the original report regardless.
+            If you hit this on a recent release, please open a fresh issue using the [bug report template](https://github.com/zirekhq/dengjen-nvda/issues/new/choose), which collects the diagnostic info up-front. Thanks for the original report regardless.

--- a/buildVars.py
+++ b/buildVars.py
@@ -38,9 +38,9 @@ addon_info = AddonInfo(
 	# Author(s)
 	addon_author="Musharraf Omer (original) <ibnomer2011@hotmail.com>, Ali Ustek (maintainer) <13117393+austek@users.noreply.github.com>",
 	# URL for the add-on documentation support
-	addon_url="https://github.com/austek/dengjen-nvda",
+	addon_url="https://github.com/zirekhq/dengjen-nvda",
 	# URL for the add-on repository where the source code can be found
-	addon_sourceURL="https://github.com/austek/dengjen-nvda",
+	addon_sourceURL="https://github.com/zirekhq/dengjen-nvda",
 	# Documentation file name
 	addon_docFileName="readme.html",
 	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)

--- a/tests/test_buildvars.py
+++ b/tests/test_buildvars.py
@@ -154,8 +154,8 @@ class TestAddonIdentity:
         assert INFO["addon_summary"] == "Dengjen Neural Voices"
 
     def test_urls_point_at_the_renamed_repo(self):
-        assert INFO["addon_url"] == "https://github.com/austek/dengjen-nvda"
-        assert INFO["addon_sourceURL"] == "https://github.com/austek/dengjen-nvda"
+        assert INFO["addon_url"] == "https://github.com/zirekhq/dengjen-nvda"
+        assert INFO["addon_sourceURL"] == "https://github.com/zirekhq/dengjen-nvda"
 
     def test_original_author_is_credited_first(self):
         assert INFO["addon_author"].startswith("Musharraf Omer (original)")


### PR DESCRIPTION
## Summary
- Repo was transferred from `austek/dengjen-nvda` to `zirekhq/dengjen-nvda` for better community support and room for additional maintainers.
- Updates `addon_url`/`addon_sourceURL` in `buildVars.py`, the release/issue links in `stale.yml`, and the matching test assertions to point at the canonical org path.
- `build_addon.yml`'s `REPO` derives from `GITHUB_REPOSITORY`, so it needed no change. `sonar-project.properties` (SonarCloud project key/org) is a separate SonarCloud-side identity, untouched here.

## Why
GitHub redirects old clone/release URLs automatically, but `addon_url`/`addon_sourceURL` ship inside the add-on manifest and get reused in NVDA Add-on Store and Crowdin submissions, so they should point at the canonical path directly rather than rely on the redirect.