### PR TITLE
fix: use env indirection for PR_SYNC_TOKEN check in crowdin workflow

### DIFF
--- a/.github/workflows/crowdinL10n.yml
+++ b/.github/workflows/crowdinL10n.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   crowdinAuthToken: ${{ secrets.CROWDIN_TOKEN }}
+  hasPrSyncToken: ${{ secrets.PR_SYNC_TOKEN }}
   GH_TOKEN: ${{ github.token }}
   CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || 780748 }}
   L10N_UTIL_CONFIG: ${{ vars.L10N_UTIL_CONFIG || 'addon' }}
@@ -41,7 +42,7 @@ jobs:
         # main requires PRs, so translations are published via PR (see
         # crowdinSync.ps1) using a PAT: GITHUB_TOKEN-authored pushes/PRs
         # don't trigger the required status checks needed to merge.
-        if: ${{ secrets.PR_SYNC_TOKEN }}
+        if: ${{ env.hasPrSyncToken }}
         shell: pwsh
         env:
           PR_SYNC_TOKEN: ${{ secrets.PR_SYNC_TOKEN }}


### PR DESCRIPTION
## Description of your changes
`.github/workflows/crowdinL10n.yml` used `if: \${{ secrets.PR_SYNC_TOKEN }}` on a step. `secrets` is not a valid context inside a step-level `if:` — `actionlint` confirms this is rejected outright, which explains the manual-trigger run that sat `queued` for 3 days (GitHub can't schedule jobs for an invalid workflow file) and the phantom 0-job "failure" runs on every push touching this file.

Fixed by mirroring the existing `crowdinAuthToken`/`env.crowdinAuthToken` pattern already in this file: added `hasPrSyncToken: \${{ secrets.PR_SYNC_TOKEN }}` to workflow-level `env:`, and changed the step to `if: \${{ env.hasPrSyncToken }}`. Verified clean with `actionlint`.

## JIRA reference
N/A

## Impact Analysis
Fixes the crowdin l10n workflow so it can run at all — it was entirely broken (not just failing at the push step) since PR #128 merged. No other workflow affected.

#### Checklist
- [x] `actionlint` passes on the modified file