### PR TITLE
fix: publish Crowdin sync via PR instead of pushing to main

### DIFF
--- a/.github/scripts/crowdinSync.ps1
+++ b/.github/scripts/crowdinSync.ps1
@@ -5,6 +5,12 @@ $ErrorActionPreference = 'Stop'
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
+# main is protected (PRs + status checks required), so remember where we
+# started to detect new commits and publish them via a branch + PR instead
+# of pushing directly.
+$baseBranch = git symbolic-ref --short HEAD
+$baseCommit = git rev-parse HEAD
+
 $rawAddonId = $env:ADDON_ID
 if ([string]::IsNullOrWhiteSpace($rawAddonId)) {
     Write-Error "Failed to get addon ID."
@@ -205,23 +211,42 @@ else {
     Write-Host "DEBUG: No changes in translations to commit."
 }
 
-# Push all generated commits after successful Crowdin synchronization
-
-$pushOutput = git push 2>&1
+# --- STEP 5: PUBLISH NEW COMMITS VIA PULL REQUEST ---
+# $baseBranch (e.g. main) requires PRs + passing status checks, so new
+# commits are pushed to a dedicated branch and opened/updated as a PR
+# instead of being pushed directly.
 
 $repository = $env:GITHUB_REPOSITORY
+$headCommit = git rev-parse HEAD
 
-Write-Host $pushOutput
+if ($headCommit -eq $baseCommit) {
 
-if ($LASTEXITCODE -ne 0) {
-
-    Write-Host "ERROR: Failed to push commits to $repository."
+    Write-Host "DEBUG: No new commits to publish."
 }
-elseif ($pushOutput -match "Everything up-to-date") {
+elseif ([string]::IsNullOrWhiteSpace($env:PR_SYNC_TOKEN)) {
 
-    Write-Host "INFO: No new commits needed to be pushed."
+    Write-Host "WARNING: PR_SYNC_TOKEN is not set; skipping publish. New commits exist only in this run's checkout."
 }
 else {
 
-    Write-Host "SUCCESS: New commits successfully pushed to $repository."
+    $env:GH_TOKEN = $env:PR_SYNC_TOKEN
+    $l10nBranch = "l10n/crowdin-sync"
+
+    git branch -f $l10nBranch HEAD
+    git push --force origin "${l10nBranch}:${l10nBranch}"
+
+    $existingPr = gh pr list --repo $repository --base $baseBranch --head $l10nBranch --state open --json number --jq ".[0].number"
+
+    if ([string]::IsNullOrWhiteSpace($existingPr)) {
+
+        gh pr create --repo $repository --base $baseBranch --head $l10nBranch `
+            --title "l10n: sync translations from Crowdin" `
+            --body "Automated translation sync from Crowdin. Review before merging."
+
+        Write-Host "SUCCESS: Opened a new translation sync PR."
+    }
+    else {
+
+        Write-Host "SUCCESS: Updated existing translation sync PR #$existingPr."
+    }
 }

--- a/.github/workflows/crowdinL10n.yml
+++ b/.github/workflows/crowdinL10n.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: windows-2025
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Random startup delay (0-5 minutes)
@@ -37,8 +38,14 @@ jobs:
           submodules: true
           persist-credentials: false
       - name: Configure git remote authentication
+        # main requires PRs, so translations are published via PR (see
+        # crowdinSync.ps1) using a PAT: GITHUB_TOKEN-authored pushes/PRs
+        # don't trigger the required status checks needed to merge.
+        if: ${{ secrets.PR_SYNC_TOKEN }}
         shell: pwsh
-        run: git remote set-url origin "https://x-access-token:${env:GH_TOKEN}@github.com/${env:GITHUB_REPOSITORY}.git"
+        env:
+          PR_SYNC_TOKEN: ${{ secrets.PR_SYNC_TOKEN }}
+        run: git remote set-url origin "https://x-access-token:${env:PR_SYNC_TOKEN}@github.com/${env:GITHUB_REPOSITORY}.git"
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -66,4 +73,5 @@ jobs:
         shell: pwsh
         env:
           ADDON_ID: ${{ steps.getAddonInfo.outputs.addonId }}
+          PR_SYNC_TOKEN: ${{ secrets.PR_SYNC_TOKEN }}
         run: ./.github/scripts/crowdinSync.ps1


### PR DESCRIPTION
## Description of your changes
The scheduled `crowdinL10n.yml` run failed pushing to `main` with `GH013` — the OSS Core Protections ruleset requires PRs and passing status checks, so a direct `git push` is always rejected regardless of translation content (confirmed in the failed run: Crowdin sync itself succeeded, only the final push was blocked).

`crowdinSync.ps1` now pushes any new commits to a dedicated `l10n/crowdin-sync` branch and opens/updates a PR against the base branch instead. This requires a PAT stored as `PR_SYNC_TOKEN` (not yet added) because `GITHUB_TOKEN`-authored pushes/PRs don't trigger the required status checks needed to merge. Until that secret exists, the job still runs the Crowdin upload/import side and just logs a warning instead of failing.

## JIRA reference
N/A

## Impact Analysis
No behavior change outside this workflow. Once `PR_SYNC_TOKEN` (fine-grained PAT, Contents: write + Pull requests: write, scoped to this repo) is added as a secret, weekly syncs open/update one PR for review instead of attempting to push straight to `main`.

#### Checklist
- [x] Workflow + script validated (YAML parse, logic walkthrough against the failed run's log)
- [ ] `PR_SYNC_TOKEN` secret added (follow-up, not part of this PR)