### PR TITLE
fix: capitalize Dengjen brand name in French translation

### DIFF
--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -394,7 +394,7 @@ msgstr "Gestionnaire de &voix Dengjen..."
 #. Translators: Dengjen's voice manager menu item help
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:51
 msgid "Open the voice manager to preview, install or download dengjen voices"
-msgstr "Ouvrir le gestionnaire de voix pour prévisualiser, installer ou télécharger des voix dengjen"
+msgstr "Ouvrir le gestionnaire de voix pour prévisualiser, installer ou télécharger des voix Dengjen"
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:67
 msgid "No Dengjen voice was found.\n"


### PR DESCRIPTION
### Description of your changes
Follow-up to #130. CodeRabbit's second review round landed after that PR was already merged, catching that `nvda.po:397` was the sole string using lowercase `dengjen` — every other occurrence in the French catalog capitalizes the brand name (e.g. "Gestionnaire de voix Dengjen", "Voix neuronales de Dengjen"). This aligns it.

### JIRA reference
N/A

### Impact Analysis
French-locale string only; no code or behavior change. Same regression risk as #130: the string is Crowdin-sourced and will be overwritten on the next sync unless corrected there too.

#### Checklist
- [x] Single-line string fix, verified against the rest of the catalog for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected capitalization of “Dengjen” in the French voice-manager help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->