### PR TITLE
chore: fix stale memory reference in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,8 +2,8 @@
 # as PRs merge into main. At release time, open the draft, confirm the
 # auto-resolved tag (e.g. v3.2.0-beta.5 for a beta, v3.2.0 for a stable cut),
 # and publish. addon_version in buildVars.py stays strict 3-part semver while
-# the -beta.N pre-release tag lives only in the git tag — see CONTRIBUTING.md
-# and the project_release_workflow memory.
+# the -beta.N pre-release tag lives only in the git tag — see CONTRIBUTING.md's
+# "Cutting a release" section.
 
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'


### PR DESCRIPTION
## Summary
The comment pointed at a Serena \`project_release_workflow\` memory that was never actually created (confirmed via \`list_memories\`). Points at \`CONTRIBUTING.md\`'s "Cutting a release" section instead, which documents the real release process.