### PR TITLE
chore: add actionlint pre-commit hook and satisfy it in existing workflows

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -206,12 +206,14 @@ jobs:
         TAG=${GITHUB_REF#refs/tags/}
         REPO="${GITHUB_REPOSITORY}"
         DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ADDON_FILE}"
-        echo "## NVDA Add-on Store submission values" >> "$GITHUB_STEP_SUMMARY"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
-        echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
-        echo "| **Download URL** | \`${DOWNLOAD_URL}\` |" >> "$GITHUB_STEP_SUMMARY"
-        echo "| **SHA256** | \`${SHA256}\` |" >> "$GITHUB_STEP_SUMMARY"
-        echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "Use these values when filling in the [Add-on Store registration form](https://github.com/nvaccess/addon-datastore/issues/new?template=registerAddon.yml)." >> "$GITHUB_STEP_SUMMARY"
+        {
+          echo "## NVDA Add-on Store submission values"
+          echo ""
+          echo "| Field | Value |"
+          echo "|---|---|"
+          echo "| **Download URL** | \`${DOWNLOAD_URL}\` |"
+          echo "| **SHA256** | \`${SHA256}\` |"
+          echo ""
+          echo "Use these values when filling in the [Add-on Store registration form](https://github.com/nvaccess/addon-datastore/issues/new?template=registerAddon.yml)."
+        } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/crowdinL10n.yml
+++ b/.github/workflows/crowdinL10n.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   crowdinAuthToken: ${{ secrets.CROWDIN_TOKEN }}
-  hasPrSyncToken: ${{ secrets.PR_SYNC_TOKEN }}
+  hasPrSyncToken: ${{ secrets.PR_SYNC_TOKEN != '' }}
   GH_TOKEN: ${{ github.token }}
   CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID || 780748 }}
   L10N_UTIL_CONFIG: ${{ vars.L10N_UTIL_CONFIG || 'addon' }}
@@ -42,7 +42,7 @@ jobs:
         # main requires PRs, so translations are published via PR (see
         # crowdinSync.ps1) using a PAT: GITHUB_TOKEN-authored pushes/PRs
         # don't trigger the required status checks needed to merge.
-        if: ${{ env.hasPrSyncToken }}
+        if: env.hasPrSyncToken == 'true'
         shell: pwsh
         env:
           PR_SYNC_TOKEN: ${{ secrets.PR_SYNC_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
     rev: v1.28.0
     hooks:
       - id: zizmor
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
## Description of your changes
Adds the `actionlint` pre-commit hook so workflow-file mistakes (like the untyped-`if:` bug fixed in #129/#133) get caught locally before CI. `crowdinL10n.yml`'s `PR_SYNC_TOKEN` gate is tightened to an explicit string comparison (`env.hasPrSyncToken == 'true'`) to satisfy the hook. `build_addon.yml`'s repeated `>> $GITHUB_STEP_SUMMARY` echo chain is collapsed into one redirected block.

## JIRA reference
N/A

## Impact Analysis
CI/tooling only — no runtime addon code touched. `crowdinL10n.yml` behavior is unchanged (non-empty secret still gates the step); `build_addon.yml` output is byte-identical, just fewer file opens.

#### Checklist
- [x] No functional/runtime code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow summary formatting without changing its content.
  * Clarified authentication checks in localization automation.
  * Added automated validation for workflow syntax to help catch configuration errors earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->