### PR TITLE
ci: add lint/audit job, zizmor linting, and upstream-watch

### DIFF
--- a/.github/scripts/checkTranslation.py
+++ b/.github/scripts/checkTranslation.py
@@ -2,143 +2,150 @@
 # This file is covered by the GNU General Public License.
 # See the file COPYING for more details.
 
-import sys
 import os
+import sys
+
 from crowdin_api import CrowdinClient
 
 
-def findFileId(client: CrowdinClient, projectId: int, baseTarget: str, searchExt: str) -> int | None:
-	"""
-	Iterates through all project files (using pagination) to find the ID of the source file matching the target name and extension.
+def findFileId(
+    client: CrowdinClient, projectId: int, baseTarget: str, searchExt: str
+) -> int | None:
+    """
+    Iterates through all project files (using pagination) to find the ID of the source file matching the target name and extension.
 
-	:param client: The Crowdin API client instance.
-	:param projectId: The ID of the Crowdin project.
-	:param base_target: The base name of the file (e.g., 'myAddon).
-	:param search_ext: The extension to look for (e.g., '.pot').
-	:return: The file ID if found, otherwise None.
-	"""
-	offset = 0
-	limit = 100
+    :param client: The Crowdin API client instance.
+    :param projectId: The ID of the Crowdin project.
+    :param base_target: The base name of the file (e.g., 'myAddon).
+    :param search_ext: The extension to look for (e.g., '.pot').
+    :return: The file ID if found, otherwise None.
+    """
+    offset = 0
+    limit = 100
 
-	while True:
-		resp = client.source_files.list_files(
-			projectId=projectId,
-			limit=limit,
-			offset=offset,
-		)
+    while True:
+        resp = client.source_files.list_files(
+            projectId=projectId,
+            limit=limit,
+            offset=offset,
+        )
 
-		data = resp["data"]
-		for f in data:
-			path_crowdin = f["data"]["path"].lower()
-			# Check if the path ends with addon_id.pot or addon_id.xliff.
-			if path_crowdin.endswith(f"{baseTarget}{searchExt}"):
-				fileId = f["data"]["id"]
-				print(f"DEBUG: Match found: {path_crowdin} (ID: {fileId})")
-				return fileId
+        data = resp["data"]
+        for f in data:
+            path_crowdin = f["data"]["path"].lower()
+            # Check if the path ends with addon_id.pot or addon_id.xliff.
+            if path_crowdin.endswith(f"{baseTarget}{searchExt}"):
+                fileId = f["data"]["id"]
+                print(f"DEBUG: Match found: {path_crowdin} (ID: {fileId})")
+                return fileId
 
-		if len(data) < limit:
-			break
+        if len(data) < limit:
+            break
 
-		offset += limit
+        offset += limit
 
-	return None
+    return None
 
 
 def getScoreFromApi(fileNameToSearch: str, langId: str) -> float:
-	"""
-	Retrieves the translation progress score for a specific language and file.
-	Handles pagination for both file listing and language status.
+    """
+    Retrieves the translation progress score for a specific language and file.
+    Handles pagination for both file listing and language status.
 
-	:param fileNameToSearch: The local path or name of the file to check.
-	:param langId: The language code (e.g., 'fr' or 'pt_BR').
-	:return: The translation ratio between 0.0 and 1.0.
-	"""
-	token = os.environ.get("crowdinAuthToken")
-	projectIdEnv = os.environ.get("CROWDIN_PROJECT_ID")
+    :param fileNameToSearch: The local path or name of the file to check.
+    :param langId: The language code (e.g., 'fr' or 'pt_BR').
+    :return: The translation ratio between 0.0 and 1.0.
+    """
+    token = os.environ.get("crowdinAuthToken")
+    projectIdEnv = os.environ.get("CROWDIN_PROJECT_ID")
 
-	if not token or not projectIdEnv:
-		print("ERROR: Missing environment variables 'crowdinAuthToken' or 'CROWDIN_PROJECT_ID'.")
-		return 0.0
+    if not token or not projectIdEnv:
+        print(
+            "ERROR: Missing environment variables 'crowdinAuthToken' or 'CROWDIN_PROJECT_ID'."
+        )
+        return 0.0
 
-	client = CrowdinClient(token=token)
-	projectId = int(projectIdEnv)
+    client = CrowdinClient(token=token)
+    projectId = int(projectIdEnv)
 
-	try:
-		# Clean and prepare search patterns.
-		# Example: 'addon/locale/fr/LC_MESSAGES/myAddon.po' -> base_target: 'myAddon'.
-		baseTarget = fileNameToSearch.replace("\\", "/").split("/")[-1].rsplit(".", 1)[0].lower()
-		extTarget = fileNameToSearch.split(".")[-1].lower()
+    try:
+        # Clean and prepare search patterns.
+        # Example: 'addon/locale/fr/LC_MESSAGES/myAddon.po' -> base_target: 'myAddon'.
+        baseTarget = (
+            fileNameToSearch.replace("\\", "/").split("/")[-1].rsplit(".", 1)[0].lower()
+        )
+        extTarget = fileNameToSearch.split(".")[-1].lower()
 
-		# On Crowdin, the source for a .po file is usually a .pot file.
-		searchExt = ".pot" if extTarget == "po" else f".{extTarget}"
+        # On Crowdin, the source for a .po file is usually a .pot file.
+        searchExt = ".pot" if extTarget == "po" else f".{extTarget}"
 
-		print(f"DEBUG: Searching for source file: {baseTarget}{searchExt}")
+        print(f"DEBUG: Searching for source file: {baseTarget}{searchExt}")
 
-		fileId = findFileId(client, projectId, baseTarget, searchExt)
+        fileId = findFileId(client, projectId, baseTarget, searchExt)
 
-		if fileId is None:
-			print(f"WARNING: File '{baseTarget}{searchExt}' not found on Crowdin.")
-			return 0.0
+        if fileId is None:
+            print(f"WARNING: File '{baseTarget}{searchExt}' not found on Crowdin.")
+            return 0.0
 
-		# Pagination for translation status (Progress).
-		offset = 0
-		limit = 100
+        # Pagination for translation status (Progress).
+        offset = 0
+        limit = 100
 
-		while True:
-			resp = client.translation_status.get_file_progress(
-				projectId=projectId,
-				fileId=fileId,
-				limit=limit,
-				offset=offset,
-			)
+        while True:
+            resp = client.translation_status.get_file_progress(
+                projectId=projectId,
+                fileId=fileId,
+                limit=limit,
+                offset=offset,
+            )
 
-			data = resp["data"]
-			for item in data:
-				langApi = item["data"]["languageId"]
+            data = resp["data"]
+            for item in data:
+                langApi = item["data"]["languageId"]
 
-				# Flexible matching (e.g., 'fr' will match 'fr' or 'fr-FR' from API).
-				# Also handles underscore to dash conversion for Crowdin compatibility
-				if langApi.lower().startswith(langId.lower().replace("_", "-")):
-					progress = float(item["data"]["translationProgress"])
-					return progress
+                # Flexible matching (e.g., 'fr' will match 'fr' or 'fr-FR' from API).
+                # Also handles underscore to dash conversion for Crowdin compatibility
+                if langApi.lower().startswith(langId.lower().replace("_", "-")):
+                    progress = float(item["data"]["translationProgress"])
+                    return progress
 
-			# Check pagination total.
-			total = resp["pagination"]["totalCount"]
-			if offset + limit >= total:
-				break
-			offset += limit
+            # Check pagination total.
+            total = resp["pagination"]["totalCount"]
+            if offset + limit >= total:
+                break
+            offset += limit
 
-		print(f"DEBUG: Language '{langId}' not found in progress list for this file.")
-		return 0.0
+        print(f"DEBUG: Language '{langId}' not found in progress list for this file.")
+        return 0.0
 
-	except Exception as e:
-		print(f"API ERROR: {e}")
-		return 0.0
+    except Exception as e:
+        print(f"API ERROR: {e}")
+        return 0.0
 
 
 def main():
-	if len(sys.argv) < 3:
-		print("Usage: python checkTranslation.py <filePath> <langId>")
-		sys.exit(2)
+    if len(sys.argv) < 3:
+        print("Usage: python checkTranslation.py <filePath> <langId>")
+        sys.exit(2)
 
-	input_file = sys.argv[1]
-	lang = sys.argv[2]
+    input_file = sys.argv[1]
+    lang = sys.argv[2]
 
-	score = getScoreFromApi(input_file, lang)
+    score = getScoreFromApi(input_file, lang)
 
-	# Output formatted for capture by the PowerShell script.
-	print(f"translationRatio={score}")
+    # Output formatted for capture by the PowerShell script.
+    print(f"translationRatio={score}")
 
-	# Identify extension to provide a specific score label.
-	ext = input_file.lower().split(".")[-1]
-	if ext == "md":
-		print(f"mdScore={score}")
-	elif ext == "xliff":
-		print(f"xliffScore={score}")
-	else:
-		# Default to poScore for .po and other localization files.
-		print(f"poScore={score}")
+    # Identify extension to provide a specific score label.
+    ext = input_file.lower().split(".")[-1]
+    if ext == "md":
+        print(f"mdScore={score}")
+    elif ext == "xliff":
+        print(f"xliffScore={score}")
+    else:
+        # Default to poScore for .po and other localization files.
+        print(f"poScore={score}")
 
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/.github/scripts/setOutputs.py
+++ b/.github/scripts/setOutputs.py
@@ -10,12 +10,12 @@ import buildVars
 
 
 def main():
-	addonId = buildVars.addon_info["addon_name"]
-	name = "addonId"
-	value = addonId
-	with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-		_ = f.write(f"{name}={value}\n")
+    addonId = buildVars.addon_info["addon_name"]
+    name = "addonId"
+    value = addonId
+    with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+        _ = f.write(f"{name}={value}\n")
 
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,62 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Install ruff
+        run: 'pip install --only-binary :all: ruff'
+
+      - run: ruff check .
+      - run: ruff format --check .
+
+  # No pip-audit precedent yet in any sibling Python repo (nvda-addon-testkit
+  # doesn't have one either), so pinned dependencies haven't been triaged
+  # against advisories before. Kept non-blocking on this first pass -- mirrors
+  # how the Rust repos' `deny` job separates cheap license/bans/sources checks
+  # from the full `audit` gate -- so findings surface without failing PRs
+  # until someone has looked at them; tighten to a hard gate once that happens.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Install pip-audit
+        run: 'pip install --only-binary :all: pip-audit'
+
+      - name: Audit dependencies
+        continue-on-error: true
+        run: |
+          pip-audit \
+            -r requirements-bootstrap.txt \
+            -r requirements-build.txt \
+            -r requirements-test.txt \
+            -r requirements-test-e2e.txt \
+            -r requirements-test-gui.txt \
+            -r requirements-l10n.txt

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,81 @@
+name: Upstream Watch
+
+# Tracks divergence from mush42/sonata-nvda, the upstream this repo was
+# forked from (see readme.md: the original author, Musharraf Omer (@mush42),
+# announced that commercial contract conflicts prevent him from continuing
+# to maintain the open-source add-on; this repo continues the project as a
+# fork). This repo's own git history is that fork lineage, so it shares
+# commit ancestry with mush42/sonata-nvda directly -- the compare API below
+# works the same way it would for any GitHub fork. Rather than auto-merging
+# upstream/main -- which would risk clobbering this fork's own divergence --
+# this just keeps one tracking issue current so a human decides when and how
+# to pull changes in.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # weekly, Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: upstream-watch
+  cancel-in-progress: true
+
+jobs:
+  check-upstream:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Compare against mush42/sonata-nvda main
+        id: compare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          compare=$(gh api "repos/${{ github.repository }}/compare/main...mush42:main")
+          ahead_by=$(echo "$compare" | jq -r '.ahead_by')
+          echo "ahead_by=$ahead_by" >> "$GITHUB_OUTPUT"
+          echo "$compare" | jq -r '.commits[] | "- [\(.sha[0:7])](\(.html_url)) \(.commit.message | split("\n")[0])"' > commits.md
+
+      - name: Ensure tracking label exists
+        if: steps.compare.outputs.ahead_by != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create upstream-sync --repo "${{ github.repository }}" \
+            --color 0e8a16 --description "Tracks divergence from mush42/sonata-nvda upstream" \
+            2>/dev/null || true
+
+      - name: Open or update tracking issue
+        if: steps.compare.outputs.ahead_by != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AHEAD_BY: ${{ steps.compare.outputs.ahead_by }}
+        run: |
+          set -euo pipefail
+          body=$(printf 'Upstream [mush42/sonata-nvda](https://github.com/mush42/sonata-nvda) main is **%s commit(s)** ahead of this fork'\''s main:\n\n%s\n\nCompare: https://github.com/%s/compare/main...mush42:main' \
+            "$AHEAD_BY" "$(cat commits.md)" "${{ github.repository }}")
+          existing=$(gh issue list --repo "${{ github.repository }}" --label upstream-sync --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "${{ github.repository }}" --body "$body"
+          else
+            gh issue create --repo "${{ github.repository }}" \
+              --title "Upstream sync: mush42/sonata-nvda has new commits" \
+              --body "$body" --label upstream-sync
+          fi
+
+      - name: Close tracking issue once caught up
+        if: steps.compare.outputs.ahead_by == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --repo "${{ github.repository }}" --label upstream-sync --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --repo "${{ github.repository }}" \
+              --comment "Caught up with mush42/sonata-nvda main."
+          fi

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: Zizmor
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # required for upload-sarif to upload SARIF files
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3

--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -1,19 +1,15 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
 import os
 import sys
 
-import wx
-
-import core
-import gui
-import globalPluginHandler
-from logHandler import log
-
 import addonHandler
+import core
+import globalPluginHandler
+import gui
+import wx
+from logHandler import log
 
 addonHandler.initTranslation()
 
@@ -23,10 +19,13 @@ _ADDON_ROOT = os.path.abspath(os.path.join(_DIR, os.pardir, os.pardir))
 _TTS_MODULE_DIR = os.path.join(_ADDON_ROOT, "synthDrivers")
 sys.path.insert(0, _TTS_MODULE_DIR)
 try:
-    from dengjen_neural_voices import helpers
-    from dengjen_neural_voices import aio
-    from dengjen_neural_voices import voice_migration
-    from dengjen_neural_voices import DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR
+    from dengjen_neural_voices import (
+        DENGJEN_VOICES_DIR,
+        DengjenTextToSpeechSystem,
+        aio,
+        helpers,
+        voice_migration,
+    )
     from dengjen_neural_voices.adapters.sonata_grpc import SonataGrpcBackend
 finally:
     sys.path.remove(_TTS_MODULE_DIR)
@@ -48,7 +47,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             # Translators: Dengjen's voice manager menu item help
             _("Open the voice manager to preview, install or download dengjen voices"),
         )
-        gui.mainFrame.sysTrayIcon.menu.Bind(wx.EVT_MENU, self.on_manager, self.itemHandle)
+        gui.mainFrame.sysTrayIcon.menu.Bind(
+            wx.EVT_MENU, self.on_manager, self.itemHandle
+        )
 
     def on_manager(self, event):
         manager_dialog = DengjenVoiceManagerDialog()
@@ -58,7 +59,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def _perform_voice_check(self):
         if self.__voice_manager_shown:
             return
-        if not any(DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(SonataGrpcBackend())):
+        if not any(
+            DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+                SonataGrpcBackend()
+            )
+        ):
             retval = gui.messageBox(
                 # Translators: message telling the user that no voice is installed
                 _(

--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -31,6 +31,17 @@ finally:
     sys.path.remove(_TTS_MODULE_DIR)
 del _DIR, _ADDON_ROOT, _TTS_MODULE_DIR
 
+# Re-exported for voice_manager.py and voice_download.py, which reach these
+# via `from . import ...` rather than importing dengjen_neural_voices directly.
+__all__ = [
+    "DENGJEN_VOICES_DIR",
+    "DengjenTextToSpeechSystem",
+    "SonataGrpcBackend",
+    "aio",
+    "helpers",
+    "voice_migration",
+]
+
 from .voice_manager import DengjenVoiceManagerDialog
 
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -1,22 +1,19 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
 from __future__ import annotations
 
-import dataclasses
 import contextlib
+import dataclasses
 import typing
 from concurrent.futures import Future
 
-import wx
-import wx.lib.mixins.listctrl as listmix
-from . import sized_controls as sc
-
-
 import addonHandler
 import gui
+import wx
+import wx.lib.mixins.listctrl as listmix
+
+from . import sized_controls as sc
 
 addonHandler.initTranslation()
 
@@ -250,7 +247,7 @@ class ImmutableObjectListView(DialogListCtrl):
         if set_focus:
             self.set_focused_item(focus_item)
 
-    def get_selected(self) -> typing.Optional[typing.Any]:
+    def get_selected(self) -> typing.Any | None:
         """Return the currently selected object or None."""
         idx = self.GetFocusedItem()
         if idx != wx.NOT_FOUND:

--- a/addon/globalPlugins/dengjen_tts_global_plugin/components.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/components.py
@@ -180,7 +180,7 @@ class ColumnDefn:
     width: int
     string_converter: typing.Callable[[typing.Any], str] | str
 
-    _ALIGNMENT_FLAGS = {
+    _ALIGNMENT_FLAGS: typing.ClassVar = {
         "left": wx.LIST_FORMAT_LEFT,
         "center": wx.LIST_FORMAT_CENTRE,
         "right": wx.LIST_FORMAT_RIGHT,

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -12,7 +10,6 @@ import shutil
 import ssl
 import tarfile
 import tempfile
-import typing
 import urllib.parse
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
@@ -21,37 +18,45 @@ from fnmatch import fnmatch
 from functools import lru_cache, partial
 from hashlib import md5
 from http.client import HTTPException
-from io import BytesIO
 
-import wx
 import addonHandler
 import core
 import gui
+import wx
 from languageHandler import normalizeLanguage
 from logHandler import log
 
 addonHandler.initTranslation()
 
-from . import DengjenTextToSpeechSystem, helpers, DENGJEN_VOICES_DIR, SonataGrpcBackend
+from . import DENGJEN_VOICES_DIR, DengjenTextToSpeechSystem, SonataGrpcBackend, helpers
 
 with helpers.import_bundled_library():
-    import mureq as request
     from concurrent.futures import ThreadPoolExecutor
     from pathlib import Path
 
+    import mureq as request
 
-PIPER_VOICE_LIST_URL = "https://huggingface.co/rhasspy/piper-voices/raw/v1.0.0/voices.json"
-PIPER_VOICE_DOWNLOAD_URL_PREFIX = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0"
+
+PIPER_VOICE_LIST_URL = (
+    "https://huggingface.co/rhasspy/piper-voices/raw/v1.0.0/voices.json"
+)
+PIPER_VOICE_DOWNLOAD_URL_PREFIX = (
+    "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0"
+)
 PIPER_SAMPLES_URL_PREFIX = "https://rhasspy.github.io/piper-samples/samples"
 PIPER_VOICES_JSON_LOCAL_CACHE = os.path.join(DENGJEN_VOICES_DIR, "piper-voices.json")
-RT_VOICE_LIST_URL = "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
-RT_VOICE_DOWNLOAD_URL_PREFIX = "https://huggingface.co/datasets/mush42/piper-rt/resolve/main"
+RT_VOICE_LIST_URL = (
+    "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
+)
+RT_VOICE_DOWNLOAD_URL_PREFIX = (
+    "https://huggingface.co/datasets/mush42/piper-rt/resolve/main"
+)
 
 VOICE_INFO_REGEX = re.compile(
     r"(?P<language>[a-z]+(_|-)?([a-z]+)?)(-|_)"
     r"(?P<name>[a-z0-9_]+(\+RT)?)(-|_)"
     r"(?P<quality>(high|medium|low|x-low|x_low))",
-    re.I
+    re.IGNORECASE,
 )
 THREAD_POOL_EXECUTOR = ThreadPoolExecutor()
 REDIRECT_STATUSES = (301, 302, 303, 307, 308)
@@ -132,9 +137,9 @@ class PiperVoice:
     name: str
     quality: PiperVoiceQualityLevel
     num_speakers: int
-    speaker_id_map: typing.Dict[str, int]
+    speaker_id_map: dict[str, int]
     language: PiperVoiceLanguage
-    files: typing.List[PiperVoiceFile]
+    files: list[PiperVoiceFile]
     has_rt_variant: bool = False
     standard_variant_installed: bool = False
     fast_variant_installed: bool = False
@@ -145,12 +150,14 @@ class PiperVoice:
 
         for data in voice_data:
             file_list = []
-            for (path, finfo) in data["files"].items():
-                file_list.append(PiperVoiceFile(
-                    file_path=path,
-                    size_in_bytes=finfo["size_bytes"],
-                    md5hash=finfo["md5_digest"]
-                ))
+            for path, finfo in data["files"].items():
+                file_list.append(
+                    PiperVoiceFile(
+                        file_path=path,
+                        size_in_bytes=finfo["size_bytes"],
+                        md5hash=finfo["md5_digest"],
+                    )
+                )
             lang_info = data["language"]
             language = PiperVoiceLanguage(
                 code=lang_info["code"],
@@ -160,18 +167,20 @@ class PiperVoice:
                 name_english=lang_info["name_english"],
                 country_english=lang_info["country_english"],
             )
-            retval.append(cls(
-                key=data["key"],
-                name=data["name"],
-                quality=PiperVoiceQualityLevel(data["quality"]),
-                num_speakers=data["num_speakers"],
-                speaker_id_map=data["speaker_id_map"],
-                language=language,
-                files=file_list,
-                has_rt_variant=data["has_rt_variant"],
-                standard_variant_installed=data["standard_variant_installed"],
-                fast_variant_installed=data["fast_variant_installed"]
-            ))
+            retval.append(
+                cls(
+                    key=data["key"],
+                    name=data["name"],
+                    quality=PiperVoiceQualityLevel(data["quality"]),
+                    num_speakers=data["num_speakers"],
+                    speaker_id_map=data["speaker_id_map"],
+                    language=language,
+                    files=file_list,
+                    has_rt_variant=data["has_rt_variant"],
+                    standard_variant_installed=data["standard_variant_installed"],
+                    fast_variant_installed=data["fast_variant_installed"],
+                )
+            )
 
         retval.sort(key=lambda v: v.language.family)
         return retval
@@ -208,7 +217,10 @@ def _get_with_cert_fallback(url, **kwargs):
     except HTTPException as e:
         if not _is_os_trust_store_gap(e):
             raise
-        log.debug("OS trust store missing a root CA; retrying with the vendored CA bundle", exc_info=True)
+        log.debug(
+            "OS trust store missing a root CA; retrying with the vendored CA bundle",
+            exc_info=True,
+        )
         return request.get(url, ssl_context=_fallback_ssl_context(), **kwargs)
 
 
@@ -216,13 +228,20 @@ def _get_with_cert_fallback(url, **kwargs):
 def _yield_response_with_cert_fallback(method, url, **kwargs):
     with ExitStack() as stack:
         try:
-            response = stack.enter_context(request.yield_response(method, url, **kwargs))
+            response = stack.enter_context(
+                request.yield_response(method, url, **kwargs)
+            )
         except HTTPException as e:
             if not _is_os_trust_store_gap(e):
                 raise
-            log.debug("OS trust store missing a root CA; retrying with the vendored CA bundle", exc_info=True)
+            log.debug(
+                "OS trust store missing a root CA; retrying with the vendored CA bundle",
+                exc_info=True,
+            )
             response = stack.enter_context(
-                request.yield_response(method, url, ssl_context=_fallback_ssl_context(), **kwargs)
+                request.yield_response(
+                    method, url, ssl_context=_fallback_ssl_context(), **kwargs
+                )
             )
         yield response
 
@@ -231,7 +250,7 @@ def _yield_response_with_cert_fallback(method, url, **kwargs):
 def _follow_redirects(url, label):
     # mureq does not follow redirects, and HuggingFace serves every file as one.
     for _redirect in range(REDIRECT_LIMIT):
-        with _yield_response_with_cert_fallback('GET', url) as response:
+        with _yield_response_with_cert_fallback("GET", url) as response:
             if response.status in REDIRECT_STATUSES:
                 location = response.getheader("Location")
                 if not location:
@@ -240,11 +259,15 @@ def _follow_redirects(url, label):
                 continue
 
             if response.status != 200:
-                raise RuntimeError(f"Download failed for {label} (status {response.status})")
+                raise RuntimeError(
+                    f"Download failed for {label} (status {response.status})"
+                )
 
             content_type = response.getheader("Content-Type", "").lower()
             if "text/html" in content_type or "xml" in content_type:
-                raise RuntimeError(f"Wrong content-type while downloading {label}: {content_type}")
+                raise RuntimeError(
+                    f"Wrong content-type while downloading {label}: {content_type}"
+                )
 
             yield response
             return
@@ -290,7 +313,9 @@ class _BaseVoiceDownloader:
             parent=gui.mainFrame,
         )
         self.progress_dialog.CenterOnScreen()
-        THREAD_POOL_EXECUTOR.submit(self._download_work).add_done_callback(partial(self._done_callback_wrapper, self.done_callback))
+        THREAD_POOL_EXECUTOR.submit(self._download_work).add_done_callback(
+            partial(self._done_callback_wrapper, self.done_callback)
+        )
 
     def done_callback(self, result):
         # add_done_callback (and so _done_callback_wrapper) runs on the
@@ -306,7 +331,7 @@ class _BaseVoiceDownloader:
             self.progress_dialog.Update(
                 0,
                 # Translators: message shown in the voice download progress dialog
-                _("Installing voice")
+                _("Installing voice"),
             )
             try:
                 self._install(result)
@@ -337,9 +362,7 @@ class _BaseVoiceDownloader:
                 parent=gui.mainFrame,
             )
             error = install_error if install_error is not None else result
-            log.error(
-                f"Failed to download voice.\nException: {error}", exc_info=error
-            )
+            log.error(f"Failed to download voice.\nException: {error}", exc_info=error)
 
     @staticmethod
     def _done_callback_wrapper(done_callback, future):
@@ -397,16 +420,18 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
             self.progress_dialog.Update(
                 0,
                 # Translators: message shown in progress dialog
-                _("Downloading file: {file}").format(file=file.name)
+                _("Downloading file: {file}").format(file=file.name),
             )
-            result = self._do_download_file(file, self.temp_download_dir.name, self.update_progress)
+            result = self._do_download_file(
+                file, self.temp_download_dir.name, self.update_progress
+            )
             retvals.append(result)
 
         return retvals
 
     @classmethod
     def _do_download_file(cls, file, download_dir, progress_callback):
-        target_file = os.path.join(download_dir, file.file_path.replace('/', os.sep))
+        target_file = os.path.join(download_dir, file.file_path.replace("/", os.sep))
         os.makedirs(os.path.dirname(target_file), exist_ok=True)
 
         hasher = md5(usedforsecurity=False)
@@ -422,10 +447,7 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
         return (file, target_file, hasher.hexdigest())
 
     def _install(self, result):
-        hashes = {
-            file.name: (file.md5hash, md5hash)
-            for (file, __, md5hash) in result
-        }
+        hashes = {file.name: (file.md5hash, md5hash) for (file, __, md5hash) in result}
         if not all(expected == actual for expected, actual in hashes.values()):
             log.error("File hashes do not match")
             raise _VoiceInstallError
@@ -437,7 +459,7 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
             dst = os.path.join(voice_dir, file.name)
             try:
                 shutil.copy(src, dst)
-            except IOError:
+            except OSError:
                 log.exception(f"Failed to copy file: {file}", exc_info=True)
                 copy_failed = True
         if copy_failed:
@@ -451,7 +473,9 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
 
     def _progress_title(self):
         # Translators: title of a progress dialog
-        return _("Downloading fast variant of the voice {voice}").format(voice=self.voice.key)
+        return _("Downloading fast variant of the voice {voice}").format(
+            voice=self.voice.key
+        )
 
     def _success_message(self):
         # Translators: content of a message box
@@ -474,13 +498,20 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
         self.progress_dialog.Update(
             0,
             # Translators: message shown in progress dialog
-            _("Downloading file: {file}").format(file=voice_name)
+            _("Downloading file: {file}").format(file=voice_name),
         )
-        result = self._do_download_archive(self.rt_download_url, voice_name, self.temp_download_dir.name, self.update_progress)
+        result = self._do_download_archive(
+            self.rt_download_url,
+            voice_name,
+            self.temp_download_dir.name,
+            self.update_progress,
+        )
         return result
 
     @classmethod
-    def _do_download_archive(cls, download_url, voice_name, download_dir, progress_callback):
+    def _do_download_archive(
+        cls, download_url, voice_name, download_dir, progress_callback
+    ):
         target_file = os.path.join(download_dir, voice_name)
         with _follow_redirects(download_url, voice_name) as response:
             _stream_to_file(
@@ -510,11 +541,13 @@ def _voice_key_from_filename(stem):
     if m is None:
         return None
     info = m.groupdict()
-    return "-".join([
-        normalizeLanguage(info["language"]),
-        info["name"].replace("-", "_"),
-        info["quality"].replace("-", "_"),
-    ])
+    return "-".join(
+        [
+            normalizeLanguage(info["language"]),
+            info["name"].replace("-", "_"),
+            info["quality"].replace("-", "_"),
+        ]
+    )
 
 
 def _voice_key_from_config(config):
@@ -539,24 +572,20 @@ def _voice_key_from_config(config):
             "file to follow that convention, or ensure the bundled config "
             "JSON carries those fields."
         )
-    return "-".join([
-        normalizeLanguage(language),
-        str(dataset).replace("-", "_"),
-        str(quality).replace("-", "_"),
-    ])
+    return "-".join(
+        [
+            normalizeLanguage(language),
+            str(dataset).replace("-", "_"),
+            str(quality).replace("-", "_"),
+        ]
+    )
 
 
 def install_voice_from_tar_archive(tar_path, voices_dir):
     with tarfile.open(tar_path) as tar:
         filenames = {f.name: f for f in tar.getmembers()}
-        onnx_files = list(filter(
-            lambda pth: fnmatch(pth, "*.onnx"),
-            filenames
-        ))
-        config_files = list(filter(
-            lambda pth: fnmatch(pth, "*.json"),
-            filenames
-        ))
+        onnx_files = list(filter(lambda pth: fnmatch(pth, "*.onnx"), filenames))
+        config_files = list(filter(lambda pth: fnmatch(pth, "*.json"), filenames))
         if not (onnx_files and config_files):
             raise FileNotFoundError("Required files not found in archive")
         if len(onnx_files) == 1:
@@ -564,7 +593,9 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
         else:
             voice_key = _voice_key_from_filename(Path(tar_path).stem[:-4])
         if voice_key is None:
-            config = json.loads(tar.extractfile(filenames[config_files[0]]).read().decode("utf-8"))
+            config = json.loads(
+                tar.extractfile(filenames[config_files[0]]).read().decode("utf-8")
+            )
             voice_key = _voice_key_from_config(config)
         voice_folder_name = Path(voices_dir).joinpath(voice_key)
         # voice_key can come from _voice_key_from_config(), which is built
@@ -573,8 +604,13 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
         # voice folder outside voices_dir (e.g. a path separator or "..").
         resolved_voices_dir = Path(voices_dir).resolve()
         resolved_voice_folder = voice_folder_name.resolve()
-        if resolved_voice_folder != resolved_voices_dir and resolved_voices_dir not in resolved_voice_folder.parents:
-            raise ValueError(f"Voice key resolves outside the voices directory: {voice_key!r}")
+        if (
+            resolved_voice_folder != resolved_voices_dir
+            and resolved_voices_dir not in resolved_voice_folder.parents
+        ):
+            raise ValueError(
+                f"Voice key resolves outside the voices directory: {voice_key!r}"
+            )
         voice_folder_name.mkdir(parents=True, exist_ok=True)
         voice_folder_name = os.fspath(voice_folder_name)
         files_to_extract = [*onnx_files, *config_files]
@@ -591,10 +627,12 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
 
 
 def _select_not_installed_voices(voices):
-    installed_voices = DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(SonataGrpcBackend())
+    installed_voices = DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+        SonataGrpcBackend()
+    )
     installed_voice_keys = {voice.key for voice in installed_voices}
     not_installed = []
-    for (key, value) in voices.items():
+    for key, value in voices.items():
         std_key, rt_key = DengjenTextToSpeechSystem.get_voice_variants(key)
         value["standard_variant_installed"] = std_key in installed_voice_keys
         value["fast_variant_installed"] = rt_key in installed_voice_keys
@@ -623,10 +661,7 @@ def _refresh_voices_cache():
     std_voices = std_resp.json()
     rt_resp = _get_with_cert_fallback(RT_VOICE_LIST_URL)
     rt_resp.raise_for_status()
-    rt_voice_names = {
-        vdata["base"]
-        for vdata in rt_resp.json().values()
-    }
+    rt_voice_names = {vdata["base"] for vdata in rt_resp.json().values()}
     voice_list = {}
     for vname, vdata in std_voices.items():
         vdata["has_rt_variant"] = vname in rt_voice_names
@@ -645,4 +680,3 @@ def get_available_voices(force_online=False):
     if voices is None:
         raise RuntimeError("Failed to read the voice list cache that was just written")
     return voices
-

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -149,7 +149,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             content = logic.sanitize_model_card(content)
             gui.messageBox(
                 content,
-                #! Intentionally untranslatable
+                # NOTE: Intentionally untranslatable
                 # Translators: title of a message box showing voice model card
                 _("Model card"),
                 style=wx.ICON_INFORMATION,

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -14,28 +12,36 @@ import tempfile
 import threading
 import winsound
 
-import wx
-from wx.adv import CommandLinkButton
 import addonHandler
 import gui
 import synthDriverHandler
+import wx
 from logHandler import log
+from wx.adv import CommandLinkButton
 
 addonHandler.initTranslation()
 
-from . import DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR, SonataGrpcBackend
-from . import voice_migration
-from . import voice_download
-from . import aio
-from . import helpers
-from .components import AsyncSnakDialog, ColumnDefn, ImmutableObjectListView, SimpleDialog, make_sized_static_box
-from .sized_controls import SizedPanel
+from . import (
+    DENGJEN_VOICES_DIR,
+    DengjenTextToSpeechSystem,
+    SonataGrpcBackend,
+    aio,
+    helpers,
+    voice_download,
+    voice_migration,
+)
 from . import voice_manager_logic as logic
-
+from .components import (
+    AsyncSnakDialog,
+    ColumnDefn,
+    ImmutableObjectListView,
+    SimpleDialog,
+    make_sized_static_box,
+)
+from .sized_controls import SizedPanel
 
 with helpers.import_bundled_library():
     import miniaudio
-    from pathlib import Path
 
 
 class InstalledDengjenVoicesPanel(SizedPanel):
@@ -53,7 +59,10 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                 ColumnDefn(_("Name"), "left", 30, self._get_installed_voice_name),
                 ColumnDefn(
                     # Translators: list view column title
-                    _("Quality"), "center", 30, lambda v: v.properties["quality"].title()
+                    _("Quality"),
+                    "center",
+                    30,
+                    lambda v: v.properties["quality"].title(),
                 ),
                 # Translators: list view column title
                 ColumnDefn(_("Language"), "right", 20, operator.attrgetter("language")),
@@ -62,9 +71,13 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         self.buttons_panel = SizedPanel(self, -1)
         self.buttons_panel.SetSizerType("horizontal")
         # Translators: label for a button for showing voice model card
-        self.model_card_button = wx.Button(self.buttons_panel, -1, _("&Voice model card..."))
+        self.model_card_button = wx.Button(
+            self.buttons_panel, -1, _("&Voice model card...")
+        )
         # Translators: label for a button for removing a voice
-        self.remove_voice_button = wx.Button(self.buttons_panel, -1, _("&Remove voice..."))
+        self.remove_voice_button = wx.Button(
+            self.buttons_panel, -1, _("&Remove voice...")
+        )
         add_voice_button = CommandLinkButton(
             self,
             -1,
@@ -75,7 +88,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                 "Install a voice from a local archive.\n"
                 "The archive contains the voice model and configuration.\n"
                 "The archive should have a (.tar.gz) file extension."
-            )
+            ),
         )
         self.import_voices_button = CommandLinkButton(
             self,
@@ -86,7 +99,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             _(
                 "Copy voices you downloaded with the Sonata Neural Voices add-on.\n"
                 "The originals are left in place, so Sonata keeps working."
-            )
+            ),
         )
         self.import_voices_button.Hide()
         self.Bind(wx.EVT_BUTTON, self.on_model_card, self.model_card_button)
@@ -95,10 +108,12 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         self.Bind(wx.EVT_BUTTON, self._on_import_voices, self.import_voices_button)
 
     def update_voices_list(self, set_focus=False, invalidate_synth_voices_cache=False):
-        voices = list(DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(SonataGrpcBackend()))
-        state = logic.installed_list_state(
-            voices, synthDriverHandler.getSynth().name
+        voices = list(
+            DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+                SonataGrpcBackend()
+            )
         )
+        state = logic.installed_list_state(voices, synthDriverHandler.getSynth().name)
         self.import_voices_button.Show(bool(voice_migration.importable_voice_keys()))
         self.Layout()
         self.buttons_panel.Enable(state.buttons_enabled)
@@ -134,10 +149,10 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             content = logic.sanitize_model_card(content)
             gui.messageBox(
                 content,
-                #! Intentionally untranslatable 
+                #! Intentionally untranslatable
                 # Translators: title of a message box showing voice model card
                 _("Model card"),
-                style=wx.ICON_INFORMATION
+                style=wx.ICON_INFORMATION,
             )
         else:
             gui.messageBox(
@@ -145,7 +160,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                 _("Model card information is unavailable for this voice"),
                 # Translators: title of a message box
                 _("Not found"),
-                style=wx.ICON_WARNING
+                style=wx.ICON_WARNING,
             )
 
     def on_remove_voice(self, event):
@@ -162,18 +177,17 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                 _("You cannot remove the currently active voice!"),
                 # Translators: title of a message box
                 _("Error"),
-                style=wx.ICON_ERROR
+                style=wx.ICON_ERROR,
             )
             return
         retval = gui.messageBox(
             # Translators: message in a message box
-            _(
-                "Do you want to remove this voice?\n"
-                "Voice: {name}"
-            ).format(name=selected.key),
+            _("Do you want to remove this voice?\nVoice: {name}").format(
+                name=selected.key
+            ),
             # Translators: title of a message box
             _("Remove voice?"),
-            style=wx.YES_NO|wx.ICON_WARNING
+            style=wx.YES_NO | wx.ICON_WARNING,
         )
         if retval == wx.YES:
             try:
@@ -185,7 +199,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                     _("Failed to remove voice.\nSee NVDA's log for more details."),
                     # Translators: title of a message box
                     _("Failed"),
-                    style=wx.ICON_WARNING
+                    style=wx.ICON_WARNING,
                 )
             else:
                 gui.messageBox(
@@ -193,9 +207,11 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                     _("Voice removed successfully."),
                     # Translators: title of a message box
                     _("Done"),
-                    style=wx.ICON_INFORMATION
+                    style=wx.ICON_INFORMATION,
                 )
-                self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
+                self.update_voices_list(
+                    set_focus=True, invalidate_synth_voices_cache=True
+                )
 
     def _on_import_voices(self, event):
         voice_keys = voice_migration.importable_voice_keys()
@@ -251,9 +267,11 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             defaultDir=wx.GetUserHome(),
             wildcard=(
                 # Translators: file dialog filter for tar archives
-                _("Tar archives (*.tar.gz, *.tgz)") + "|*.tar.gz;*.tgz|"
+                _("Tar archives (*.tar.gz, *.tgz)")
+                + "|*.tar.gz;*.tgz|"
                 # Translators: file dialog filter for all files
-                + _("All files") + "|*.*"
+                + _("All files")
+                + "|*.*"
             ),
             style=wx.FD_OPEN,
         )
@@ -287,9 +305,9 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         else:
             gui.messageBox(
                 # Translators: message telling the user that installing the voice is successful
-                _(
-                    "Voice {voice} has been installed successfully."
-                ).format(voice=voice_key),
+                _("Voice {voice} has been installed successfully.").format(
+                    voice=voice_key
+                ),
                 _("Voice installed successfully"),
                 style=wx.ICON_INFORMATION,
             )
@@ -309,17 +327,13 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         wx.StaticText(self, -1, _("Language"))
         self.language_choice = wx.Choice(self, -1, choices=[])
         wx.StaticText(self, -1, _("Available voices"))
-        voice_list_columns=[
+        voice_list_columns = [
             # Translators: list view column title
             ColumnDefn(_("Name"), "left", 30, operator.attrgetter("name")),
             # Translators: list view column title
             ColumnDefn(_("Quality"), "center", 30, operator.attrgetter("quality")),
         ]
-        self.voices_list = ImmutableObjectListView(
-            self,
-            -1,
-            columns=voice_list_columns
-        )
+        self.voices_list = ImmutableObjectListView(self, -1, columns=voice_list_columns)
         self.voices_list.SetSizerProps(expand=True)
         self.buttons_panel = SizedPanel(self, -1)
         self.buttons_panel.SetSizerType("vertical")
@@ -333,26 +347,38 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         dl_buttons_panel = SizedPanel(self.buttons_panel, -1)
         dl_buttons_panel.SetSizerType("horizontal")
         # Translators: label of a button to download the standard variant of the voice
-        self.download_std_btn = wx.Button(dl_buttons_panel, -1, _("&Download standard variant"))
+        self.download_std_btn = wx.Button(
+            dl_buttons_panel, -1, _("&Download standard variant")
+        )
         # Translators: label of a button to download the fast variant of voice
-        self.download_rt_btn = wx.Button(dl_buttons_panel, -1, _("Download &fast variant"))
+        self.download_rt_btn = wx.Button(
+            dl_buttons_panel, -1, _("Download &fast variant")
+        )
         # Translators: label of a button to refresh the voices list
         refresh_list_btn = wx.Button(self, -1, _("&Refresh voices list"))
-        self.Bind(wx.EVT_CHOICE, self.on_language_selection_change, self.language_choice)
+        self.Bind(
+            wx.EVT_CHOICE, self.on_language_selection_change, self.language_choice
+        )
         self.Bind(wx.EVT_LIST_ITEM_SELECTED, self.on_voice_selected, self.voices_list)
         self.Bind(wx.EVT_BUTTON, self.on_preview, self.preview_btn)
         self.Bind(wx.EVT_BUTTON, self.on_download, self.download_std_btn)
         self.Bind(wx.EVT_BUTTON, self.on_download_rt, self.download_rt_btn)
-        self.Bind(wx.EVT_BUTTON, lambda e: self.populate_list(force_online=True), refresh_list_btn)
+        self.Bind(
+            wx.EVT_BUTTON,
+            lambda e: self.populate_list(force_online=True),
+            refresh_list_btn,
+        )
         self.speaker_choice.Enable(False)
         self.buttons_panel.Enable(False)
 
     def populate_list(self, force_online=False):
-        if not force_online and  self.__already_populated.is_set():
+        if not force_online and self.__already_populated.is_set():
             return
         AsyncSnakDialog(
             executor=voice_download.THREAD_POOL_EXECUTOR,
-            func=functools.partial(voice_download.get_available_voices, force_online=force_online),
+            func=functools.partial(
+                voice_download.get_available_voices, force_online=force_online
+            ),
             done_callback=self._voice_list_retrieved_callback,
             parent=self,
             # Translators: message in a dialog
@@ -371,7 +397,9 @@ class OnlineDengjenVoicesPanel(SizedPanel):
             log.exception("Failed to retreive voices list", exc_info=True)
             wx.CallAfter(
                 gui.messageBox,
-                _("Could not retrieve voice list.\nPlease check your connection and try again."),
+                _(
+                    "Could not retrieve voice list.\nPlease check your connection and try again."
+                ),
                 _("Error"),
                 style=wx.ICON_ERROR,
                 parent=gui.mainFrame,
@@ -428,9 +456,7 @@ class OnlineDengjenVoicesPanel(SizedPanel):
             self._preview_active = False
             self.preview_btn.SetLabel(self._preview_label)
             return
-        future.add_done_callback(
-            lambda f: wx.CallAfter(self._on_preview_done, f)
-        )
+        future.add_done_callback(lambda f: wx.CallAfter(self._on_preview_done, f))
 
     def _on_preview_done(self, future):
         self._preview_active = False
@@ -442,7 +468,9 @@ class OnlineDengjenVoicesPanel(SizedPanel):
             )
             gui.messageBox(
                 # Translators: error shown when voice preview fails to play
-                _("Could not play voice preview.\nCheck your connection and try again."),
+                _(
+                    "Could not play voice preview.\nCheck your connection and try again."
+                ),
                 # Translators: title of an error message box
                 _("Preview failed"),
                 style=wx.ICON_ERROR,
@@ -459,8 +487,7 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         selected_voice = self.voices_list.get_selected()
         if selected_voice is not None:
             downloader = voice_download.PiperVoiceDownloader(
-                selected_voice,
-                success_callback=success_callback
+                selected_voice, success_callback=success_callback
             )
             downloader.download()
 
@@ -475,22 +502,17 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         if selected_voice is None:
             return
         downloader = voice_download.PiperRTVoiceDownloader(
-            selected_voice,
-            success_callback=success_callback
+            selected_voice, success_callback=success_callback
         )
         downloader.download()
 
-
     def set_voices(self, voices):
         self.languages, self.lang_to_voices = logic.group_voices_by_language(voices)
-        self.language_choice.SetItems(
-            [lang.description for lang in self.languages]
-        )
+        self.language_choice.SetItems([lang.description for lang in self.languages])
         self.__already_populated.set()
 
 
 class DengjenVoiceManagerDialog(SimpleDialog):
-
     def __init__(self):
         super().__init__(
             gui.mainFrame,
@@ -521,7 +543,9 @@ class DengjenVoiceManagerDialog(SimpleDialog):
         self.Bind(
             wx.EVT_NOTEBOOK_PAGE_CHANGED, self.onNotebookPageChanged, self.notebookCtrl
         )
-        self.notebookCtrl._invalidate_pages_voice_cache = self._invalidate_pages_voice_cache
+        self.notebookCtrl._invalidate_pages_voice_cache = (
+            self._invalidate_pages_voice_cache
+        )
         self.notebookCtrl.GetCurrentPage().populate_list()
 
     def getButtons(self, parent):
@@ -549,8 +573,4 @@ def play_remote_mp3(mp3_url):
     with tempfile.TemporaryDirectory() as tempdir:
         wav_file = os.path.join(tempdir, "speaker_0.wav")
         miniaudio.wav_write_file(wav_file, decoded_file)
-        winsound.PlaySound(
-            wav_file,
-            winsound.SND_FILENAME | winsound.SND_PURGE
-        )
-
+        winsound.PlaySound(wav_file, winsound.SND_FILENAME | winsound.SND_PURGE)

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager_logic.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -14,7 +12,6 @@ from __future__ import annotations
 
 import dataclasses
 import operator
-import typing
 
 DENGJEN_SYNTH_NAME = "dengjen_neural_voices"
 
@@ -37,15 +34,13 @@ def is_active_voice(synth_name: str, synth_voice: str, voice_key: str) -> bool:
     )
 
 
-def group_voices_by_language(voices) -> typing.Tuple[list, dict]:
+def group_voices_by_language(voices) -> tuple[list, dict]:
     lang_to_voices: dict = {}
     for voice in voices:
         lang_to_voices.setdefault(voice.language, []).append(voice)
     for vlist in lang_to_voices.values():
         vlist.sort(key=operator.attrgetter("key"))
-    languages = sorted(
-        lang_to_voices.keys(), key=operator.attrgetter("name_english")
-    )
+    languages = sorted(lang_to_voices.keys(), key=operator.attrgetter("name_english"))
     return languages, lang_to_voices
 
 

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -24,12 +24,12 @@ LIB_DIR = os.path.join(_PIPER_SYNTH_DIR, "lib")
 BIN_DIR = os.path.join(_PIPER_SYNTH_DIR, "bin")
 
 
-def _load_voice_migration():
+def _load_voice_migration(piper_synth_dir=_PIPER_SYNTH_DIR):
     """By file path, not import: the synth package pulls in grpc and the
     bundled Windows libraries at import time, which install must not need."""
     spec = importlib.util.spec_from_file_location(
         "_dengjen_voice_migration",
-        os.path.join(_PIPER_SYNTH_DIR, "voice_migration.py"),
+        os.path.join(piper_synth_dir, "voice_migration.py"),
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -78,7 +76,7 @@ def warn_if_old_addon_installed(addons=None):
             "The Sonata Neural Voices add-on is still installed, so your downloaded "
             "voices have been left where they are and Sonata keeps working. To use "
             "them with Dengjen Neural Voices, open the Dengjen voice manager and "
-            "choose \"Import voices from Sonata\". Removing the Sonata Neural Voices "
+            'choose "Import voices from Sonata". Removing the Sonata Neural Voices '
             "add-on also avoids two synthesizers appearing in your speech settings."
         ),
         # Translators: title of the message shown when the pre-rename add-on is still present
@@ -160,6 +158,7 @@ def _temporary_import_psutil():
     sys.path.insert(0, temp_import_dir.name)
     try:
         import psutil
+
         yield psutil
     finally:
         sys.path.remove(temp_import_dir.name)

--- a/addon/synthDrivers/dengjen_neural_voices/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/__init__.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -17,6 +15,6 @@ bundled deps into that hot path instead of staying lazily imported at the
 point of use."""
 
 from .adapters.nvda.synth_driver import SynthDriver
-from .domain.tts_system import DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR
+from .domain.tts_system import DENGJEN_VOICES_DIR, DengjenTextToSpeechSystem
 
-__all__ = ["SynthDriver", "DengjenTextToSpeechSystem", "DENGJEN_VOICES_DIR"]
+__all__ = ["DENGJEN_VOICES_DIR", "DengjenTextToSpeechSystem", "SynthDriver"]

--- a/addon/synthDrivers/dengjen_neural_voices/_config.py
+++ b/addon/synthDrivers/dengjen_neural_voices/_config.py
@@ -1,10 +1,9 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
-import config
 from io import StringIO
+
+import config
 from configobj import ConfigObj
 
 _configSpec = """[voices]

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -7,30 +5,33 @@ from asyncio.exceptions import CancelledError as AsyncioCancelledError
 from collections import OrderedDict
 from contextlib import suppress
 
+import addonHandler
 import config
 import languageHandler
-import synthDriverHandler
 import ui
 from autoSettingsUtils.driverSetting import DriverSetting, NumericDriverSetting
-from nvwave import WavePlayer
 from logHandler import log
+from nvwave import WavePlayer
 from speech import sayAll
 from speech.commands import (
     BreakCommand,
     IndexCommand,
     LangChangeCommand,
+    PitchCommand,
     RateCommand,
     VolumeCommand,
-    PitchCommand,
 )
 from synthDriverHandler import (
     SynthDriver as NvdaSynthDriver,
+)
+from synthDriverHandler import (
     VoiceInfo,
     synthDoneSpeaking,
     synthIndexReached,
 )
 
 from ... import aio
+from ..._config import DengjenConfig
 from ...aio import (
     CancelledError,
     asyncio,
@@ -38,16 +39,13 @@ from ...aio import (
     asyncio_coroutine_to_concurrent_future,
     run_in_executor,
 )
-from ..._config import DengjenConfig
-from ...helpers import update_displaied_params_on_voice_change
-from ...ports.tts_backend import BackendUnavailableError
 from ...domain.tts_system import (
     DengjenTextToSpeechSystem,
     SpeakerNotFoundError,
     SpeechOptions,
 )
-
-import addonHandler
+from ...helpers import update_displaied_params_on_voice_change
+from ...ports.tts_backend import BackendUnavailableError
 
 addonHandler.initTranslation()
 
@@ -75,7 +73,7 @@ def _bootstrap_backend():
 
 
 class DoneSpeakingTask:
-    __slots__ = ["player", "on_index_reached"]
+    __slots__ = ["on_index_reached", "player"]
 
     def __init__(self, player, on_index_reached):
         self.player = player
@@ -99,7 +97,7 @@ class IndexReachedTask:
 
 
 class SpeechTask:
-    __slots__ = ["task", "player"]
+    __slots__ = ["player", "task"]
 
     def __init__(self, task, player):
         self.task = task
@@ -117,7 +115,7 @@ class SpeechTask:
 
 
 class BreakTask:
-    __slots__ = ["task", "player"]
+    __slots__ = ["player", "task"]
 
     def __init__(self, task, player):
         self.task = task
@@ -163,7 +161,6 @@ async def process_speech(speech_seq):
 
 
 class SynthDriver(NvdaSynthDriver):
-
     supportedSettings = (
         NvdaSynthDriver.VoiceSetting(),
         NvdaSynthDriver.VariantSetting(),
@@ -224,7 +221,9 @@ class SynthDriver(NvdaSynthDriver):
                 exc_info=True,
             )
             return
-        voices = DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(backend)
+        voices = DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+            backend
+        )
         if not any(voices):
             log.error(
                 "No installed voices were found for Dengjen. Synthesizer will not be available."
@@ -293,12 +292,10 @@ class SynthDriver(NvdaSynthDriver):
         if any(text_list):
             speech_seq.append(self._create_speech_task(text_list))
         if any(index_command_list):
-            speech_seq.append(IndexReachedTask(self._on_index_reached, index_command_list))
-        speech_seq.append(
-            DoneSpeakingTask(
-                self._player, self._on_index_reached
+            speech_seq.append(
+                IndexReachedTask(self._on_index_reached, index_command_list)
             )
-        )
+        speech_seq.append(DoneSpeakingTask(self._player, self._on_index_reached))
         return speech_seq
 
     def _create_speech_task(self, text_list):
@@ -387,9 +384,21 @@ class SynthDriver(NvdaSynthDriver):
     # an unchanged value). name doubles as the DengjenConfig key and the
     # attribute on tts.speech_options.voice / voice.default_scales.
     _SCALE_SETTINGS = {
-        "noise_scale": {"factor_attr": "_noise_scale_factor", "multiplier": 3, "skip_if_unchanged": False},
-        "length_scale": {"factor_attr": "_length_scale_factor", "multiplier": 2, "skip_if_unchanged": False},
-        "noise_w": {"factor_attr": "_noise_w_factor", "multiplier": 3, "skip_if_unchanged": True},
+        "noise_scale": {
+            "factor_attr": "_noise_scale_factor",
+            "multiplier": 3,
+            "skip_if_unchanged": False,
+        },
+        "length_scale": {
+            "factor_attr": "_length_scale_factor",
+            "multiplier": 2,
+            "skip_if_unchanged": False,
+        },
+        "noise_w": {
+            "factor_attr": "_noise_w_factor",
+            "multiplier": 3,
+            "skip_if_unchanged": True,
+        },
     }
 
     def _get_scale_factor(self, name):
@@ -406,14 +415,28 @@ class SynthDriver(NvdaSynthDriver):
     def _set_scale_factor(self, name, value, force=False):
         spec = self._SCALE_SETTINGS[name]
         factor_attr = spec["factor_attr"]
-        if not force and spec["skip_if_unchanged"] and getattr(self, factor_attr, None) == value:
+        if (
+            not force
+            and spec["skip_if_unchanged"]
+            and getattr(self, factor_attr, None) == value
+        ):
             return
         voice = self.tts.speech_options.voice
         default = getattr(voice.default_scales, name)
         if value == 50:
             setattr(voice, name, default)
         else:
-            setattr(voice, name, max(0.1, round(self._percentToParam(value, 0.0, default * spec["multiplier"]), 2)))
+            setattr(
+                voice,
+                name,
+                max(
+                    0.1,
+                    round(
+                        self._percentToParam(value, 0.0, default * spec["multiplier"]),
+                        2,
+                    ),
+                ),
+            )
         setattr(self, factor_attr, value)
 
     def _reapply_scale_settings(self):

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
+import typing
 from asyncio.exceptions import CancelledError as AsyncioCancelledError
 from collections import OrderedDict
 from contextlib import suppress
@@ -173,7 +174,7 @@ class SynthDriver(NvdaSynthDriver):
         NumericDriverSetting("length_scale", _("&Length scale"), True),
         NumericDriverSetting("noise_w", _("Noise &w"), False),
     )
-    supportedCommands = {
+    supportedCommands: typing.ClassVar = {
         IndexCommand,
         LangChangeCommand,
         BreakCommand,
@@ -181,7 +182,7 @@ class SynthDriver(NvdaSynthDriver):
         VolumeCommand,
         PitchCommand,
     }
-    supportedNotifications = {synthIndexReached, synthDoneSpeaking}
+    supportedNotifications: typing.ClassVar = {synthIndexReached, synthDoneSpeaking}
 
     description = "Dengjen Neural Voices"
     name = "dengjen_neural_voices"
@@ -383,7 +384,7 @@ class SynthDriver(NvdaSynthDriver):
     # name -> (backing attribute, default_scales multiplier, skip re-applying
     # an unchanged value). name doubles as the DengjenConfig key and the
     # attribute on tts.speech_options.voice / voice.default_scales.
-    _SCALE_SETTINGS = {
+    _SCALE_SETTINGS: typing.ClassVar = {
         "noise_scale": {
             "factor_attr": "_noise_scale_factor",
             "multiplier": 3,

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/__init__.py
@@ -131,7 +131,9 @@ def start_grpc_server():
             DENGJEN_VOICES_BASE_DIR, "logs", "dengjen-tts-grpc.log"
         )
         Path(server_log_file).parent.mkdir(parents=True, exist_ok=True)
-        server_stdout = SERVER_LOG_HANDLE = open(server_log_file, "wb")
+        # Held open past this function: used as the subprocess's stdout and
+        # closed later, alongside the process, by the module's cleanup path.
+        server_stdout = SERVER_LOG_HANDLE = open(server_log_file, "wb")  # noqa: SIM115
     except OSError:
         log.exception("Failed to open server log file for writing", exc_info=True)
         server_stdout = subprocess.DEVNULL
@@ -160,7 +162,7 @@ def start_grpc_server():
 
 @aio.asyncio_coroutine_to_concurrent_future
 async def initialize():
-    global CHANNEL, SONATA_GRPC_SERVICE, SONATA_GRPC_SERVER_PORT
+    global CHANNEL, SONATA_GRPC_SERVICE
     if not start_grpc_server():
         raise RuntimeError("Failed to start the Dengjen GRPC server")
     if CHANNEL is not None:

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/__init__.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import asyncio
 import atexit
 import ctypes
@@ -41,8 +39,9 @@ def _show_vcruntime_warning():
     contexts (tests, headless tooling) where the NVDA GUI isn't available.
     """
     try:
-        import wx
         import gui
+        import wx
+
         wx.CallAfter(
             gui.messageBox,
             (
@@ -56,7 +55,10 @@ def _show_vcruntime_warning():
             parent=gui.mainFrame,
         )
     except Exception:
-        log.exception("Failed to show VC++ redistributable warning dialog", exc_info=True)
+        log.exception(
+            "Failed to show VC++ redistributable warning dialog", exc_info=True
+        )
+
 
 from ...const import DENGJEN_VOICES_BASE_DIR
 from ...helpers import BIN_DIRECTORY, find_free_port, import_bundled_library
@@ -68,12 +70,12 @@ from ...ports.tts_backend import (
     VoiceLoadError,
 )
 
-
 with import_bundled_library():
     import grpc
+
     from ... import aio
-    from .grpc_protos.dengjen_grpc_pb2_grpc import DengjenGrpcStub
     from .grpc_protos import dengjen_grpc_pb2 as msgs
+    from .grpc_protos.dengjen_grpc_pb2_grpc import DengjenGrpcStub
 
 
 # All of the module-level state below is normally only touched from the
@@ -112,18 +114,22 @@ def start_grpc_server():
     grpc_server_exe = os.path.join(BIN_DIRECTORY, "dengjen-tts-grpc.exe")
     nvda_espeak_dir = os.path.join(globalVars.appDir, "synthDrivers")
     env = os.environ.copy()
-    env.update({
-        "DENGJEN_GRPC_SERVER_PORT": str(SONATA_GRPC_SERVER_PORT),
-        "DENGJEN_ESPEAKNG_DATA_DIRECTORY": os.fspath(nvda_espeak_dir),
-        "DENGJEN_GRPC": "info",
-    })
+    env.update(
+        {
+            "DENGJEN_GRPC_SERVER_PORT": str(SONATA_GRPC_SERVER_PORT),
+            "DENGJEN_ESPEAKNG_DATA_DIRECTORY": os.fspath(nvda_espeak_dir),
+            "DENGJEN_GRPC": "info",
+        }
+    )
     creationflags = (
         subprocess.DETACHED_PROCESS
         | subprocess.CREATE_NEW_PROCESS_GROUP
         | subprocess.REALTIME_PRIORITY_CLASS
     )
     try:
-        server_log_file = os.path.join(DENGJEN_VOICES_BASE_DIR, "logs", "dengjen-tts-grpc.log")
+        server_log_file = os.path.join(
+            DENGJEN_VOICES_BASE_DIR, "logs", "dengjen-tts-grpc.log"
+        )
         Path(server_log_file).parent.mkdir(parents=True, exist_ok=True)
         server_stdout = SERVER_LOG_HANDLE = open(server_log_file, "wb")
     except OSError:
@@ -141,7 +147,7 @@ def start_grpc_server():
     except Exception:
         log.exception(
             "Failed to start Dengjen GRPC server. The synth will not be available.",
-            exc_info=True
+            exc_info=True,
         )
         if SERVER_LOG_HANDLE is not None:
             SERVER_LOG_HANDLE.close()
@@ -162,7 +168,10 @@ async def initialize():
             # grpc.aio binds a channel to the loop that created it, so a channel
             # outliving its loop has to be replaced rather than reused.
             channel_loop = getattr(CHANNEL, "_loop", None)
-            if channel_loop is aio.ENGINE.event_loop and aio.ENGINE.event_loop.is_running():
+            if (
+                channel_loop is aio.ENGINE.event_loop
+                and aio.ENGINE.event_loop.is_running()
+            ):
                 return
         except Exception:
             log.debug("Failed to inspect the existing GRPC channel", exc_info=True)
@@ -241,7 +250,12 @@ async def _clear_stale_server_state():
     loop already -- close_channel()'s run_coroutine_threadsafe().result()
     would deadlock waiting on the very loop it's called from.
     """
-    global GRPC_SERVER_PROCESS, SONATA_GRPC_SERVER_PORT, SERVER_LOG_HANDLE, CHANNEL, SONATA_GRPC_SERVICE
+    global \
+        GRPC_SERVER_PROCESS, \
+        SONATA_GRPC_SERVER_PORT, \
+        SERVER_LOG_HANDLE, \
+        CHANNEL, \
+        SONATA_GRPC_SERVICE
     process, GRPC_SERVER_PROCESS = GRPC_SERVER_PROCESS, None
     SONATA_GRPC_SERVER_PORT = None
     SONATA_GRPC_SERVICE = None
@@ -309,7 +323,13 @@ async def set_synth_options(
 
 
 async def speak(
-    voice_id, text, rate=None, volume=None, pitch=None, appended_silence_ms=None, streaming=False
+    voice_id,
+    text,
+    rate=None,
+    volume=None,
+    pitch=None,
+    appended_silence_ms=None,
+    streaming=False,
 ):
     speech_args = None
     if any(v is not None for v in (rate, volume, pitch, appended_silence_ms)):
@@ -421,7 +441,16 @@ class SonataGrpcBackend:
         except Exception as exc:
             raise VoiceLoadError(str(exc)) from exc
 
-    async def synthesize(self, backend_voice_id, text, rate, volume, pitch, sentence_silence_ms, streaming):
+    async def synthesize(
+        self,
+        backend_voice_id,
+        text,
+        rate,
+        volume,
+        pitch,
+        sentence_silence_ms,
+        streaming,
+    ):
         try:
             async for ret in speak(
                 voice_id=backend_voice_id,

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/grpc_protos/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/grpc_protos/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/addon/synthDrivers/dengjen_neural_voices/aio.py
+++ b/addon/synthDrivers/dengjen_neural_voices/aio.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 import threading
 import typing as t
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial, wraps
 
 from logHandler import log

--- a/addon/synthDrivers/dengjen_neural_voices/aio.py
+++ b/addon/synthDrivers/dengjen_neural_voices/aio.py
@@ -2,10 +2,14 @@ import asyncio
 import os
 import threading
 import typing as t
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
 from functools import partial, wraps
 
 from logHandler import log
+
+# Re-exported for synth_driver.py, which reaches this via `from ...aio import ...`
+# rather than importing concurrent.futures directly.
+__all__ = ["CancelledError"]
 
 LOOP_STARTUP_TIMEOUT = 5
 LOOP_SHUTDOWN_TIMEOUT = 2

--- a/addon/synthDrivers/dengjen_neural_voices/aio.py
+++ b/addon/synthDrivers/dengjen_neural_voices/aio.py
@@ -1,14 +1,11 @@
-# coding: utf-8
-
 import asyncio
 import os
 import threading
 import typing as t
-from concurrent.futures import CancelledError, ThreadPoolExecutor
-from functools import wraps, partial
-from logHandler import log
-from .helpers import import_bundled_library
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial, wraps
 
+from logHandler import log
 
 LOOP_STARTUP_TIMEOUT = 5
 LOOP_SHUTDOWN_TIMEOUT = 2
@@ -75,7 +72,10 @@ class AsyncEngine:
                 # The thread is started before run_forever() marks the loop
                 # running, so wait on the handshake rather than sampling
                 # is_running().
-                if self._loop_running.wait(timeout=LOOP_SHUTDOWN_TIMEOUT) and self.is_running():
+                if (
+                    self._loop_running.wait(timeout=LOOP_SHUTDOWN_TIMEOUT)
+                    and self.is_running()
+                ):
                     return
                 self._loop_thread.join(timeout=LOOP_SHUTDOWN_TIMEOUT)
 

--- a/addon/synthDrivers/dengjen_neural_voices/const.py
+++ b/addon/synthDrivers/dengjen_neural_voices/const.py
@@ -1,33 +1,29 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
 __all__ = [
-    "IGNORED_PUNCS",
-    "PIPER_VOICES_VERSION",
-    "DENGJEN_VOICES_BASE_DIR",
-    "DENGJEN_VOICES_DIR",
     "BATCH_SIZE",
-    "FALLBACK_SPEAKER_NAME",
+    "DEFAULT_PITCH",
     "DEFAULT_RATE",
     "DEFAULT_VOLUME",
-    "DEFAULT_PITCH",
+    "DENGJEN_VOICES_BASE_DIR",
+    "DENGJEN_VOICES_DIR",
+    "FALLBACK_SPEAKER_NAME",
+    "IGNORED_PUNCS",
+    "PIPER_VOICES_VERSION",
 ]
 
 
 import os
-import globalVars
 
+import globalVars
 
 # An utterance is ignored if it only contains the following chars
 # Eventually, this should be moved to sonata-rs
 IGNORED_PUNCS = frozenset(",(){}[]`\"'")
 PIPER_VOICES_VERSION = "v1.0"
 DENGJEN_VOICES_BASE_DIR = os.path.join(globalVars.appArgs.configPath, "dengjen")
-DENGJEN_VOICES_DIR = os.path.join(
-    DENGJEN_VOICES_BASE_DIR, "voices", "piper"
-)
+DENGJEN_VOICES_DIR = os.path.join(DENGJEN_VOICES_BASE_DIR, "voices", "piper")
 BATCH_SIZE = max((os.cpu_count() or 2) // 2, 2)
 FALLBACK_SPEAKER_NAME = "default"
 DEFAULT_RATE = 50

--- a/addon/synthDrivers/dengjen_neural_voices/domain/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/domain/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
+++ b/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -14,10 +12,10 @@ import copy
 import operator
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Mapping, Optional, Sequence
 
 from languageHandler import normalizeLanguage
 
@@ -25,12 +23,12 @@ from ..const import (
     DEFAULT_PITCH,
     DEFAULT_RATE,
     DEFAULT_VOLUME,
+    DENGJEN_VOICES_DIR,
     FALLBACK_SPEAKER_NAME,
     IGNORED_PUNCS,
-    DENGJEN_VOICES_DIR,
 )
-from ..voice_migration import migrate_voices_directory
 from ..ports.tts_backend import TTSBackend
+from ..voice_migration import migrate_voices_directory
 
 
 class VoiceNotFoundError(LookupError):
@@ -55,7 +53,7 @@ class AudioProvider(ABC):
 
 
 class SilenceProvider(AudioProvider):
-    __slots__ = ["time_ms", "sample_rate"]
+    __slots__ = ["sample_rate", "time_ms"]
 
     def __init__(self, time_ms, sample_rate):
         self.time_ms = time_ms
@@ -69,7 +67,7 @@ class SilenceProvider(AudioProvider):
 class SpeechProvider(AudioProvider):
     """A pending request to speak some text."""
 
-    __slots__ = ["text", "speech_options"]
+    __slots__ = ["speech_options", "text"]
 
     def __init__(self, text, speech_options):
         self.text = text
@@ -87,8 +85,8 @@ class DengjenVoice:
     description: str
     location: str
     backend: TTSBackend
-    properties: Optional[Mapping[str, int]] = field(default_factory=dict)
-    remote_id: Optional[str] = None
+    properties: Mapping[str, int] | None = field(default_factory=dict)
+    remote_id: str | None = None
     supports_streaming_output: bool = False
 
     @classmethod
@@ -115,7 +113,9 @@ class DengjenVoice:
         try:
             self.config_path = next(self.location.glob("*.json"))
         except StopIteration:
-            raise RuntimeError(f"Could not load voice from `{os.fspath(self.location)}`")
+            raise RuntimeError(
+                f"Could not load voice from `{os.fspath(self.location)}`"
+            )
         loaded = self.backend.load_voice(str(self.config_path))
         self.remote_id = loaded.backend_voice_id
         self.supports_streaming_output = loaded.supports_streaming_output
@@ -128,7 +128,9 @@ class DengjenVoice:
         self.speakers = loaded.speakers
         self.speaker_names = list(self.speakers.values())
         self.is_multi_speaker = bool(self.speakers)
-        self.default_speaker = loaded.defaults.speaker if self.is_multi_speaker else None
+        self.default_speaker = (
+            loaded.defaults.speaker if self.is_multi_speaker else None
+        )
 
     def _get_synth_option(self, name):
         options = self.backend.get_synth_options(self.remote_id)
@@ -192,7 +194,12 @@ class DengjenVoice:
         if (len(text) < 10) and (set(text.strip()).issubset(IGNORED_PUNCS)):
             return
         stream = self.backend.synthesize(
-            self.remote_id, text, rate, volume, pitch, sentence_silence_ms,
+            self.remote_id,
+            text,
+            rate,
+            volume,
+            pitch,
+            sentence_silence_ms,
             streaming=self.supports_streaming_output,
         )
         async for chunk in stream:
@@ -200,9 +207,17 @@ class DengjenVoice:
 
 
 class SpeechOptions:
-    __slots__ = ["voice", "rate", "volume", "pitch", "sentence_silence_ms"]
+    __slots__ = ["pitch", "rate", "sentence_silence_ms", "voice", "volume"]
 
-    def __init__(self, voice, speaker=None, rate=None, volume=None, pitch=None, sentence_silence_ms=None):
+    def __init__(
+        self,
+        voice,
+        speaker=None,
+        rate=None,
+        volume=None,
+        pitch=None,
+        sentence_silence_ms=None,
+    ):
         self.voice = None
         self.set_voice(voice)
         self.rate = rate
@@ -232,8 +247,9 @@ class SpeechOptions:
 
 
 class DengjenTextToSpeechSystem:
-
-    def __init__(self, voices: Sequence[DengjenVoice], speech_options: SpeechOptions = None):
+    def __init__(
+        self, voices: Sequence[DengjenVoice], speech_options: SpeechOptions = None
+    ):
         self.voices = voices
         if speech_options is not None:
             self.speech_options = speech_options
@@ -268,7 +284,9 @@ class DengjenTextToSpeechSystem:
             if voice.key == new_voice:
                 self.speech_options.set_voice(voice)
                 return
-        raise VoiceNotFoundError(f"A voice with the given key `{new_voice}` was not found")
+        raise VoiceNotFoundError(
+            f"A voice with the given key `{new_voice}` was not found"
+        )
 
     @property
     def speaker(self) -> str:
@@ -305,7 +323,9 @@ class DengjenTextToSpeechSystem:
         if possible_voices:
             self.speech_options.set_voice(possible_voices[0])
             return
-        raise VoiceNotFoundError(f"A voice with the given language `{new_language}` was not found")
+        raise VoiceNotFoundError(
+            f"A voice with the given language `{new_language}` was not found"
+        )
 
     @property
     def volume(self) -> float:
@@ -369,7 +389,9 @@ class DengjenTextToSpeechSystem:
         )
 
     @classmethod
-    def load_voices_from_directory(cls, voices_directory, backend, *, directory_name_prefix="voice-"):
+    def load_voices_from_directory(
+        cls, voices_directory, backend, *, directory_name_prefix="voice-"
+    ):
         rv = []
         for directory in (d for d in Path(voices_directory).iterdir() if d.is_dir()):
             try:

--- a/addon/synthDrivers/dengjen_neural_voices/helpers.py
+++ b/addon/synthDrivers/dengjen_neural_voices/helpers.py
@@ -1,17 +1,13 @@
-# coding: utf-8
-
 # Copyright (c) 2021 Blind Pandas Team
 # This file is covered by the GNU General Public License.
 
-import sys
-import os
 import contextlib
+import os
 import socket
-
+import sys
 
 import wx
 from gui.settingsDialogs import NVDASettingsDialog, SpeechSettingsPanel
-
 
 PLUGIN_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 LIB_DIRECTORY = os.path.join(PLUGIN_DIRECTORY, "lib")
@@ -52,11 +48,11 @@ def update_displaied_params_on_voice_change(synth):
             if isinstance(win, NVDASettingsDialog)
         )
     except StopIteration:
-        # No gui displaied 
+        # No gui displaied
         return
     current_panel = setting_dialog.currentCategory
     if not isinstance(current_panel, SpeechSettingsPanel):
-        # No gui displaied 
+        # No gui displaied
         return
     voice_panel = current_panel.voicePanel
     # Patch values

--- a/addon/synthDrivers/dengjen_neural_voices/ports/__init__.py
+++ b/addon/synthDrivers/dengjen_neural_voices/ports/__init__.py
@@ -1,1 +1,0 @@
-# coding: utf-8

--- a/addon/synthDrivers/dengjen_neural_voices/ports/tts_backend.py
+++ b/addon/synthDrivers/dengjen_neural_voices/ports/tts_backend.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """The TTSBackend port: the one interface a TTS engine adapter must satisfy.
 
 No implementation and no NVDA/gRPC imports live here -- this module is the
@@ -7,8 +5,9 @@ seam domain/tts_system.py and every adapters/*_backend implementation both
 depend on.
 """
 
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass
-from typing import AsyncIterator, Mapping, Optional, Protocol
+from typing import Protocol
 
 
 @dataclass(frozen=True)
@@ -20,7 +19,7 @@ class SynthOptions:
     both are the same four fields.
     """
 
-    speaker: Optional[str]
+    speaker: str | None
     length_scale: float
     noise_scale: float
     noise_w: float
@@ -80,9 +79,9 @@ class TTSBackend(Protocol):
         self,
         backend_voice_id: str,
         text: str,
-        rate: Optional[float],
-        volume: Optional[float],
-        pitch: Optional[float],
-        sentence_silence_ms: Optional[float],
+        rate: float | None,
+        volume: float | None,
+        pitch: float | None,
+        sentence_silence_ms: float | None,
         streaming: bool,
     ) -> AsyncIterator[bytes]: ...

--- a/addon/synthDrivers/dengjen_neural_voices/voice_migration.py
+++ b/addon/synthDrivers/dengjen_neural_voices/voice_migration.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 # Copyright (c) 2023 Musharraf Omer
 # This file is covered by the GNU General Public License.
 
@@ -23,7 +21,6 @@ import shutil
 import addonHandler
 import globalVars
 from logHandler import log
-
 
 __all__ = [
     "OLD_ADDON_NAME",
@@ -96,9 +93,7 @@ def copy_voices_from_old_dir(config_path=None):
     )
     copied = []
     for key in importable_voice_keys(config_path):
-        shutil.copytree(
-            os.path.join(old_voices, key), os.path.join(new_voices, key)
-        )
+        shutil.copytree(os.path.join(old_voices, key), os.path.join(new_voices, key))
         copied.append(key)
     if copied:
         log.info(f"Copied {len(copied)} voice(s) from {old_voices}")
@@ -128,9 +123,7 @@ def migrate_voices_directory(config_path=None, addons=None):
     if not os.path.isdir(old_dir):
         return False
     if is_old_addon_installed(addons):
-        log.debug(
-            f"Skipping voices migration: {OLD_ADDON_NAME} is still installed"
-        )
+        log.debug(f"Skipping voices migration: {OLD_ADDON_NAME} is still installed")
         return False
     # Not os.path.exists: the synth driver creates an empty tree here on every
     # load, so existence alone would refuse the migration for good.

--- a/buildVars.py
+++ b/buildVars.py
@@ -1,7 +1,11 @@
 # Build customizations
 # Change this file instead of sconstruct or manifest files, whenever possible.
 
-from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, SymbolDictionaries
+from site_scons.site_tools.NVDATool.typings import (
+    AddonInfo,
+    BrailleTables,
+    SymbolDictionaries,
+)
 
 # Since some strings in `addon_info` are translatable,
 # we need to include them in the .po files.
@@ -10,50 +14,49 @@ from site_scons.site_tools.NVDATool.typings import AddonInfo, BrailleTables, Sym
 # which returns whatever is given to it as an argument.
 from site_scons.site_tools.NVDATool.utils import _
 
-
 # Add-on information variables
 addon_info = AddonInfo(
-	# add-on Name/identifier, internal for NVDA
-	addon_name="dengjen_neural_voices",
-	# Add-on summary/title, usually the user visible name of the add-on
-	# Translators: Summary/title for this add-on
-	# to be shown on installation and add-on information found in add-on store
-	addon_summary=_("Dengjen Neural Voices"),
-	# Add-on description
-	# Translators: Long description to be shown for this add-on on add-on information from add-on store
-	addon_description=_(
-		"""Adds fast, local neural text-to-speech voices to NVDA. Provides a synthesizer driver for Piper voice models via the dengjen engine, together with a voice manager for downloading and installing voices."""
-	),
-	# version
-	addon_version="4.0.1",
-	# Brief changelog for this version
-	# Translators: what's new content for the add-on version to be shown in the add-on store
-	addon_changelog=_(
-		"Corrected the declared minimum NVDA version to 2026.1. "
-		"The bundled speech engine has required NVDA's Python 3.13 64-bit runtime since v3.2-beta.1; "
-		"the add-on previously claimed support for NVDA 2025.1+ and failed to load with an ImportError "
-		"on those older, incompatible NVDA versions."
-	),
-	# Author(s)
-	addon_author="Musharraf Omer (original) <ibnomer2011@hotmail.com>, Ali Ustek (maintainer) <13117393+austek@users.noreply.github.com>",
-	# URL for the add-on documentation support
-	addon_url="https://github.com/zirekhq/dengjen-nvda",
-	# URL for the add-on repository where the source code can be found
-	addon_sourceURL="https://github.com/zirekhq/dengjen-nvda",
-	# Documentation file name
-	addon_docFileName="readme.html",
-	# Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
-	addon_minimumNVDAVersion="2026.1",
-	# Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
-	addon_lastTestedNVDAVersion="2026.1",
-	# Add-on update channel (default is None, denoting stable releases,
-	# and for development releases, use "dev".)
-	# Do not change unless you know what you are doing!
-	addon_updateChannel=None,
-	# Add-on license such as GPL 2
-	addon_license="GPL 2",
-	# URL for the license document the ad-on is licensed under
-	addon_licenseURL="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",
+    # add-on Name/identifier, internal for NVDA
+    addon_name="dengjen_neural_voices",
+    # Add-on summary/title, usually the user visible name of the add-on
+    # Translators: Summary/title for this add-on
+    # to be shown on installation and add-on information found in add-on store
+    addon_summary=_("Dengjen Neural Voices"),
+    # Add-on description
+    # Translators: Long description to be shown for this add-on on add-on information from add-on store
+    addon_description=_(
+        """Adds fast, local neural text-to-speech voices to NVDA. Provides a synthesizer driver for Piper voice models via the dengjen engine, together with a voice manager for downloading and installing voices."""
+    ),
+    # version
+    addon_version="4.0.1",
+    # Brief changelog for this version
+    # Translators: what's new content for the add-on version to be shown in the add-on store
+    addon_changelog=_(
+        "Corrected the declared minimum NVDA version to 2026.1. "
+        "The bundled speech engine has required NVDA's Python 3.13 64-bit runtime since v3.2-beta.1; "
+        "the add-on previously claimed support for NVDA 2025.1+ and failed to load with an ImportError "
+        "on those older, incompatible NVDA versions."
+    ),
+    # Author(s)
+    addon_author="Musharraf Omer (original) <ibnomer2011@hotmail.com>, Ali Ustek (maintainer) <13117393+austek@users.noreply.github.com>",
+    # URL for the add-on documentation support
+    addon_url="https://github.com/zirekhq/dengjen-nvda",
+    # URL for the add-on repository where the source code can be found
+    addon_sourceURL="https://github.com/zirekhq/dengjen-nvda",
+    # Documentation file name
+    addon_docFileName="readme.html",
+    # Minimum NVDA version supported (e.g. "2019.3.0", minor version is optional)
+    addon_minimumNVDAVersion="2026.1",
+    # Last NVDA version supported/tested (e.g. "2024.4.0", ideally more recent than minimum version)
+    addon_lastTestedNVDAVersion="2026.1",
+    # Add-on update channel (default is None, denoting stable releases,
+    # and for development releases, use "dev".)
+    # Do not change unless you know what you are doing!
+    addon_updateChannel=None,
+    # Add-on license such as GPL 2
+    addon_license="GPL 2",
+    # URL for the license document the ad-on is licensed under
+    addon_licenseURL="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html",
 )
 
 # Define the python files that are the sources of your add-on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,21 @@ extend-exclude = [
 ]
 # `_` is NVDA's gettext translation function, injected via addonHandler.initTranslation()
 builtins = ["_"]
+
+[tool.ruff.lint]
+extend-ignore = [
+    # This codebase's error handling convention is deliberately broad at
+    # boundaries (subprocess/IPC lookups, best-effort cleanup) rather than
+    # enumerating specific exception types - see the comments throughout
+    # installTasks.py and the sonata_grpc adapter.
+    "BLE001",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# SCons discovers tools by matching the package name to the tool name, so
+# `NVDATool/__init__.py` cannot be renamed to satisfy module-naming rules.
+"site_scons/site_tools/NVDATool/__init__.py" = ["N999"]
+# Test doubles freely use generic exceptions, exec(), and mutable class
+# attributes for throwaway fixtures/fakes - none of that is production API.
+"tests/**/*.py" = ["TRY002", "S102", "RUF012"]
+"tests_*/**/*.py" = ["TRY002", "S102", "RUF012"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,16 @@
 addon-bundle = "dengjen_neural_voices-*.nvda-addon"
 nvda-channel = "stable"
 allow-eval = true
+
+[tool.ruff]
+extend-exclude = [
+    "addon/synthDrivers/dengjen_neural_voices/lib",
+    "addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/grpc_protos/dengjen_grpc_pb2.py",
+    "addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/grpc_protos/dengjen_grpc_pb2.pyi",
+    "addon/synthDrivers/dengjen_neural_voices/adapters/sonata_grpc/grpc_protos/dengjen_grpc_pb2_grpc.py",
+    # Vendored wx.lib.sized_controls (c) 2006 Kevin Ollivier, wxWindows license -
+    # not our code to reshape for lint conformance.
+    "addon/globalPlugins/dengjen_tts_global_plugin/sized_controls.py",
+]
+# `_` is NVDA's gettext translation function, injected via addonHandler.initTranslation()
+builtins = ["_"]

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -22,84 +22,89 @@ The following environment variables are required to build the HTML:
 
 """
 
-from SCons.Script import Environment, Builder
+from SCons.Script import Builder, Environment
 
 from .addon import createAddonBundleFromPath
-from .manifests import generateManifest, generateTranslatedManifest
 from .docs import md2html
-
+from .manifests import generateManifest, generateTranslatedManifest
 
 
 def generate(env: Environment):
-	env.SetDefault(excludePatterns=tuple())
+    env.SetDefault(excludePatterns=tuple())
 
-	addonAction = env.Action(
-		lambda target, source, env: createAddonBundleFromPath(
-			source[0].abspath, target[0].abspath, env["excludePatterns"]
-		) and None,
-		lambda target, source, env: f"Generating Addon {target[0]}",
-	)
-	env["BUILDERS"]["NVDAAddon"] = Builder(
-		action=addonAction,
-		suffix=".nvda-addon",
-		src_suffix="/"
-	)
+    addonAction = env.Action(
+        lambda target, source, env: (
+            createAddonBundleFromPath(
+                source[0].abspath, target[0].abspath, env["excludePatterns"]
+            )
+            and None
+        ),
+        lambda target, source, env: f"Generating Addon {target[0]}",
+    )
+    env["BUILDERS"]["NVDAAddon"] = Builder(
+        action=addonAction, suffix=".nvda-addon", src_suffix="/"
+    )
 
-	env.SetDefault(brailleTables={})
-	env.SetDefault(symbolDictionaries={})
+    env.SetDefault(brailleTables={})
+    env.SetDefault(symbolDictionaries={})
 
-	manifestAction = env.Action(
-		lambda target, source, env: generateManifest(
-			source[0].abspath,
-			target[0].abspath,
-			addon_info=env["addon_info"],
-			brailleTables=env["brailleTables"],
-			symbolDictionaries=env["symbolDictionaries"],
-		) and None,
-		lambda target, source, env: f"Generating manifest {target[0]}",
-	)
-	env["BUILDERS"]["NVDAManifest"] = Builder(
-		action=manifestAction,
-		suffix=".ini",
-		src_siffix=".ini.tpl"
-	)
+    manifestAction = env.Action(
+        lambda target, source, env: (
+            generateManifest(
+                source[0].abspath,
+                target[0].abspath,
+                addon_info=env["addon_info"],
+                brailleTables=env["brailleTables"],
+                symbolDictionaries=env["symbolDictionaries"],
+            )
+            and None
+        ),
+        lambda target, source, env: f"Generating manifest {target[0]}",
+    )
+    env["BUILDERS"]["NVDAManifest"] = Builder(
+        action=manifestAction, suffix=".ini", src_siffix=".ini.tpl"
+    )
 
-	translatedManifestAction = env.Action(
-		lambda target, source, env: generateTranslatedManifest(
-			source[1].abspath,
-			target[0].abspath,
-			mo=source[0].abspath,
-			addon_info=env["addon_info"],
-			brailleTables=env["brailleTables"],
-			symbolDictionaries=env["symbolDictionaries"],
-		) and None,
-		lambda target, source, env: f"Generating translated manifest {target[0]}",
-	)
+    translatedManifestAction = env.Action(
+        lambda target, source, env: (
+            generateTranslatedManifest(
+                source[1].abspath,
+                target[0].abspath,
+                mo=source[0].abspath,
+                addon_info=env["addon_info"],
+                brailleTables=env["brailleTables"],
+                symbolDictionaries=env["symbolDictionaries"],
+            )
+            and None
+        ),
+        lambda target, source, env: f"Generating translated manifest {target[0]}",
+    )
 
-	env["BUILDERS"]["NVDATranslatedManifest"] = Builder(
-		action=translatedManifestAction,
-		suffix=".ini",
-		src_siffix=".ini.tpl"
-	)
+    env["BUILDERS"]["NVDATranslatedManifest"] = Builder(
+        action=translatedManifestAction, suffix=".ini", src_siffix=".ini.tpl"
+    )
 
-	env.SetDefault(mdExtensions = {})
+    env.SetDefault(mdExtensions={})
 
-	mdAction = env.Action(
-		lambda target, source, env: md2html(
-			source[0].path,
-			target[0].path,
-			moFile=env["moFile"].path if env["moFile"] else None,
-			mdExtensions=env["mdExtensions"],
-			addon_info=env["addon_info"],
-		) and None,
-		lambda target, source, env: f"Generating {target[0]}",
-	)
-	env["BUILDERS"]["md2html"] = env.Builder(
-		action=mdAction,
-		suffix=".html",
-		src_suffix=".md",
-	)
+    mdAction = env.Action(
+        lambda target, source, env: (
+            md2html(
+                source[0].path,
+                target[0].path,
+                moFile=env["moFile"].path if env["moFile"] else None,
+                mdExtensions=env["mdExtensions"],
+                addon_info=env["addon_info"],
+            )
+            and None
+        ),
+        lambda target, source, env: f"Generating {target[0]}",
+    )
+    env["BUILDERS"]["md2html"] = env.Builder(
+        action=mdAction,
+        suffix=".html",
+        src_suffix=".md",
+    )
 
 
 def exists():
-	return True
+    return True

--- a/site_scons/site_tools/NVDATool/__init__.py
+++ b/site_scons/site_tools/NVDATool/__init__.py
@@ -30,7 +30,7 @@ from .manifests import generateManifest, generateTranslatedManifest
 
 
 def generate(env: Environment):
-    env.SetDefault(excludePatterns=tuple())
+    env.SetDefault(excludePatterns=())
 
     addonAction = env.Action(
         lambda target, source, env: (

--- a/site_scons/site_tools/NVDATool/addon.py
+++ b/site_scons/site_tools/NVDATool/addon.py
@@ -3,22 +3,23 @@ from collections.abc import Iterable
 from pathlib import Path
 
 
-
 def matchesNoPatterns(path: Path, patterns: Iterable[str]) -> bool:
-	"""Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
-	return not any((path.match(pattern) for pattern in patterns))
+    """Checks if the path, the first argument, does not match any of the patterns passed as the second argument."""
+    return not any(path.match(pattern) for pattern in patterns)
 
 
-def createAddonBundleFromPath(path: str | Path, dest: str, excludePatterns: Iterable[str]):
-	"""Creates a bundle from a directory that contains an addon manifest file."""
-	if isinstance(path, str):
-		path = Path(path)
-	basedir = path.absolute()
-	with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
-		for p in basedir.rglob("*"):
-			if p.is_dir():
-				continue
-			pathInBundle = p.relative_to(basedir)
-			if matchesNoPatterns(pathInBundle, excludePatterns):
-				z.write(p, pathInBundle)
-	return dest
+def createAddonBundleFromPath(
+    path: str | Path, dest: str, excludePatterns: Iterable[str]
+):
+    """Creates a bundle from a directory that contains an addon manifest file."""
+    if isinstance(path, str):
+        path = Path(path)
+    basedir = path.absolute()
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
+        for p in basedir.rglob("*"):
+            if p.is_dir():
+                continue
+            pathInBundle = p.relative_to(basedir)
+            if matchesNoPatterns(pathInBundle, excludePatterns):
+                z.write(p, pathInBundle)
+    return dest

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -1,4 +1,3 @@
-
 import gettext
 from pathlib import Path
 
@@ -7,55 +6,54 @@ import markdown
 from .typings import AddonInfo
 
 
-
 def md2html(
-		source: str | Path,
-		dest: str | Path,
-		*,
-		moFile: str | Path|None,
-		mdExtensions: list[str],
-		addon_info: AddonInfo
-	):
-	if isinstance(source, str):
-		source = Path(source)
-	if isinstance(dest, str):
-		dest = Path(dest)
-	if isinstance(moFile, str):
-		moFile = Path(moFile)
+    source: str | Path,
+    dest: str | Path,
+    *,
+    moFile: str | Path | None,
+    mdExtensions: list[str],
+    addon_info: AddonInfo,
+):
+    if isinstance(source, str):
+        source = Path(source)
+    if isinstance(dest, str):
+        dest = Path(dest)
+    if isinstance(moFile, str):
+        moFile = Path(moFile)
 
-	try:
-		with moFile.open("rb") as f:
-			_ = gettext.GNUTranslations(f).gettext
-	except Exception:
-		summary = addon_info["addon_summary"]
-	else:
-		summary = _(addon_info["addon_summary"])
-	version = addon_info["addon_version"]
-	title = f"{summary} {version}"
-	lang = source.parent.name.replace("_", "-")
-	headerDic = {
-		'[[!meta title="': "# ",
-		'"]]': " #",
-	}
-	with source.open("r", encoding="utf-8") as f:
-		mdText = f.read()
-	for k, v in headerDic.items():
-		mdText = mdText.replace(k, v, 1)
-	htmlText = markdown.markdown(mdText, extensions=mdExtensions)
-	# Optimization: build resulting HTML text in one go instead of writing parts separately.
-	docText = "\n".join(
-		(
-			"<!DOCTYPE html>",
-			f'<html lang="{lang}">',
-			"<head>",
-			'<meta charset="UTF-8">',
-			'<meta name="viewport" content="width=device-width, initial-scale=1.0">',
-			'<link rel="stylesheet" type="text/css" href="../style.css" media="screen">',
-			f"<title>{title}</title>",
-			"</head>\n<body>",
-			htmlText,
-			"</body>\n</html>",
-		)
-	)
-	with dest.open("w", encoding="utf-8") as f:
-		f.write(docText) # type: ignore
+    try:
+        with moFile.open("rb") as f:
+            _ = gettext.GNUTranslations(f).gettext
+    except Exception:
+        summary = addon_info["addon_summary"]
+    else:
+        summary = _(addon_info["addon_summary"])
+    version = addon_info["addon_version"]
+    title = f"{summary} {version}"
+    lang = source.parent.name.replace("_", "-")
+    headerDic = {
+        '[[!meta title="': "# ",
+        '"]]': " #",
+    }
+    with source.open("r", encoding="utf-8") as f:
+        mdText = f.read()
+    for k, v in headerDic.items():
+        mdText = mdText.replace(k, v, 1)
+    htmlText = markdown.markdown(mdText, extensions=mdExtensions)
+    # Optimization: build resulting HTML text in one go instead of writing parts separately.
+    docText = "\n".join(
+        (
+            "<!DOCTYPE html>",
+            f'<html lang="{lang}">',
+            "<head>",
+            '<meta charset="UTF-8">',
+            '<meta name="viewport" content="width=device-width, initial-scale=1.0">',
+            '<link rel="stylesheet" type="text/css" href="../style.css" media="screen">',
+            f"<title>{title}</title>",
+            "</head>\n<body>",
+            htmlText,
+            "</body>\n</html>",
+        )
+    )
+    with dest.open("w", encoding="utf-8") as f:
+        f.write(docText)  # type: ignore

--- a/site_scons/site_tools/NVDATool/manifests.py
+++ b/site_scons/site_tools/NVDATool/manifests.py
@@ -1,4 +1,3 @@
-
 import codecs
 import gettext
 from functools import partial
@@ -7,63 +6,66 @@ from .typings import AddonInfo, BrailleTables, SymbolDictionaries
 from .utils import format_nested_section
 
 
-
 def generateManifest(
-		source: str,
-		dest: str,
-		addon_info: AddonInfo,
-		brailleTables: BrailleTables,
-		symbolDictionaries: SymbolDictionaries,
-	):
-	# Prepare the root manifest section
-	with codecs.open(source, "r", "utf-8") as f:
-		manifest_template = f.read()
-	manifest = manifest_template.format(**addon_info)
-	# Add additional manifest sections such as custom braile tables
-	# Custom braille translation tables
-	if brailleTables:
-		manifest += format_nested_section("brailleTables", brailleTables)
+    source: str,
+    dest: str,
+    addon_info: AddonInfo,
+    brailleTables: BrailleTables,
+    symbolDictionaries: SymbolDictionaries,
+):
+    # Prepare the root manifest section
+    with codecs.open(source, "r", "utf-8") as f:
+        manifest_template = f.read()
+    manifest = manifest_template.format(**addon_info)
+    # Add additional manifest sections such as custom braile tables
+    # Custom braille translation tables
+    if brailleTables:
+        manifest += format_nested_section("brailleTables", brailleTables)
 
-	# Custom speech symbol dictionaries
-	if symbolDictionaries:
-		manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
+    # Custom speech symbol dictionaries
+    if symbolDictionaries:
+        manifest += format_nested_section("symbolDictionaries", symbolDictionaries)
 
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(manifest)
+    with codecs.open(dest, "w", "utf-8") as f:
+        f.write(manifest)
 
 
 def generateTranslatedManifest(
-		source: str,
-		dest: str,
-		*,
-		mo: str,
-		addon_info: AddonInfo,
-		brailleTables: BrailleTables,
-		symbolDictionaries: SymbolDictionaries,
-	):
-	with open(mo, "rb") as f:
-		_ = gettext.GNUTranslations(f).gettext
-	vars: dict[str, str] = {}
-	for var in ("addon_summary", "addon_description", "addon_changelog"):
-		vars[var] = _(addon_info[var])
-	with codecs.open(source, "r", "utf-8") as f:
-		manifest_template = f.read()
-	manifest = manifest_template.format(**vars)
+    source: str,
+    dest: str,
+    *,
+    mo: str,
+    addon_info: AddonInfo,
+    brailleTables: BrailleTables,
+    symbolDictionaries: SymbolDictionaries,
+):
+    with open(mo, "rb") as f:
+        _ = gettext.GNUTranslations(f).gettext
+    vars: dict[str, str] = {}
+    for var in ("addon_summary", "addon_description", "addon_changelog"):
+        vars[var] = _(addon_info[var])
+    with codecs.open(source, "r", "utf-8") as f:
+        manifest_template = f.read()
+    manifest = manifest_template.format(**vars)
 
-	_format_section_only_with_displayName = partial(
-		format_nested_section,
-		include_only_keys = ("displayName",),
-		_ = _,
-	)
+    _format_section_only_with_displayName = partial(
+        format_nested_section,
+        include_only_keys=("displayName",),
+        _=_,
+    )
 
-	# Add additional manifest sections such as custom braile tables
-	# Custom braille translation tables
-	if brailleTables:
-		manifest += _format_section_only_with_displayName("brailleTables", brailleTables)
+    # Add additional manifest sections such as custom braile tables
+    # Custom braille translation tables
+    if brailleTables:
+        manifest += _format_section_only_with_displayName(
+            "brailleTables", brailleTables
+        )
 
-	# Custom speech symbol dictionaries
-	if symbolDictionaries:
-		manifest += _format_section_only_with_displayName("symbolDictionaries", symbolDictionaries)
+    # Custom speech symbol dictionaries
+    if symbolDictionaries:
+        manifest += _format_section_only_with_displayName(
+            "symbolDictionaries", symbolDictionaries
+        )
 
-	with codecs.open(dest, "w", "utf-8") as f:
-		f.write(manifest)
+    with codecs.open(dest, "w", "utf-8") as f:
+        f.write(manifest)

--- a/site_scons/site_tools/NVDATool/typings.py
+++ b/site_scons/site_tools/NVDATool/typings.py
@@ -1,22 +1,21 @@
-from typing import TypedDict, Protocol
-
+from typing import Protocol, TypedDict
 
 
 class AddonInfo(TypedDict):
-	addon_name: str
-	addon_summary: str
-	addon_description: str
-	addon_version: str
-	addon_changelog: str
-	addon_author: str
-	addon_url: str | None
-	addon_sourceURL: str | None
-	addon_docFileName: str
-	addon_minimumNVDAVersion: str | None
-	addon_lastTestedNVDAVersion: str | None
-	addon_updateChannel: str | None
-	addon_license: str | None
-	addon_licenseURL: str | None
+    addon_name: str
+    addon_summary: str
+    addon_description: str
+    addon_version: str
+    addon_changelog: str
+    addon_author: str
+    addon_url: str | None
+    addon_sourceURL: str | None
+    addon_docFileName: str
+    addon_minimumNVDAVersion: str | None
+    addon_lastTestedNVDAVersion: str | None
+    addon_updateChannel: str | None
+    addon_license: str | None
+    addon_licenseURL: str | None
 
 
 class BrailleTableAttributes(TypedDict):
@@ -36,4 +35,4 @@ SymbolDictionaries = dict[str, SymbolDictionaryAttributes]
 
 
 class Strable(Protocol):
-	def __str__(self) -> str: ...
+    def __str__(self) -> str: ...

--- a/site_scons/site_tools/NVDATool/utils.py
+++ b/site_scons/site_tools/NVDATool/utils.py
@@ -3,26 +3,25 @@ from collections.abc import Callable, Container, Mapping
 from .typings import Strable
 
 
-
 def _(arg: str) -> str:
-	"""
-	A function that passes the string to it without doing anything to it.
-	Needed for recognizing strings for translation by Gettext.
-	"""
-	return arg
+    """
+    A function that passes the string to it without doing anything to it.
+    Needed for recognizing strings for translation by Gettext.
+    """
+    return arg
 
 
 def format_nested_section(
-	section_name: str,
-	data: Mapping[str, Mapping[str, Strable]],
-	include_only_keys: Container[str] | None = None,
-	_: Callable[[str], str] = _,
+    section_name: str,
+    data: Mapping[str, Mapping[str, Strable]],
+    include_only_keys: Container[str] | None = None,
+    _: Callable[[str], str] = _,
 ) -> str:
-	lines = [f"\n[{section_name}]"]
-	for item_name, inner_dict in data.items():
-		lines.append(f"[[{item_name}]]")
-		for key, val in inner_dict.items():
-			if include_only_keys and key not in include_only_keys:
-				continue
-			lines.append(f"{key} = {_(str(val))}")
-	return "\n".join(lines) + "\n"
+    lines = [f"\n[{section_name}]"]
+    for item_name, inner_dict in data.items():
+        lines.append(f"[[{item_name}]]")
+        for key, val in inner_dict.items():
+            if include_only_keys and key not in include_only_keys:
+                continue
+            lines.append(f"{key} = {_(str(val))}")
+    return "\n".join(lines) + "\n"

--- a/site_scons/site_tools/gettexttool/__init__.py
+++ b/site_scons/site_tools/gettexttool/__init__.py
@@ -20,36 +20,40 @@ from SCons.Action import Action
 
 
 def exists(env):
-	return True
+    return True
 
 
 XGETTEXT_COMMON_ARGS = (
-	"--msgid-bugs-address='$gettext_package_bugs_address' "
-	"--package-name='$gettext_package_name' "
-	"--package-version='$gettext_package_version' "
-	"--keyword=pgettext:1c,2 "
-	"-c -o $TARGET $SOURCES"
+    "--msgid-bugs-address='$gettext_package_bugs_address' "
+    "--package-name='$gettext_package_name' "
+    "--package-version='$gettext_package_version' "
+    "--keyword=pgettext:1c,2 "
+    "-c -o $TARGET $SOURCES"
 )
 
 
 def generate(env):
-	env.SetDefault(gettext_package_bugs_address="example@example.com")
-	env.SetDefault(gettext_package_name="")
-	env.SetDefault(gettext_package_version="")
+    env.SetDefault(gettext_package_bugs_address="example@example.com")
+    env.SetDefault(gettext_package_name="")
+    env.SetDefault(gettext_package_version="")
 
-	env["BUILDERS"]["gettextMoFile"] = env.Builder(
-		action=Action("msgfmt -o $TARGET $SOURCE", "Compiling translation $SOURCE"),
-		suffix=".mo",
-		src_suffix=".po",
-	)
+    env["BUILDERS"]["gettextMoFile"] = env.Builder(
+        action=Action("msgfmt -o $TARGET $SOURCE", "Compiling translation $SOURCE"),
+        suffix=".mo",
+        src_suffix=".po",
+    )
 
-	env["BUILDERS"]["gettextPotFile"] = env.Builder(
-		action=Action("xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"), suffix=".pot"
-	)
+    env["BUILDERS"]["gettextPotFile"] = env.Builder(
+        action=Action(
+            "xgettext " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"
+        ),
+        suffix=".pot",
+    )
 
-	env["BUILDERS"]["gettextMergePotFile"] = env.Builder(
-		action=Action(
-			"xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS, "Generating pot file $TARGET"
-		),
-		suffix=".pot",
-	)
+    env["BUILDERS"]["gettextMergePotFile"] = env.Builder(
+        action=Action(
+            "xgettext " + "--omit-header --no-location " + XGETTEXT_COMMON_ARGS,
+            "Generating pot file $TARGET",
+        ),
+        suffix=".pot",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 conftest.py for the stub-based test tree.
 

--- a/tests/fake_tts_backend.py
+++ b/tests/fake_tts_backend.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Shared TTSBackend test double.
 
 A plain class, not a MagicMock() spec -- consistent with this project's
@@ -13,14 +12,22 @@ from dengjen_neural_voices.ports.tts_backend import LoadedVoice, SynthOptions
 
 
 class FakeTTSBackend:
-    def __init__(self, *, version="1.0.0-fake", default_loaded_voice=None, synthesize_chunks=(b"",)):
+    def __init__(
+        self,
+        *,
+        version="1.0.0-fake",
+        default_loaded_voice=None,
+        synthesize_chunks=(b"",),
+    ):
         self.version = version
         self.default_loaded_voice = default_loaded_voice or LoadedVoice(
             backend_voice_id="fake-remote-id",
             supports_streaming_output=False,
             sample_rate=22050,
             speakers={},
-            defaults=SynthOptions(speaker=None, length_scale=1.0, noise_scale=0.667, noise_w=0.8),
+            defaults=SynthOptions(
+                speaker=None, length_scale=1.0, noise_scale=0.667, noise_w=0.8
+            ),
         )
         self.synthesize_chunks = list(synthesize_chunks)
         self.voices_by_config_path = {}
@@ -68,7 +75,9 @@ class FakeTTSBackend:
         if self._raise_on_load_voice is not None:
             raise self._raise_on_load_voice
         loaded = self.voices_by_config_path.get(config_path, self.default_loaded_voice)
-        self._synth_options_by_voice_id.setdefault(loaded.backend_voice_id, loaded.defaults)
+        self._synth_options_by_voice_id.setdefault(
+            loaded.backend_voice_id, loaded.defaults
+        )
         return loaded
 
     def get_synth_options(self, backend_voice_id):
@@ -81,7 +90,16 @@ class FakeTTSBackend:
         updates = {k: v for k, v in kwargs.items() if v is not None}
         self._synth_options_by_voice_id[backend_voice_id] = replace(current, **updates)
 
-    async def synthesize(self, backend_voice_id, text, rate, volume, pitch, sentence_silence_ms, streaming):
+    async def synthesize(
+        self,
+        backend_voice_id,
+        text,
+        rate,
+        volume,
+        pitch,
+        sentence_silence_ms,
+        streaming,
+    ):
         self.synthesize_calls.append((backend_voice_id, text))
         if self._raise_on_synthesize is not None:
             raise self._raise_on_synthesize

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Stubs for NVDA's internal modules, so add-on code can be imported and driven
 outside a real NVDA process.
@@ -27,18 +26,18 @@ then drifts. Strategy, unchanged from before:
 """
 
 import builtins
-import inspect
-import sys
-import os
-import types
 import importlib.util
+import inspect
+import os
+import sys
+import types
 from concurrent.futures import Future as _Future
 from unittest.mock import MagicMock
-
 
 # ---------------------------------------------------------------------------
 # Helper utilities
 # ---------------------------------------------------------------------------
+
 
 def _stub_module(name: str, **attrs) -> types.ModuleType:
     """Create a plain module stub and register it in sys.modules."""
@@ -116,8 +115,12 @@ def install(*, stub_wx: bool = True) -> None:
     # -----------------------------------------------------------------------
 
     for _grpc_name in [
-        "grpc", "grpc._cython", "grpc._cython.cygrpc",
-        "grpc._compression", "grpc.experimental", "grpc.aio",
+        "grpc",
+        "grpc._cython",
+        "grpc._cython.cygrpc",
+        "grpc._compression",
+        "grpc.experimental",
+        "grpc.aio",
     ]:
         sys.modules.setdefault(_grpc_name, MagicMock())
 
@@ -130,7 +133,9 @@ def install(*, stub_wx: bool = True) -> None:
     # -----------------------------------------------------------------------
 
     # globalVars
-    _stub_module("globalVars", appArgs=types.SimpleNamespace(configPath="/tmp/nvda_test_config"))
+    _stub_module(
+        "globalVars", appArgs=types.SimpleNamespace(configPath="/tmp/nvda_test_config")
+    )
 
     # languageHandler
     def _normalize_language(lang: str) -> str:
@@ -155,11 +160,14 @@ def install(*, stub_wx: bool = True) -> None:
             val = _FakeConfSection()
             self[key] = val
             return val
+
         def isSet(self, key):
             return key in self
+
         @property
         def spec(self):
             return _FakeConfSection()
+
         def update(self, other):
             pass
 
@@ -189,9 +197,9 @@ def install(*, stub_wx: bool = True) -> None:
             for klass in cls.__mro__:
                 for attr_name in vars(klass):
                     if attr_name.startswith("_get_"):
-                        prop_names.add(attr_name[len("_get_"):])
+                        prop_names.add(attr_name[len("_get_") :])
                     elif attr_name.startswith("_set_"):
-                        prop_names.add(attr_name[len("_set_"):])
+                        prop_names.add(attr_name[len("_set_") :])
             for prop_name in prop_names:
                 if prop_name in cls.__dict__:
                     continue
@@ -199,7 +207,6 @@ def install(*, stub_wx: bool = True) -> None:
                 setter = getattr(cls, f"_set_{prop_name}", None)
                 setattr(cls, prop_name, property(getter, setter))
             return cls
-
 
     class _FakeSynthDriver(metaclass=_AutoPropertyMeta):
         cachePropertiesByDefault = False
@@ -209,7 +216,10 @@ def install(*, stub_wx: bool = True) -> None:
         RateBoostSetting = MagicMock(return_value=MagicMock())
         VolumeSetting = MagicMock(return_value=MagicMock())
         PitchSetting = MagicMock(return_value=MagicMock())
-        def __init__(self): pass
+
+        def __init__(self):
+            pass
+
         def _percentToParam(self, percent, min_val, max_val):
             return min_val + (max_val - min_val) * percent / 100
 
@@ -237,14 +247,29 @@ def install(*, stub_wx: bool = True) -> None:
 
     # nvwave
     class _FakeWavePlayer:
-        def __init__(self, *args, **kwargs): pass
-        def feed(self, data): pass
-        def sync(self): pass
-        def stop(self): pass
-        def pause(self, switch): pass
-        def close(self): pass
-        def idle(self): pass
-        def setVolume(self, **kwargs): pass
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def feed(self, data):
+            pass
+
+        def sync(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def pause(self, switch):
+            pass
+
+        def close(self):
+            pass
+
+        def idle(self):
+            pass
+
+        def setVolume(self, **kwargs):
+            pass
 
     _stub_module("nvwave", WavePlayer=_FakeWavePlayer)
 
@@ -258,7 +283,9 @@ def install(*, stub_wx: bool = True) -> None:
         "speech.commands",
         IndexCommand=type("IndexCommand", (), {"index": 0}),
         BreakCommand=type("BreakCommand", (), {"time": 0}),
-        LangChangeCommand=type("LangChangeCommand", (), {"lang": "en", "isDefault": False}),
+        LangChangeCommand=type(
+            "LangChangeCommand", (), {"lang": "en", "isDefault": False}
+        ),
         RateCommand=type("RateCommand", (), {"newValue": 50}),
         VolumeCommand=type("VolumeCommand", (), {"newValue": 100}),
         PitchCommand=type("PitchCommand", (), {"newValue": 50}),
@@ -279,7 +306,7 @@ def install(*, stub_wx: bool = True) -> None:
     _stub_module(
         "addonHandler",
         initTranslation=_init_translation,
-        getAvailableAddons=lambda: [],
+        getAvailableAddons=list,
     )
 
     # wx / gui
@@ -291,14 +318,29 @@ def install(*, stub_wx: bool = True) -> None:
             # Distinct bit flags, as in real wx, so bitwise-OR combinations (e.g.
             # wx.YES_NO | wx.ICON_WARNING) can't collide with any other stubbed
             # constant, including ones ORed together elsewhere (e.g. wx.OK).
-            ID_ANY=0, YES=1, NO=2, YES_NO=3, OK=4,
-            ICON_WARNING=8, ICON_ERROR=16, ICON_INFORMATION=32,
+            ID_ANY=0,
+            YES=1,
+            NO=2,
+            YES_NO=3,
+            OK=4,
+            ICON_WARNING=8,
+            ICON_ERROR=16,
+            ICON_INFORMATION=32,
             EVT_MENU=MagicMock(),
             CallAfter=MagicMock(side_effect=lambda func, *a, **kw: func(*a, **kw)),
             ProgressDialog=MagicMock(return_value=MagicMock()),
         )
-    _stub_module("gui", messageBox=MagicMock(), mainFrame=MagicMock(), runScriptModalDialog=MagicMock())
-    _stub_module("gui.settingsDialogs", NVDASettingsDialog=MagicMock(), SpeechSettingsPanel=MagicMock())
+    _stub_module(
+        "gui",
+        messageBox=MagicMock(),
+        mainFrame=MagicMock(),
+        runScriptModalDialog=MagicMock(),
+    )
+    _stub_module(
+        "gui.settingsDialogs",
+        NVDASettingsDialog=MagicMock(),
+        SpeechSettingsPanel=MagicMock(),
+    )
     _stub_module("core", postNvdaStartup=MagicMock(), restart=MagicMock())
 
     class _FakeGlobalPlugin:
@@ -314,7 +356,6 @@ def install(*, stub_wx: bool = True) -> None:
 
     _stub_module("globalPluginHandler", GlobalPlugin=_FakeGlobalPlugin)
     _stub_module("ui", message=MagicMock())
-
 
     # -----------------------------------------------------------------------
     # 3. Register `dengjen_neural_voices` as a package WITHOUT running __init__.py
@@ -334,7 +375,6 @@ def install(*, stub_wx: bool = True) -> None:
         submodule_search_locations=[_SYNTH_PKG_DIR],
     )
     sys.modules["dengjen_neural_voices"] = _pkg
-
 
     # -----------------------------------------------------------------------
     # 4. Stub intra-package submodules that have platform/runtime dependencies
@@ -367,10 +407,10 @@ def install(*, stub_wx: bool = True) -> None:
                 return _aio.ENGINE.executor.submit(func, *args, **kwargs)
             except RuntimeError:
                 return None
+
         return wrapper
 
     _aio.call_threaded = _call_threaded
-
 
     # -----------------------------------------------------------------------
     # 5. Load real submodules we actually want to test
@@ -390,8 +430,12 @@ def install(*, stub_wx: bool = True) -> None:
     # dengjen_tts_global_plugin's `from dengjen_neural_voices import
     # DengjenTextToSpeechSystem, DENGJEN_VOICES_DIR`, exercised for real in
     # tests_gui/) have to be set here by hand, from the module just loaded.
-    _pkg.DengjenTextToSpeechSystem = sys.modules["dengjen_neural_voices.domain.tts_system"].DengjenTextToSpeechSystem
-    _pkg.DENGJEN_VOICES_DIR = sys.modules["dengjen_neural_voices.domain.tts_system"].DENGJEN_VOICES_DIR
+    _pkg.DengjenTextToSpeechSystem = sys.modules[
+        "dengjen_neural_voices.domain.tts_system"
+    ].DengjenTextToSpeechSystem
+    _pkg.DENGJEN_VOICES_DIR = sys.modules[
+        "dengjen_neural_voices.domain.tts_system"
+    ].DENGJEN_VOICES_DIR
 
     # -----------------------------------------------------------------------
     # 6. Register `dengjen_tts_global_plugin` as a package WITHOUT running its
@@ -413,10 +457,16 @@ def install(*, stub_wx: bool = True) -> None:
         _gui_plugin_pkg = types.ModuleType("dengjen_tts_global_plugin")
         _gui_plugin_pkg.__path__ = [_GLOBAL_PLUGIN_PKG_DIR]
         _gui_plugin_pkg.__package__ = "dengjen_tts_global_plugin"
-        _gui_plugin_pkg.DengjenTextToSpeechSystem = sys.modules["dengjen_neural_voices.domain.tts_system"].DengjenTextToSpeechSystem
-        _gui_plugin_pkg.DENGJEN_VOICES_DIR = sys.modules["dengjen_neural_voices.domain.tts_system"].DENGJEN_VOICES_DIR
+        _gui_plugin_pkg.DengjenTextToSpeechSystem = sys.modules[
+            "dengjen_neural_voices.domain.tts_system"
+        ].DengjenTextToSpeechSystem
+        _gui_plugin_pkg.DENGJEN_VOICES_DIR = sys.modules[
+            "dengjen_neural_voices.domain.tts_system"
+        ].DENGJEN_VOICES_DIR
         _gui_plugin_pkg.helpers = sys.modules["dengjen_neural_voices.helpers"]
-        _gui_plugin_pkg.voice_migration = sys.modules["dengjen_neural_voices.voice_migration"]
+        _gui_plugin_pkg.voice_migration = sys.modules[
+            "dengjen_neural_voices.voice_migration"
+        ]
         _gui_plugin_pkg.aio = _aio
         _gui_plugin_pkg.SonataGrpcBackend = _sonata_grpc.SonataGrpcBackend
         sys.modules["dengjen_tts_global_plugin"] = _gui_plugin_pkg

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -66,7 +66,7 @@ GLOBAL_PLUGIN_PKG_DIR = os.path.abspath(_GLOBAL_PLUGIN_PKG_DIR)
 
 
 def load_module_from_path(
-    module_name: str, path: str, package: str = None
+    module_name: str, path: str, package: str | None = None
 ) -> types.ModuleType:
     """Execute a real .py file as a registered module.
 

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for aio.AsyncEngine — the class that owns the thread pool executor and
 asyncio event loop the synth driver runs its gRPC and audio work on.
@@ -171,9 +170,9 @@ class TestRunInExecutor:
         async def drive():
             return await running_engine.run_in_executor(recorded.append, "value")
 
-        asyncio.run_coroutine_threadsafe(
-            drive(), running_engine.event_loop
-        ).result(timeout=5)
+        asyncio.run_coroutine_threadsafe(drive(), running_engine.event_loop).result(
+            timeout=5
+        )
         assert recorded == ["value"]
 
     def test_passes_through_keyword_arguments(self, running_engine):
@@ -290,7 +289,9 @@ class TestModuleLevelDelegation:
             return await aio.run_in_executor(recorded.append, "value")
 
         aio.initialize()
-        asyncio.run_coroutine_threadsafe(drive(), aio.ENGINE.event_loop).result(timeout=5)
+        asyncio.run_coroutine_threadsafe(drive(), aio.ENGINE.event_loop).result(
+            timeout=5
+        )
         assert recorded == ["value"]
 
     def test_asyncio_coroutine_to_concurrent_future_uses_the_singleton(self):

--- a/tests/test_buildvars.py
+++ b/tests/test_buildvars.py
@@ -1,17 +1,15 @@
-# coding: utf-8
 """
 Tests for buildVars.py — validate that the addon manifest metadata
 meets NVDA Add-on Store requirements.
 """
 
+import os
 import re
 import sys
-import os
 
 # Ensure repo root is on path so buildVars is importable directly
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import buildVars
-
 
 INFO = buildVars.addon_info
 
@@ -111,7 +109,9 @@ class TestURLFields:
         for field in self.URL_FIELDS:
             url = INFO.get(field)
             if url is not None:
-                assert url_re.match(url), f"'{field}' does not look like a valid URL: {url!r}"
+                assert url_re.match(url), (
+                    f"'{field}' does not look like a valid URL: {url!r}"
+                )
 
 
 class TestAddonName:
@@ -133,8 +133,12 @@ class TestAuthorFormat:
 
     def test_author_contains_email(self):
         author = INFO["addon_author"]
-        assert "<" in author, f"addon_author '{author}' should contain an opening angle bracket"
-        assert ">" in author, f"addon_author '{author}' should contain a closing angle bracket"
+        assert "<" in author, (
+            f"addon_author '{author}' should contain an opening angle bracket"
+        )
+        assert ">" in author, (
+            f"addon_author '{author}' should contain a closing angle bracket"
+        )
 
     def test_author_email_is_valid(self):
         author = INFO["addon_author"]

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for _config.py — the thin mapping over NVDA's config section for this
 synth, which stores per-voice variant/speaker/scale settings.

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for aio module lifecycle resilience and re-initialization behavior.
 """
@@ -6,13 +5,13 @@ Tests for aio module lifecycle resilience and re-initialization behavior.
 import ast
 import asyncio
 import gc
-import os
 import glob
+import importlib.util
+import os
 import threading
 import time
 import types
 import warnings
-import importlib.util
 
 _STRESS_THREADS = 8
 _STRESS_ITERATIONS = 40
@@ -87,16 +86,13 @@ def _settled_loop_thread_count(timeout=2):
     """Loop-thread count once stopped threads have had a chance to exit."""
     deadline = time.monotonic() + timeout
     while True:
-        count = len(
-            [t for t in threading.enumerate() if t.name == _LOOP_THREAD_NAME]
-        )
+        count = len([t for t in threading.enumerate() if t.name == _LOOP_THREAD_NAME])
         if count <= 1 or time.monotonic() > deadline:
             return count
         time.sleep(0.05)
 
 
 class TestAioLifecycle:
-
     def setup_method(self):
         aio.initialize()
 
@@ -244,7 +240,6 @@ class TestAioGlobalsDoNotLeakMutableState:
 
 
 class TestGrpcChannelTeardown:
-
     def setup_method(self):
         aio.initialize()
 
@@ -311,7 +306,8 @@ class TestSynthDriverShimReexport:
         shim_tree = ast.parse(shim_source, filename=_SHIM_INIT_PATH)
 
         import_nodes = [
-            node for node in ast.walk(shim_tree)
+            node
+            for node in ast.walk(shim_tree)
             if isinstance(node, ast.ImportFrom)
             and node.level == 1
             and node.module == "adapters.nvda.synth_driver"
@@ -333,11 +329,10 @@ class TestSynthDriverShimReexport:
             target_source = f.read()
         target_tree = ast.parse(target_source, filename=_SYNTH_DRIVER_PATH)
         defined_names = {
-            node.name for node in ast.walk(target_tree)
+            node.name
+            for node in ast.walk(target_tree)
             if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
         }
         assert "SynthDriver" in defined_names, (
             f"{_SYNTH_DRIVER_PATH} no longer defines SynthDriver"
         )
-
-

--- a/tests/test_fake_tts_backend.py
+++ b/tests/test_fake_tts_backend.py
@@ -1,9 +1,8 @@
-# coding: utf-8
 import asyncio
 
 import pytest
-
 from dengjen_neural_voices.ports.tts_backend import BackendUnavailableError
+
 from tests.fake_tts_backend import FakeTTSBackend
 
 
@@ -20,7 +19,9 @@ def test_set_synth_options_updates_get_synth_options():
     backend.set_synth_options(loaded.backend_voice_id, noise_scale=1.5)
     assert backend.get_synth_options(loaded.backend_voice_id).noise_scale == 1.5
     # Explicit None values must not clobber existing fields.
-    backend.set_synth_options(loaded.backend_voice_id, length_scale=2.0, noise_scale=None)
+    backend.set_synth_options(
+        loaded.backend_voice_id, length_scale=2.0, noise_scale=None
+    )
     assert backend.get_synth_options(loaded.backend_voice_id).noise_scale == 1.5
     assert backend.get_synth_options(loaded.backend_voice_id).length_scale == 2.0
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,16 +1,13 @@
-# coding: utf-8
 """
 Tests for helpers.py — port utilities with no NVDA dependency.
 """
 
 import socket
-import pytest
 
-from dengjen_neural_voices.helpers import is_free_port, find_free_port
+from dengjen_neural_voices.helpers import find_free_port, is_free_port
 
 
 class TestIsFreePport:
-
     def test_returns_true_for_free_port(self):
         port = find_free_port()
         assert is_free_port(port)
@@ -24,7 +21,6 @@ class TestIsFreePport:
 
 
 class TestFindFreePort:
-
     def test_returns_integer(self):
         port = find_free_port()
         assert isinstance(port, int)

--- a/tests/test_install_migrations.py
+++ b/tests/test_install_migrations.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Tests for the 4.0.0 upgrade path in installTasks.py.
 
 The real upgrade runs inside NVDA on Windows. These exercise the decision
@@ -130,7 +129,9 @@ class _FakeAggregatedSection:
 
     def as_plain_dict(self):
         return {
-            key: value.as_plain_dict() if isinstance(value, _FakeAggregatedSection) else value
+            key: value.as_plain_dict()
+            if isinstance(value, _FakeAggregatedSection)
+            else value
             for key, value in self._data.items()
         }
 
@@ -208,19 +209,24 @@ class _FakeAddon:
 
 class TestIsOldAddonInstalled:
     def test_detects_the_old_addon(self):
-        assert install_tasks.is_old_addon_installed(
-            [_FakeAddon("sonata_neural_voices")]
-        ) is True
+        assert (
+            install_tasks.is_old_addon_installed([_FakeAddon("sonata_neural_voices")])
+            is True
+        )
 
     def test_ignores_the_new_addon(self):
-        assert install_tasks.is_old_addon_installed(
-            [_FakeAddon("dengjen_neural_voices")]
-        ) is False
+        assert (
+            install_tasks.is_old_addon_installed([_FakeAddon("dengjen_neural_voices")])
+            is False
+        )
 
     def test_ignores_an_addon_already_pending_removal(self):
-        assert install_tasks.is_old_addon_installed(
-            [_FakeAddon("sonata_neural_voices", pending_remove=True)]
-        ) is False
+        assert (
+            install_tasks.is_old_addon_installed(
+                [_FakeAddon("sonata_neural_voices", pending_remove=True)]
+            )
+            is False
+        )
 
     def test_handles_an_empty_addon_list(self):
         assert install_tasks.is_old_addon_installed([]) is False

--- a/tests/test_install_tasks.py
+++ b/tests/test_install_tasks.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for installTasks.py — the uninstall hook that force-kills a leftover
 dengjen-tts-grpc server process.
@@ -22,7 +21,9 @@ GRPC_EXE = os.path.join(install_tasks.BIN_DIR, "dengjen-tts-grpc.exe")
 
 
 class _FakeProcess:
-    def __init__(self, name, exe, pid=1, name_error=None, exe_error=None, kill_error=None):
+    def __init__(
+        self, name, exe, pid=1, name_error=None, exe_error=None, kill_error=None
+    ):
         self._name = name
         self._exe = exe
         self.pid = pid
@@ -103,14 +104,18 @@ class TestForceKillDengjenGrpcServer:
     def test_does_not_kill_a_same_named_exe_from_another_location(
         self, samefile_by_path
     ):
-        impostor = _FakeProcess("dengjen-tts-grpc.exe", "/tmp/elsewhere/dengjen-tts-grpc.exe")
+        impostor = _FakeProcess(
+            "dengjen-tts-grpc.exe", "/tmp/elsewhere/dengjen-tts-grpc.exe"
+        )
         psutil = _FakePsutil([impostor])
         install_tasks.force_kill_dengjen_grpc_server(psutil)
         assert not impostor.killed
 
     def test_kills_only_the_matching_process_among_several(self, samefile_by_path):
         ours = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=1)
-        impostor = _FakeProcess("dengjen-tts-grpc.exe", "/tmp/dengjen-tts-grpc.exe", pid=2)
+        impostor = _FakeProcess(
+            "dengjen-tts-grpc.exe", "/tmp/dengjen-tts-grpc.exe", pid=2
+        )
         unrelated = _FakeProcess("bash", "/bin/bash", pid=3)
         psutil = _FakePsutil([ours, impostor, unrelated])
         install_tasks.force_kill_dengjen_grpc_server(psutil)
@@ -118,9 +123,7 @@ class TestForceKillDengjenGrpcServer:
         assert not impostor.killed
         assert not unrelated.killed
 
-    def test_waits_on_the_name_matched_processes_with_a_timeout(
-        self, samefile_by_path
-    ):
+    def test_waits_on_the_name_matched_processes_with_a_timeout(self, samefile_by_path):
         ours = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=1)
         unrelated = _FakeProcess("bash", "/bin/bash", pid=2)
         psutil = _FakePsutil([ours, unrelated])
@@ -134,7 +137,9 @@ class TestForceKillDengjenGrpcServer:
         assert psutil.waited_for == []
 
     def test_skips_a_process_whose_name_cannot_be_inspected(self, samefile_by_path):
-        unreadable = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=1, name_error=Exception("gone"))
+        unreadable = _FakeProcess(
+            "dengjen-tts-grpc.exe", GRPC_EXE, pid=1, name_error=Exception("gone")
+        )
         ours = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=2)
         psutil = _FakePsutil([unreadable, ours])
         install_tasks.force_kill_dengjen_grpc_server(psutil)
@@ -142,7 +147,9 @@ class TestForceKillDengjenGrpcServer:
         assert ours.killed
 
     def test_skips_a_process_whose_exe_cannot_be_inspected(self, samefile_by_path):
-        unreadable = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=1, exe_error=Exception("gone"))
+        unreadable = _FakeProcess(
+            "dengjen-tts-grpc.exe", GRPC_EXE, pid=1, exe_error=Exception("gone")
+        )
         ours = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=2)
         psutil = _FakePsutil([unreadable, ours])
         install_tasks.force_kill_dengjen_grpc_server(psutil)
@@ -160,8 +167,15 @@ class TestForceKillDengjenGrpcServer:
         install_tasks.force_kill_dengjen_grpc_server(psutil)
         assert not proc.killed
 
-    def test_one_process_failing_to_die_does_not_stop_the_others(self, samefile_by_path):
-        stubborn = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=1, kill_error=Exception("access denied"))
+    def test_one_process_failing_to_die_does_not_stop_the_others(
+        self, samefile_by_path
+    ):
+        stubborn = _FakeProcess(
+            "dengjen-tts-grpc.exe",
+            GRPC_EXE,
+            pid=1,
+            kill_error=Exception("access denied"),
+        )
         ours = _FakeProcess("dengjen-tts-grpc.exe", GRPC_EXE, pid=2)
         psutil = _FakePsutil([stubborn, ours])
         install_tasks.force_kill_dengjen_grpc_server(psutil)

--- a/tests/test_ports_tts_backend.py
+++ b/tests/test_ports_tts_backend.py
@@ -1,6 +1,4 @@
-# coding: utf-8
 import pytest
-
 from dengjen_neural_voices.ports.tts_backend import (
     BackendError,
     BackendUnavailableError,
@@ -19,7 +17,9 @@ def test_synth_options_is_frozen():
 
 
 def test_loaded_voice_carries_defaults_as_synth_options():
-    defaults = SynthOptions(speaker=None, length_scale=1.0, noise_scale=0.5, noise_w=0.8)
+    defaults = SynthOptions(
+        speaker=None, length_scale=1.0, noise_scale=0.5, noise_w=0.8
+    )
     voice = LoadedVoice(
         backend_voice_id="v1",
         supports_streaming_output=True,

--- a/tests/test_sonata_grpc_backend.py
+++ b/tests/test_sonata_grpc_backend.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for SonataGrpcBackend's TTSBackend surface: that it correctly
 translates the underlying module-level gRPC calls' failures into the
@@ -9,8 +8,7 @@ dengjen-tts-grpc.exe) are covered by tests_contract/, not here.
 from concurrent.futures import Future
 
 import pytest
-
-import dengjen_neural_voices.adapters.sonata_grpc as sonata_grpc
+from dengjen_neural_voices.adapters import sonata_grpc
 from dengjen_neural_voices.ports.tts_backend import (
     BackendUnavailableError,
     SynthesisError,
@@ -33,7 +31,9 @@ def _resolved_future(value):
 
 
 def test_initialize_wraps_a_failure_as_backend_unavailable(monkeypatch):
-    monkeypatch.setattr(sonata_grpc, "initialize", lambda: _failed_future(RuntimeError("no port")))
+    monkeypatch.setattr(
+        sonata_grpc, "initialize", lambda: _failed_future(RuntimeError("no port"))
+    )
     with pytest.raises(BackendUnavailableError):
         backend.initialize()
 
@@ -46,8 +46,12 @@ def test_check_version_wraps_a_failure_as_backend_unavailable(monkeypatch):
     # .result() can't call -- caught by check_version()'s except, so this
     # test would still pass, but only after leaking an unawaited-coroutine
     # RuntimeWarning into the test output.
-    monkeypatch.setattr(sonata_grpc, "check_grpc_server", lambda: _failed_future(TimeoutError()))
-    monkeypatch.setattr(sonata_grpc, "initialize", lambda: _failed_future(RuntimeError("no port")))
+    monkeypatch.setattr(
+        sonata_grpc, "check_grpc_server", lambda: _failed_future(TimeoutError())
+    )
+    monkeypatch.setattr(
+        sonata_grpc, "initialize", lambda: _failed_future(RuntimeError("no port"))
+    )
     with pytest.raises(BackendUnavailableError):
         backend.check_version()
 
@@ -71,7 +75,9 @@ def test_check_version_retries_once_after_a_failed_handshake_and_succeeds(monkey
     assert len(attempts) == 2
 
 
-def test_check_version_gives_up_as_backend_unavailable_after_one_failed_retry(monkeypatch):
+def test_check_version_gives_up_as_backend_unavailable_after_one_failed_retry(
+    monkeypatch,
+):
     """The retry is bounded: a second consecutive failure still surfaces as
     BackendUnavailableError rather than looping indefinitely."""
     attempts = []
@@ -90,7 +96,11 @@ def test_check_version_gives_up_as_backend_unavailable_after_one_failed_retry(mo
 
 
 def test_load_voice_wraps_a_failure_as_voice_load_error(monkeypatch):
-    monkeypatch.setattr(sonata_grpc, "load_voice", lambda path: _failed_future(RuntimeError("bad proto")))
+    monkeypatch.setattr(
+        sonata_grpc,
+        "load_voice",
+        lambda path: _failed_future(RuntimeError("bad proto")),
+    )
     with pytest.raises(VoiceLoadError):
         backend.load_voice("/tmp/v/config.json")
 
@@ -99,9 +109,12 @@ def test_load_voice_maps_the_response_fields(monkeypatch):
     class _FakeInfo:
         voice_key = "v1"
         supports_streaming_output = True
+
         class audio:
             sample_rate = 22050
+
         speakers = {"0": "Alice"}
+
         class synthesis_options:
             speaker = "Alice"
             length_scale = 1.0
@@ -122,7 +135,9 @@ def test_load_voice_maps_the_response_fields(monkeypatch):
 
 def test_set_synth_options_wraps_a_failure_as_voice_load_error(monkeypatch):
     monkeypatch.setattr(
-        sonata_grpc, "set_synth_options", lambda voice_id, **kw: _failed_future(RuntimeError("boom"))
+        sonata_grpc,
+        "set_synth_options",
+        lambda voice_id, **kw: _failed_future(RuntimeError("boom")),
     )
     with pytest.raises(VoiceLoadError):
         backend.set_synth_options("v1", noise_scale=0.5)
@@ -137,10 +152,13 @@ def test_synthesize_wraps_a_failure_as_synthesis_error():
 
     async def _run():
         with pytest.raises(SynthesisError):
-            async for _ in backend.synthesize("v1", "hi", None, None, None, None, False):
+            async for _ in backend.synthesize(
+                "v1", "hi", None, None, None, None, False
+            ):
                 pass
 
     import dengjen_neural_voices.adapters.sonata_grpc as mod
+
     orig = mod.speak
     mod.speak = _boom
     try:
@@ -165,10 +183,13 @@ def test_synthesize_yields_audio_bytes_not_the_raw_message():
     async def _run():
         return [
             chunk
-            async for chunk in backend.synthesize("v1", "hi", None, None, None, None, False)
+            async for chunk in backend.synthesize(
+                "v1", "hi", None, None, None, None, False
+            )
         ]
 
     import dengjen_neural_voices.adapters.sonata_grpc as mod
+
     orig = mod.speak
     mod.speak = _fake_speak
     try:
@@ -198,7 +219,9 @@ class TestClearStaleServerState:
         import types
 
         killed = types.SimpleNamespace(value=False)
-        fake_process = types.SimpleNamespace(kill=lambda: setattr(killed, "value", True))
+        fake_process = types.SimpleNamespace(
+            kill=lambda: setattr(killed, "value", True)
+        )
         monkeypatch.setattr(sonata_grpc, "GRPC_SERVER_PROCESS", fake_process)
         monkeypatch.setattr(sonata_grpc, "SONATA_GRPC_SERVER_PORT", 12345)
 
@@ -227,7 +250,9 @@ class TestClearStaleServerState:
         assert sonata_grpc.CHANNEL is None
         assert sonata_grpc.SONATA_GRPC_SERVICE is None
 
-    def test_a_channel_that_fails_to_close_does_not_stop_the_rest_of_the_cleanup(self, monkeypatch):
+    def test_a_channel_that_fails_to_close_does_not_stop_the_rest_of_the_cleanup(
+        self, monkeypatch
+    ):
         import asyncio
         import types
 
@@ -236,7 +261,9 @@ class TestClearStaleServerState:
                 raise Exception("channel already broken")
 
         killed = types.SimpleNamespace(value=False)
-        fake_process = types.SimpleNamespace(kill=lambda: setattr(killed, "value", True))
+        fake_process = types.SimpleNamespace(
+            kill=lambda: setattr(killed, "value", True)
+        )
         monkeypatch.setattr(sonata_grpc, "CHANNEL", _FakeChannel())
         monkeypatch.setattr(sonata_grpc, "GRPC_SERVER_PROCESS", fake_process)
 
@@ -251,6 +278,7 @@ class TestClearStaleServerState:
         # (not delattr) undoes its own patches -- it would raise trying to
         # restore an attribute the code under test already removed.
         import asyncio
+
         import globalVars
 
         globalVars.SONATA_GRPC_SERVER_PORT = 12345
@@ -266,7 +294,9 @@ class TestClearStaleServerState:
         import types
 
         closed = types.SimpleNamespace(value=False)
-        fake_handle = types.SimpleNamespace(close=lambda: setattr(closed, "value", True))
+        fake_handle = types.SimpleNamespace(
+            close=lambda: setattr(closed, "value", True)
+        )
         monkeypatch.setattr(sonata_grpc, "SERVER_LOG_HANDLE", fake_handle)
 
         asyncio.run(sonata_grpc._clear_stale_server_state())
@@ -276,6 +306,7 @@ class TestClearStaleServerState:
 
     def test_is_a_noop_when_nothing_is_cached(self, monkeypatch):
         import asyncio
+
         import globalVars
 
         monkeypatch.setattr(sonata_grpc, "GRPC_SERVER_PROCESS", None)

--- a/tests/test_synth_driver.py
+++ b/tests/test_synth_driver.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for the SynthDriver itself: construction, speech sequence handling,
 flush/cancel ordering, the settings NVDA reads and writes through driver
@@ -23,20 +22,18 @@ stand-ins used here don't interfere with the on-disk fixtures above.
 
 import asyncio
 import os
+from unittest.mock import MagicMock
 
 import config
 import pytest
 import ui
-from unittest.mock import MagicMock
-
+from dengjen_neural_voices.const import FALLBACK_SPEAKER_NAME
+from dengjen_neural_voices.domain import tts_system
 from logHandler import log
+from speech.commands import BreakCommand, IndexCommand, LangChangeCommand
 
 from tests.conftest import SYNTH_PKG_DIR, load_module_from_path
 from tests.fake_tts_backend import FakeTTSBackend
-
-from dengjen_neural_voices.domain import tts_system
-from dengjen_neural_voices.const import FALLBACK_SPEAKER_NAME
-from speech.commands import BreakCommand, IndexCommand, LangChangeCommand
 
 driver_module = load_module_from_path(
     "dengjen_neural_voices.adapters.nvda.synth_driver",
@@ -141,7 +138,9 @@ class TestConstruction:
         expected_lang = languageHandler.normalizeLanguage(lang).replace("_", "-")
         assert f"({expected_lang})" in display_name
 
-    def test_loads_voices_from_disk_only_once(self, configured_voice, fake_backend, monkeypatch):
+    def test_loads_voices_from_disk_only_once(
+        self, configured_voice, fake_backend, monkeypatch
+    ):
         """A previous version called load_piper_voices_from_nvda_config_dir()
         twice back to back in __init__ for no reason."""
         real_load = driver_module.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir.__func__
@@ -162,7 +161,9 @@ class TestConstruction:
         finally:
             d.terminate()
 
-    def test_backend_unavailable_leaves_the_driver_without_voices(self, configured_voice, monkeypatch):
+    def test_backend_unavailable_leaves_the_driver_without_voices(
+        self, configured_voice, monkeypatch
+    ):
         """A BackendUnavailableError from bootstrap must not raise out of
         __init__ -- the driver stays constructed but non-functional, same as
         today's broad except-Exception behavior, so NVDA can still report the
@@ -218,7 +219,12 @@ class TestBuildSpeechTasks:
         # A LangChangeCommand to the voice's own (already-default) language
         # is a no-op for tts.language, but must still split the surrounding
         # text into two SpeechTasks rather than merging it into one.
-        seq = ["hello ", "world", _lang_change_command("en_US", is_default=True), "more"]
+        seq = [
+            "hello ",
+            "world",
+            _lang_change_command("en_US", is_default=True),
+            "more",
+        ]
         tasks = driver._build_speech_tasks(seq)
         assert [type(t) for t in tasks] == [SpeechTask, SpeechTask, DoneSpeakingTask]
 
@@ -277,6 +283,7 @@ class TestProcessSpeechSequence:
                 await asyncio.sleep(0)
                 ran.append(n)
                 active -= 1
+
             return task
 
         asyncio.run(
@@ -406,7 +413,9 @@ class TestSettings:
         calls = [kwargs for _, kwargs in fake_backend.set_synth_options_calls]
         assert any("noise_scale" in kwargs for kwargs in calls)
 
-    def test_switching_variant_reapplies_noise_w_even_when_the_cached_value_is_unchanged(self, driver, fake_backend):
+    def test_switching_variant_reapplies_noise_w_even_when_the_cached_value_is_unchanged(
+        self, driver, fake_backend
+    ):
         # noise_w's skip_if_unchanged guard exists for the direct-set path
         # (avoid a redundant call when the user re-enters the same value);
         # a variant-switch reapply must bypass it, since the cached factor

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Catalogue-level checks, plus the source-level check that the catalogue is
 reached at all. No NVDA, no wx -- these run on both CI legs.
@@ -20,10 +19,11 @@ import re
 
 import pytest
 
-
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 _CATALOGUES = sorted(
-    glob.glob(os.path.join(_REPO_ROOT, "addon", "locale", "*", "LC_MESSAGES", "nvda.po"))
+    glob.glob(
+        os.path.join(_REPO_ROOT, "addon", "locale", "*", "LC_MESSAGES", "nvda.po")
+    )
 )
 _LOCALES = [path.split(os.sep)[-3] for path in _CATALOGUES]
 
@@ -73,7 +73,9 @@ def _po_entries(path):
         for lineno, raw in enumerate(handle, 1):
             line = raw.strip()
             if line.startswith(("msgid_plural", "msgstr[", "#~")):
-                raise AssertionError(f"{path}:{lineno}: unhandled po construct {line!r}")
+                raise AssertionError(
+                    f"{path}:{lineno}: unhandled po construct {line!r}"
+                )
             if line.startswith("msgid "):
                 if field is not None:
                     yield msgid, msgstr

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for the core TTS system logic in domain/tts_system.py.
 
@@ -6,32 +5,32 @@ All NVDA internals are stubbed by conftest.py. No gRPC/NVDA dependency: every
 voice here is constructed against a FakeTTSBackend.
 """
 
-import pytest
 from pathlib import Path
 
-from dengjen_neural_voices.domain.tts_system import (
-    DengjenVoice,
-    DengjenTextToSpeechSystem,
-    SpeechOptions,
-    SilenceProvider,
-    VoiceNotFoundError,
-    SpeakerNotFoundError,
-    Scales,
-)
+import pytest
 from dengjen_neural_voices.const import (
+    DEFAULT_PITCH,
     DEFAULT_RATE,
     DEFAULT_VOLUME,
-    DEFAULT_PITCH,
     FALLBACK_SPEAKER_NAME,
     IGNORED_PUNCS,
 )
+from dengjen_neural_voices.domain.tts_system import (
+    DengjenTextToSpeechSystem,
+    DengjenVoice,
+    Scales,
+    SilenceProvider,
+    SpeechOptions,
+    VoiceNotFoundError,
+)
 from dengjen_neural_voices.ports.tts_backend import SynthOptions
-from tests.fake_tts_backend import FakeTTSBackend
 
+from tests.fake_tts_backend import FakeTTSBackend
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 def _make_voice(
     backend,
@@ -62,7 +61,9 @@ def _make_voice(
     v.default_speaker = None
     backend._synth_options_by_voice_id.setdefault(
         v.remote_id,
-        SynthOptions(speaker="default", length_scale=1.0, noise_scale=0.667, noise_w=0.8),
+        SynthOptions(
+            speaker="default", length_scale=1.0, noise_scale=0.667, noise_w=0.8
+        ),
     )
     return v
 
@@ -92,7 +93,13 @@ def multi_voice(backend):
 def voice_list(backend, single_voice):
     return [
         single_voice,
-        _make_voice(backend, key="en-test+RT-medium", name="Test", language="en", sample_rate=16000),
+        _make_voice(
+            backend,
+            key="en-test+RT-medium",
+            name="Test",
+            language="en",
+            sample_rate=16000,
+        ),
         _make_voice(backend, key="fr-durand-medium", name="Durand", language="fr"),
     ]
 
@@ -115,8 +122,8 @@ def tts(voice_list):
 # DengjenVoice unit tests
 # ---------------------------------------------------------------------------
 
-class TestDengjenVoiceFromPath:
 
+class TestDengjenVoiceFromPath:
     def test_parses_standard_key(self, backend):
         v = DengjenVoice.from_path("/tmp/en-john-medium", backend)
         assert v.key == "en-john-medium"
@@ -153,8 +160,8 @@ class TestDengjenVoiceFromPath:
 # SilenceProvider unit tests -- unchanged, no backend involved
 # ---------------------------------------------------------------------------
 
-class TestSilenceProvider:
 
+class TestSilenceProvider:
     def test_generates_correct_byte_length(self):
         provider = SilenceProvider(time_ms=100, sample_rate=22050)
         audio = provider.generate_audio()
@@ -175,8 +182,8 @@ class TestSilenceProvider:
 # DengjenTextToSpeechSystem -- defaults
 # ---------------------------------------------------------------------------
 
-class TestTTSDefaults:
 
+class TestTTSDefaults:
     def test_rate_default(self, tts):
         assert tts.rate == DEFAULT_RATE
 
@@ -197,8 +204,8 @@ class TestTTSDefaults:
 # DengjenTextToSpeechSystem -- voice switching
 # ---------------------------------------------------------------------------
 
-class TestTTSVoiceSwitching:
 
+class TestTTSVoiceSwitching:
     def test_set_valid_voice(self, tts, voice_list):
         tts.voice = voice_list[1].key
         assert tts.voice == voice_list[1].key
@@ -230,7 +237,9 @@ class TestTTSVoiceSwitching:
         hyphen-joined code ('en-') while voice.language is underscore-joined
         ('en_US'), so the match always failed for dialect voices.
         """
-        dialect_voice = _make_voice(backend, key="en_US-alex-medium", name="Alex", language="en_US")
+        dialect_voice = _make_voice(
+            backend, key="en_US-alex-medium", name="Alex", language="en_US"
+        )
         opts = SpeechOptions.__new__(SpeechOptions)
         opts.voice = dialect_voice
         opts.rate = opts.volume = opts.pitch = opts.sentence_silence_ms = None
@@ -248,7 +257,9 @@ class TestTTSVoiceSwitching:
         before the driver ever compares languages, so a dash- or
         differently-cased request must resolve to the same dialect voice as
         the canonical 'en_US' form."""
-        dialect_voice = _make_voice(backend, key="en_US-alex-medium", name="Alex", language="en_US")
+        dialect_voice = _make_voice(
+            backend, key="en_US-alex-medium", name="Alex", language="en_US"
+        )
         opts = SpeechOptions.__new__(SpeechOptions)
         opts.voice = dialect_voice
         opts.rate = opts.volume = opts.pitch = opts.sentence_silence_ms = None
@@ -266,8 +277,8 @@ class TestTTSVoiceSwitching:
 # DengjenTextToSpeechSystem -- rate / volume / pitch
 # ---------------------------------------------------------------------------
 
-class TestTTSParameters:
 
+class TestTTSParameters:
     def test_set_rate(self, tts):
         tts.rate = 75
         assert tts.rate == 75
@@ -285,8 +296,8 @@ class TestTTSParameters:
 # DengjenTextToSpeechSystem -- synthesis context
 # ---------------------------------------------------------------------------
 
-class TestSynthesisContext:
 
+class TestSynthesisContext:
     def test_context_restores_rate(self, tts):
         tts.rate = 30
         with tts.create_synthesis_context():
@@ -310,8 +321,8 @@ class TestSynthesisContext:
 # DengjenTextToSpeechSystem -- providers
 # ---------------------------------------------------------------------------
 
-class TestProviders:
 
+class TestProviders:
     def test_create_speech_provider_stores_text(self, tts):
         provider = tts.create_speech_provider("Hello world")
         assert provider.text == "Hello world"
@@ -326,8 +337,8 @@ class TestProviders:
 # DengjenTextToSpeechSystem -- get_voice_variants
 # ---------------------------------------------------------------------------
 
-class TestGetVoiceVariants:
 
+class TestGetVoiceVariants:
     def test_standard_and_rt_keys(self):
         std, rt = DengjenTextToSpeechSystem.get_voice_variants("en-john-medium")
         assert std == "en-john-medium"
@@ -343,8 +354,8 @@ class TestGetVoiceVariants:
 # Speaker (single-speaker voice)
 # ---------------------------------------------------------------------------
 
-class TestSpeakerSingleVoice:
 
+class TestSpeakerSingleVoice:
     def test_speaker_returns_fallback_for_single_speaker(self, tts):
         assert tts.speaker == FALLBACK_SPEAKER_NAME
 
@@ -357,8 +368,8 @@ class TestSpeakerSingleVoice:
 # Synthesis options (backend-forwarded accessors)
 # ---------------------------------------------------------------------------
 
-class TestSynthOptionAccessors:
 
+class TestSynthOptionAccessors:
     @pytest.mark.parametrize(
         "name, expected",
         [("noise_scale", 0.667), ("length_scale", 1.0), ("noise_w", 0.8)],
@@ -375,10 +386,14 @@ class TestSynthOptionAccessors:
     def test_speaker_getter_reads_from_backend_for_multi_speaker(self, multi_voice):
         assert multi_voice.speaker == "default"
 
-    def test_speaker_setter_forwards_to_backend_for_multi_speaker(self, multi_voice, backend):
+    def test_speaker_setter_forwards_to_backend_for_multi_speaker(
+        self, multi_voice, backend
+    ):
         backend.set_synth_options_calls.clear()
         multi_voice.speaker = "Bob"
-        assert backend.set_synth_options_calls == [(multi_voice.remote_id, {"speaker": "Bob"})]
+        assert backend.set_synth_options_calls == [
+            (multi_voice.remote_id, {"speaker": "Bob"})
+        ]
 
     def test_accessor_propagates_a_backend_error(self, multi_voice, backend):
         from dengjen_neural_voices.ports.tts_backend import VoiceLoadError
@@ -397,8 +412,8 @@ class TestSynthOptionAccessors:
 # Constants -- unchanged
 # ---------------------------------------------------------------------------
 
-class TestConstants:
 
+class TestConstants:
     def test_ignored_puncs_is_frozenset(self):
         assert isinstance(IGNORED_PUNCS, frozenset)
 

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -405,7 +405,7 @@ class TestSynthOptionAccessors:
 
         backend.get_synth_options = _boom
         with pytest.raises(VoiceLoadError):
-            multi_voice.noise_scale
+            _ = multi_voice.noise_scale
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -157,7 +157,7 @@ class TestPiperVoiceDataclasses:
     def test_file_type_raises_for_unknown_suffix(self):
         f = PiperVoiceFile(file_path="v/voice.txt", size_in_bytes=10, md5hash="x")
         with pytest.raises(ValueError):
-            f.type
+            _ = f.type
 
     def test_language_str_uses_dash_not_underscore(self):
         assert str(_language(code="en_US")) == "en-US"
@@ -656,11 +656,13 @@ class TestCertVerificationFallback:
         fake_request = _FakeMureq(stream_responses=[HTTPException("connection reset")])
         monkeypatch.setattr(voice_download, "request", fake_request)
 
-        with pytest.raises(HTTPException, match="connection reset"):
-            with voice_download._yield_response_with_cert_fallback(
+        with (
+            pytest.raises(HTTPException, match="connection reset"),
+            voice_download._yield_response_with_cert_fallback(
                 "GET", "https://example.com/voice.onnx"
-            ):
-                pass
+            ),
+        ):
+            pass
 
         assert len(fake_request.yield_calls) == 1
 
@@ -698,7 +700,8 @@ class TestPiperVoiceDownloaderFileTransfer:
             file, str(tmp_path), MagicMock()
         )
         assert result_file is file
-        assert open(target, "rb").read() == body
+        with open(target, "rb") as f:
+            assert f.read() == body
         assert digest == hashlib.md5(body).hexdigest()
 
     def test_follows_a_redirect_before_downloading(self, tmp_path, monkeypatch):
@@ -720,7 +723,8 @@ class TestPiperVoiceDownloaderFileTransfer:
         __, target, __ = PiperVoiceDownloader._do_download_file(
             file, str(tmp_path), MagicMock()
         )
-        assert open(target, "rb").read() == body
+        with open(target, "rb") as f:
+            assert f.read() == body
         assert len(fake_request.yield_urls) == 2
 
     def test_raises_after_too_many_redirects(self, tmp_path, monkeypatch):
@@ -912,7 +916,8 @@ class TestPiperRTVoiceDownloader:
             str(tmp_path),
             MagicMock(),
         )
-        assert open(target, "rb").read() == body
+        with open(target, "rb") as f:
+            assert f.read() == body
 
     def test_success_installs_the_archive_and_offers_a_restart(
         self, tmp_path, monkeypatch

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for voice_download.py: the piper-voice metadata parsing, voice-key
 derivation, tar-archive install, and the non-GUI parts of the download
@@ -19,7 +18,6 @@ import hashlib
 import io
 import json
 import os
-import shutil
 import ssl
 import tarfile
 from concurrent.futures import Future
@@ -27,12 +25,11 @@ from contextlib import contextmanager
 from http.client import HTTPException
 from unittest.mock import MagicMock
 
+import addonHandler
 import pytest
-
-from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
 from dengjen_neural_voices.domain import tts_system
 
-import addonHandler
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
 
 # In production this runs once, in the package __init__.py, before anything
 # that uses `_(...)` is ever imported. We load voice_download.py directly
@@ -136,9 +133,14 @@ def _piper_voice(key="en_US-lessac-medium", has_rt_variant=False, files=None):
 
 class TestPiperVoiceDataclasses:
     def test_file_derives_name_and_download_url_from_path(self):
-        f = PiperVoiceFile(file_path="en/en_US-lessac-medium.onnx", size_in_bytes=10, md5hash="x")
+        f = PiperVoiceFile(
+            file_path="en/en_US-lessac-medium.onnx", size_in_bytes=10, md5hash="x"
+        )
         assert f.name == "en_US-lessac-medium.onnx"
-        assert f.download_url == f"{voice_download.PIPER_VOICE_DOWNLOAD_URL_PREFIX}/en/en_US-lessac-medium.onnx"
+        assert (
+            f.download_url
+            == f"{voice_download.PIPER_VOICE_DOWNLOAD_URL_PREFIX}/en/en_US-lessac-medium.onnx"
+        )
 
     @pytest.mark.parametrize(
         "path,expected",
@@ -174,8 +176,12 @@ class TestPiperVoiceDataclasses:
 
     def test_language_description_includes_native_name_when_not_english(self):
         lang = PiperVoiceLanguage(
-            code="de_DE", family="de", region="DE",
-            name_native="Deutsch", name_english="German", country_english="Germany",
+            code="de_DE",
+            family="de",
+            region="DE",
+            name_native="Deutsch",
+            name_english="German",
+            country_english="Germany",
         )
         assert lang.description == "German (Germany) , de-DE, Deutsch"
 
@@ -191,8 +197,12 @@ class TestPiperVoiceDataclasses:
                 "num_speakers": 1,
                 "speaker_id_map": {},
                 "language": {
-                    "code": "de_DE", "family": "de", "region": "DE",
-                    "name_native": "Deutsch", "name_english": "German", "country_english": "Germany",
+                    "code": "de_DE",
+                    "family": "de",
+                    "region": "DE",
+                    "name_native": "Deutsch",
+                    "name_english": "German",
+                    "country_english": "Germany",
                 },
                 "files": {"de/thorsten.onnx": {"size_bytes": 5, "md5_digest": "a"}},
                 "has_rt_variant": False,
@@ -206,8 +216,12 @@ class TestPiperVoiceDataclasses:
                 "num_speakers": 1,
                 "speaker_id_map": {},
                 "language": {
-                    "code": "en_US", "family": "en", "region": "US",
-                    "name_native": "English", "name_english": "English", "country_english": "United States",
+                    "code": "en_US",
+                    "family": "en",
+                    "region": "US",
+                    "name_native": "English",
+                    "name_english": "English",
+                    "country_english": "United States",
                 },
                 "files": {"en/lessac.onnx": {"size_bytes": 5, "md5_digest": "b"}},
                 "has_rt_variant": True,
@@ -247,7 +261,12 @@ class TestVoiceInfoRegex:
         [
             ("en_US-lessac-medium", "en_US", "lessac", "medium"),
             ("en_US-amy-medium", "en_US", "amy", "medium"),
-            ("en_GB-southern_english_female-low", "en_GB", "southern_english_female", "low"),
+            (
+                "en_GB-southern_english_female-low",
+                "en_GB",
+                "southern_english_female",
+                "low",
+            ),
             ("vi_VN-vivos-x_low", "vi_VN", "vivos", "x_low"),
             ("de_DE-thorsten-medium", "de_DE", "thorsten", "medium"),
         ],
@@ -300,10 +319,10 @@ class TestVoiceKeyDerivation:
     @pytest.mark.parametrize(
         "stem",
         [
-            "aivars",              # upstream #47 — no separators at all
-            "voice",               # single word
-            "aivars-medium",       # missing language part
-            "en-foo-banana",       # quality not in {high,medium,low,x-low,x_low}
+            "aivars",  # upstream #47 — no separators at all
+            "voice",  # single word
+            "aivars-medium",  # missing language part
+            "en-foo-banana",  # quality not in {high,medium,low,x-low,x_low}
         ],
     )
     def test_from_filename_returns_none_when_it_does_not_match(self, stem):
@@ -313,13 +332,21 @@ class TestVoiceKeyDerivation:
         "config,expected",
         [
             (
-                {"language": {"code": "en-us"}, "dataset": "lessac", "audio": {"quality": "medium"}},
+                {
+                    "language": {"code": "en-us"},
+                    "dataset": "lessac",
+                    "audio": {"quality": "medium"},
+                },
                 "en_US-lessac-medium",
             ),
             (
                 # Dashes inside dataset/quality would break the X-Y-Z voice_key
                 # structure if left unreplaced (upstream #47's fallback path).
-                {"language": {"code": "en_US"}, "dataset": "my-dataset", "audio": {"quality": "x-low"}},
+                {
+                    "language": {"code": "en_US"},
+                    "dataset": "my-dataset",
+                    "audio": {"quality": "x-low"},
+                },
                 "en_US-my_dataset-x_low",
             ),
         ],
@@ -356,13 +383,19 @@ def _make_tar(tmp_path, name, members):
 
 class TestInstallVoiceFromTarArchive:
     def test_installs_a_single_onnx_voice_deriving_key_from_filename(self, tmp_path):
-        tar_path = _make_tar(tmp_path, "voice.tar.gz", {
-            "en_US-lessac-medium.onnx": b"model-bytes",
-            "en_US-lessac-medium.onnx.json": b"{}",
-            "MODEL_CARD": b"card",
-        })
+        tar_path = _make_tar(
+            tmp_path,
+            "voice.tar.gz",
+            {
+                "en_US-lessac-medium.onnx": b"model-bytes",
+                "en_US-lessac-medium.onnx.json": b"{}",
+                "MODEL_CARD": b"card",
+            },
+        )
         voices_dir = tmp_path / "voices"
-        voice_key = voice_download.install_voice_from_tar_archive(str(tar_path), str(voices_dir))
+        voice_key = voice_download.install_voice_from_tar_archive(
+            str(tar_path), str(voices_dir)
+        )
         assert voice_key == "en_US-lessac-medium"
         installed = voices_dir / voice_key
         assert (installed / "en_US-lessac-medium.onnx").read_bytes() == b"model-bytes"
@@ -370,27 +403,49 @@ class TestInstallVoiceFromTarArchive:
         assert (installed / "MODEL_CARD").read_bytes() == b"card"
 
     def test_multi_onnx_archive_derives_key_from_the_archive_filename(self, tmp_path):
-        tar_path = _make_tar(tmp_path, "en_US-lessac-medium.tar.gz", {
-            "std/en_US-lessac-medium.onnx": b"a",
-            "rt/en_US-lessac+RT-medium.onnx": b"b",
-            "std/en_US-lessac-medium.onnx.json": b"{}",
-        })
-        voice_key = voice_download.install_voice_from_tar_archive(str(tar_path), str(tmp_path / "voices"))
+        tar_path = _make_tar(
+            tmp_path,
+            "en_US-lessac-medium.tar.gz",
+            {
+                "std/en_US-lessac-medium.onnx": b"a",
+                "rt/en_US-lessac+RT-medium.onnx": b"b",
+                "std/en_US-lessac-medium.onnx.json": b"{}",
+            },
+        )
+        voice_key = voice_download.install_voice_from_tar_archive(
+            str(tar_path), str(tmp_path / "voices")
+        )
         assert voice_key == "en_US-lessac-medium"
 
-    def test_falls_back_to_config_derived_key_when_filename_does_not_match(self, tmp_path):
-        config = {"language": {"code": "en_US"}, "dataset": "custom", "audio": {"quality": "medium"}}
-        tar_path = _make_tar(tmp_path, "archive.tar.gz", {
-            "weird-name.onnx": json.dumps(config).encode(),  # content unused for onnx
-            "weird-name.onnx.json": json.dumps(config).encode(),
-        })
-        voice_key = voice_download.install_voice_from_tar_archive(str(tar_path), str(tmp_path / "voices"))
+    def test_falls_back_to_config_derived_key_when_filename_does_not_match(
+        self, tmp_path
+    ):
+        config = {
+            "language": {"code": "en_US"},
+            "dataset": "custom",
+            "audio": {"quality": "medium"},
+        }
+        tar_path = _make_tar(
+            tmp_path,
+            "archive.tar.gz",
+            {
+                "weird-name.onnx": json.dumps(
+                    config
+                ).encode(),  # content unused for onnx
+                "weird-name.onnx.json": json.dumps(config).encode(),
+            },
+        )
+        voice_key = voice_download.install_voice_from_tar_archive(
+            str(tar_path), str(tmp_path / "voices")
+        )
         assert voice_key == "en_US-custom-medium"
 
     def test_raises_when_required_files_are_missing(self, tmp_path):
         tar_path = _make_tar(tmp_path, "voice.tar.gz", {"MODEL_CARD": b"card"})
         with pytest.raises(FileNotFoundError):
-            voice_download.install_voice_from_tar_archive(str(tar_path), str(tmp_path / "voices"))
+            voice_download.install_voice_from_tar_archive(
+                str(tar_path), str(tmp_path / "voices")
+            )
 
 
 class TestSelectNotInstalledVoices:
@@ -403,6 +458,7 @@ class TestSelectNotInstalledVoices:
                 "load_piper_voices_from_nvda_config_dir",
                 classmethod(lambda cls, backend: fake_voices),
             )
+
         return _set
 
     def _voice_dict(self, has_rt_variant):
@@ -418,7 +474,9 @@ class TestSelectNotInstalledVoices:
         voices = {"en_US-lessac-medium": self._voice_dict(has_rt_variant=False)}
         assert voice_download._select_not_installed_voices(voices) == []
 
-    def test_includes_standard_installed_voice_that_still_has_an_rt_variant_to_offer(self, installed):
+    def test_includes_standard_installed_voice_that_still_has_an_rt_variant_to_offer(
+        self, installed
+    ):
         installed(["en_US-lessac-medium"])
         voices = {"en_US-lessac-medium": self._voice_dict(has_rt_variant=True)}
         result = voice_download._select_not_installed_voices(voices)
@@ -432,7 +490,9 @@ class TestSelectNotInstalledVoices:
         result = voice_download._select_not_installed_voices(voices)
         assert len(result) == 1
 
-    def test_calls_the_real_backend_threaded_call_without_raising(self, tmp_path, monkeypatch):
+    def test_calls_the_real_backend_threaded_call_without_raising(
+        self, tmp_path, monkeypatch
+    ):
         # Regression test for a TypeError: load_piper_voices_from_nvda_config_dir
         # requires a backend argument, and this caller (voice_download.py:594)
         # was missing it. Deliberately does NOT monkeypatch
@@ -456,7 +516,9 @@ class TestVoicesCache:
     def test_get_voices_from_cache_returns_none_when_file_is_missing(self, cache_path):
         assert voice_download._get_voices_from_cache() is None
 
-    def test_get_available_voices_uses_the_cache_without_going_online(self, cache_path, monkeypatch):
+    def test_get_available_voices_uses_the_cache_without_going_online(
+        self, cache_path, monkeypatch
+    ):
         cache_path.write_text(json.dumps({}), encoding="utf-8")
         fake_request = _FakeMureq()
         monkeypatch.setattr(voice_download, "request", fake_request)
@@ -469,23 +531,34 @@ class TestVoicesCache:
         assert result == []
         assert fake_request.get_urls == []
 
-    def test_get_available_voices_refreshes_from_both_endpoints_when_forced(self, cache_path, monkeypatch):
+    def test_get_available_voices_refreshes_from_both_endpoints_when_forced(
+        self, cache_path, monkeypatch
+    ):
         std_payload = {
             "en_US-lessac-medium": {
-                "key": "en_US-lessac-medium", "name": "lessac", "quality": "medium",
-                "num_speakers": 1, "speaker_id_map": {},
+                "key": "en_US-lessac-medium",
+                "name": "lessac",
+                "quality": "medium",
+                "num_speakers": 1,
+                "speaker_id_map": {},
                 "language": {
-                    "code": "en_US", "family": "en", "region": "US",
-                    "name_native": "English", "name_english": "English", "country_english": "United States",
+                    "code": "en_US",
+                    "family": "en",
+                    "region": "US",
+                    "name_native": "English",
+                    "name_english": "English",
+                    "country_english": "United States",
                 },
                 "files": {"en/lessac.onnx": {"size_bytes": 5, "md5_digest": "a"}},
             }
         }
         rt_payload = {"some-rt-entry": {"base": "en_US-lessac-medium"}}
-        fake_request = _FakeMureq(get_responses=[
-            _FakeResponse(status=200, json_data=std_payload),
-            _FakeResponse(status=200, json_data=rt_payload),
-        ])
+        fake_request = _FakeMureq(
+            get_responses=[
+                _FakeResponse(status=200, json_data=std_payload),
+                _FakeResponse(status=200, json_data=rt_payload),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         monkeypatch.setattr(
             voice_download.DengjenTextToSpeechSystem,
@@ -499,14 +572,21 @@ class TestVoicesCache:
             voice_download.PIPER_VOICE_LIST_URL,
             voice_download.RT_VOICE_LIST_URL,
         ]
-        assert json.loads(cache_path.read_text(encoding="utf-8"))["en_US-lessac-medium"]["has_rt_variant"] is True
+        assert (
+            json.loads(cache_path.read_text(encoding="utf-8"))["en_US-lessac-medium"][
+                "has_rt_variant"
+            ]
+            is True
+        )
 
 
 def _cert_verification_error():
     """An HTTPException as mureq wraps a TLS trust-store failure, i.e. with
     the original ssl.SSLCertVerificationError preserved as __cause__."""
     exc = HTTPException("certificate verify failed")
-    exc.__cause__ = ssl.SSLCertVerificationError("unable to get local issuer certificate")
+    exc.__cause__ = ssl.SSLCertVerificationError(
+        "unable to get local issuer certificate"
+    )
     return exc
 
 
@@ -521,14 +601,20 @@ class TestCertVerificationFallback:
         monkeypatch.setattr(voice_download, "_fallback_ssl_context", lambda: sentinel)
         return sentinel
 
-    def test_get_retries_with_fallback_context_on_cert_error(self, monkeypatch, fallback_context):
-        fake_request = _FakeMureq(get_responses=[
-            _cert_verification_error(),
-            _FakeResponse(status=200, json_data={"ok": True}),
-        ])
+    def test_get_retries_with_fallback_context_on_cert_error(
+        self, monkeypatch, fallback_context
+    ):
+        fake_request = _FakeMureq(
+            get_responses=[
+                _cert_verification_error(),
+                _FakeResponse(status=200, json_data={"ok": True}),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
 
-        result = voice_download._get_with_cert_fallback("https://example.com/voices.json")
+        result = voice_download._get_with_cert_fallback(
+            "https://example.com/voices.json"
+        )
 
         assert result.json() == {"ok": True}
         assert len(fake_request.get_calls) == 2
@@ -544,26 +630,36 @@ class TestCertVerificationFallback:
 
         assert len(fake_request.get_calls) == 1
 
-    def test_yield_response_retries_with_fallback_context_on_cert_error(self, monkeypatch, fallback_context):
-        fake_request = _FakeMureq(stream_responses=[
-            _cert_verification_error(),
-            _FakeResponse(status=200, body=b"voice-bytes"),
-        ])
+    def test_yield_response_retries_with_fallback_context_on_cert_error(
+        self, monkeypatch, fallback_context
+    ):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _cert_verification_error(),
+                _FakeResponse(status=200, body=b"voice-bytes"),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
 
-        with voice_download._yield_response_with_cert_fallback("GET", "https://example.com/voice.onnx") as response:
+        with voice_download._yield_response_with_cert_fallback(
+            "GET", "https://example.com/voice.onnx"
+        ) as response:
             assert response.read() == b"voice-bytes"
 
         assert len(fake_request.yield_calls) == 2
         assert "ssl_context" not in fake_request.yield_calls[0]
         assert fake_request.yield_calls[1]["ssl_context"] is fallback_context
 
-    def test_yield_response_does_not_retry_on_unrelated_http_exception(self, monkeypatch):
+    def test_yield_response_does_not_retry_on_unrelated_http_exception(
+        self, monkeypatch
+    ):
         fake_request = _FakeMureq(stream_responses=[HTTPException("connection reset")])
         monkeypatch.setattr(voice_download, "request", fake_request)
 
         with pytest.raises(HTTPException, match="connection reset"):
-            with voice_download._yield_response_with_cert_fallback("GET", "https://example.com/voice.onnx"):
+            with voice_download._yield_response_with_cert_fallback(
+                "GET", "https://example.com/voice.onnx"
+            ):
                 pass
 
         assert len(fake_request.yield_calls) == 1
@@ -579,35 +675,61 @@ class TestPiperVoiceDownloaderFileTransfer:
     actually surface — HuggingFace serves every file through a redirect."""
 
     def _file(self, body):
-        return PiperVoiceFile(file_path="en/en_US-lessac-medium.onnx", size_in_bytes=len(body), md5hash="unused")
+        return PiperVoiceFile(
+            file_path="en/en_US-lessac-medium.onnx",
+            size_in_bytes=len(body),
+            md5hash="unused",
+        )
 
     def test_downloads_and_hashes_a_direct_200_response(self, tmp_path, monkeypatch):
         body = b"piper-model-bytes"
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Type": "application/octet-stream"}, body=body),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=body,
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         file = self._file(body)
-        result_file, target, digest = PiperVoiceDownloader._do_download_file(file, str(tmp_path), MagicMock())
+        result_file, target, digest = PiperVoiceDownloader._do_download_file(
+            file, str(tmp_path), MagicMock()
+        )
         assert result_file is file
         assert open(target, "rb").read() == body
         assert digest == hashlib.md5(body).hexdigest()
 
     def test_follows_a_redirect_before_downloading(self, tmp_path, monkeypatch):
         body = b"redirected-bytes"
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=302, headers={"Location": "https://example.com/final.onnx"}),
-            _FakeResponse(status=200, headers={"Content-Type": "application/octet-stream"}, body=body),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=302, headers={"Location": "https://example.com/final.onnx"}
+                ),
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=body,
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         file = self._file(body)
-        __, target, __ = PiperVoiceDownloader._do_download_file(file, str(tmp_path), MagicMock())
+        __, target, __ = PiperVoiceDownloader._do_download_file(
+            file, str(tmp_path), MagicMock()
+        )
         assert open(target, "rb").read() == body
         assert len(fake_request.yield_urls) == 2
 
     def test_raises_after_too_many_redirects(self, tmp_path, monkeypatch):
-        redirect = _FakeResponse(status=302, headers={"Location": "https://example.com/again"})
-        fake_request = _FakeMureq(stream_responses=[redirect] * voice_download.REDIRECT_LIMIT)
+        redirect = _FakeResponse(
+            status=302, headers={"Location": "https://example.com/again"}
+        )
+        fake_request = _FakeMureq(
+            stream_responses=[redirect] * voice_download.REDIRECT_LIMIT
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
@@ -615,7 +737,9 @@ class TestPiperVoiceDownloaderFileTransfer:
             PiperVoiceDownloader._do_download_file(file, str(tmp_path), callback)
 
     def test_raises_on_redirect_without_a_location_header(self, tmp_path, monkeypatch):
-        fake_request = _FakeMureq(stream_responses=[_FakeResponse(status=302, headers={})])
+        fake_request = _FakeMureq(
+            stream_responses=[_FakeResponse(status=302, headers={})]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
@@ -623,9 +747,13 @@ class TestPiperVoiceDownloaderFileTransfer:
             PiperVoiceDownloader._do_download_file(file, str(tmp_path), callback)
 
     def test_raises_on_wrong_content_type(self, tmp_path, monkeypatch):
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Type": "text/html"}, body=b"<html/>"),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200, headers={"Content-Type": "text/html"}, body=b"<html/>"
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
@@ -640,16 +768,26 @@ class TestPiperVoiceDownloaderFileTransfer:
         with pytest.raises(RuntimeError, match="Download failed"):
             PiperVoiceDownloader._do_download_file(file, str(tmp_path), callback)
 
-    def test_download_voice_files_collects_a_result_per_file(self, tmp_path, monkeypatch):
+    def test_download_voice_files_collects_a_result_per_file(
+        self, tmp_path, monkeypatch
+    ):
         bodies = [b"one", b"two"]
         files = [
-            PiperVoiceFile(file_path=f"en/f{i}.onnx", size_in_bytes=len(b), md5hash="unused")
+            PiperVoiceFile(
+                file_path=f"en/f{i}.onnx", size_in_bytes=len(b), md5hash="unused"
+            )
             for i, b in enumerate(bodies)
         ]
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Type": "application/octet-stream"}, body=b)
-            for b in bodies
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=b,
+                )
+                for b in bodies
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         voice = _piper_voice(files=files)
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -664,14 +802,20 @@ class TestPiperVoiceDownloaderDoneCallback:
         src = tmp_path / "downloaded.onnx"
         src.write_bytes(body)
         digest = hashlib.md5(body).hexdigest()
-        file = PiperVoiceFile(file_path="en/en_US-lessac-medium.onnx", size_in_bytes=len(body), md5hash=digest)
+        file = PiperVoiceFile(
+            file_path="en/en_US-lessac-medium.onnx",
+            size_in_bytes=len(body),
+            md5hash=digest,
+        )
         return file, str(src), digest
 
     def test_success_copies_files_and_offers_a_restart(self, tmp_path, monkeypatch):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
         monkeypatch.setattr(voice_download.wx, "YES", "YES")
-        monkeypatch.setattr(voice_download.gui, "messageBox", MagicMock(return_value="YES"))
+        monkeypatch.setattr(
+            voice_download.gui, "messageBox", MagicMock(return_value="YES")
+        )
         restart_mock = MagicMock()
         monkeypatch.setattr(voice_download.core, "restart", restart_mock)
 
@@ -687,7 +831,9 @@ class TestPiperVoiceDownloaderDoneCallback:
         downloader.success_callback.assert_called_once()
         restart_mock.assert_called_once()
 
-    def test_hash_mismatch_does_not_install_and_reports_failure(self, tmp_path, monkeypatch):
+    def test_hash_mismatch_does_not_install_and_reports_failure(
+        self, tmp_path, monkeypatch
+    ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
@@ -708,7 +854,9 @@ class TestPiperVoiceDownloaderDoneCallback:
     def test_copy_failure_reports_failure_without_crashing(self, tmp_path, monkeypatch):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
-        monkeypatch.setattr(voice_download.shutil, "copy", MagicMock(side_effect=IOError("disk full")))
+        monkeypatch.setattr(
+            voice_download.shutil, "copy", MagicMock(side_effect=OSError("disk full"))
+        )
         messagebox_mock = MagicMock()
         monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
 
@@ -722,7 +870,9 @@ class TestPiperVoiceDownloaderDoneCallback:
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 
-    def test_an_exception_result_is_reported_without_touching_disk(self, tmp_path, monkeypatch):
+    def test_an_exception_result_is_reported_without_touching_disk(
+        self, tmp_path, monkeypatch
+    ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
@@ -748,39 +898,58 @@ class TestPiperRTVoiceDownloader:
 
     def test_do_download_archive_streams_to_a_file(self, tmp_path, monkeypatch):
         body = b"archive-bytes"
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Length": str(len(body))}, body=body),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200, headers={"Content-Length": str(len(body))}, body=body
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         target = PiperRTVoiceDownloader._do_download_archive(
-            "https://example.com/voice.tar.gz", "voice.tar.gz", str(tmp_path), MagicMock()
+            "https://example.com/voice.tar.gz",
+            "voice.tar.gz",
+            str(tmp_path),
+            MagicMock(),
         )
         assert open(target, "rb").read() == body
 
-    def test_success_installs_the_archive_and_offers_a_restart(self, tmp_path, monkeypatch):
+    def test_success_installs_the_archive_and_offers_a_restart(
+        self, tmp_path, monkeypatch
+    ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
         monkeypatch.setattr(voice_download.wx, "YES", "YES")
-        monkeypatch.setattr(voice_download.gui, "messageBox", MagicMock(return_value="YES"))
+        monkeypatch.setattr(
+            voice_download.gui, "messageBox", MagicMock(return_value="YES")
+        )
         restart_mock = MagicMock()
         monkeypatch.setattr(voice_download.core, "restart", restart_mock)
 
-        tar_path = _make_tar(tmp_path, "en_US-lessac-medium.tar.gz", {
-            "en_US-lessac+RT-medium.onnx": b"rt-model",
-            "en_US-lessac+RT-medium.onnx.json": b"{}",
-        })
+        tar_path = _make_tar(
+            tmp_path,
+            "en_US-lessac-medium.tar.gz",
+            {
+                "en_US-lessac+RT-medium.onnx": b"rt-model",
+                "en_US-lessac+RT-medium.onnx.json": b"{}",
+            },
+        )
         voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
         downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
         downloader.progress_dialog = MagicMock()
 
         downloader.done_callback(str(tar_path))
 
-        installed = voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
+        installed = (
+            voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
+        )
         assert installed.read_bytes() == b"rt-model"
         downloader.success_callback.assert_called_once()
         restart_mock.assert_called_once()
 
-    def test_extraction_failure_is_reported_without_crashing(self, tmp_path, monkeypatch):
+    def test_extraction_failure_is_reported_without_crashing(
+        self, tmp_path, monkeypatch
+    ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
@@ -842,16 +1011,25 @@ class TestDownloadWiresProgressDialogToInstall:
             size_in_bytes=len(body),
             md5hash=hashlib.md5(body).hexdigest(),
         )
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Type": "application/octet-stream"}, body=body),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=body,
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         voice = _piper_voice(key="en_US-lessac-medium", files=[file])
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
 
         downloader.download()
 
-        assert dialog_cls.call_args.kwargs["title"] == "Downloading voice en_US-lessac-medium"
+        assert (
+            dialog_cls.call_args.kwargs["title"]
+            == "Downloading voice en_US-lessac-medium"
+        )
         installed = voices_dir / "en_US-lessac-medium" / file.name
         assert installed.read_bytes() == body
         downloader.success_callback.assert_called_once()
@@ -862,22 +1040,35 @@ class TestDownloadWiresProgressDialogToInstall:
         dialog_cls, __ = progress_dialog
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
-        tar_path = _make_tar(tmp_path, "en_US-lessac-medium.tar.gz", {
-            "en_US-lessac+RT-medium.onnx": b"rt-model",
-            "en_US-lessac+RT-medium.onnx.json": b"{}",
-        })
+        tar_path = _make_tar(
+            tmp_path,
+            "en_US-lessac-medium.tar.gz",
+            {
+                "en_US-lessac+RT-medium.onnx": b"rt-model",
+                "en_US-lessac+RT-medium.onnx.json": b"{}",
+            },
+        )
         body = tar_path.read_bytes()
-        fake_request = _FakeMureq(stream_responses=[
-            _FakeResponse(status=200, headers={"Content-Length": str(len(body))}, body=body),
-        ])
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200, headers={"Content-Length": str(len(body))}, body=body
+                ),
+            ]
+        )
         monkeypatch.setattr(voice_download, "request", fake_request)
         voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
         downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
 
         downloader.download()
 
-        assert dialog_cls.call_args.kwargs["title"] == "Downloading fast variant of the voice en_US-lessac-medium"
-        installed = voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
+        assert (
+            dialog_cls.call_args.kwargs["title"]
+            == "Downloading fast variant of the voice en_US-lessac-medium"
+        )
+        installed = (
+            voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
+        )
         assert installed.read_bytes() == b"rt-model"
         downloader.success_callback.assert_called_once()
 
@@ -894,9 +1085,12 @@ class TestDownloadWiresProgressDialogToInstall:
         fake_request = _FakeMureq(stream_responses=[_FakeResponse(status=404)])
         monkeypatch.setattr(voice_download, "request", fake_request)
 
-        voice = _piper_voice(key="en_US-lessac-medium", files=[
-            PiperVoiceFile(file_path="en/f.onnx", size_in_bytes=1, md5hash="x"),
-        ])
+        voice = _piper_voice(
+            key="en_US-lessac-medium",
+            files=[
+                PiperVoiceFile(file_path="en/f.onnx", size_in_bytes=1, md5hash="x"),
+            ],
+        )
         PiperVoiceDownloader(voice, success_callback=MagicMock()).download()
         std_message = messagebox_mock.call_args.args[0]
 

--- a/tests/test_voice_manager_logic.py
+++ b/tests/test_voice_manager_logic.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Tests for voice_manager_logic.py: the wx-free decisions behind the voice
 manager UI, extracted from voice_manager.py so they can be driven on any
@@ -8,10 +7,10 @@ they subclass real wx types -- and are covered by tests_gui/ on Windows.
 
 import os
 
-from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
-
 import addonHandler
 from dengjen_neural_voices.domain import tts_system
+
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
 from tests.fake_tts_backend import FakeTTSBackend
 
 # In production this runs in the package __init__.py before anything using
@@ -112,9 +111,7 @@ class TestIsActiveVoice:
         )
 
     def test_false_when_another_synth_is_active(self):
-        assert not logic.is_active_voice(
-            "espeak", "en_US-amy", "en_US-amy-medium"
-        )
+        assert not logic.is_active_voice("espeak", "en_US-amy", "en_US-amy-medium")
 
     def test_quality_does_not_affect_the_match(self):
         assert logic.is_active_voice(
@@ -215,36 +212,48 @@ class TestDownloadButtonState:
 
     def test_standard_download_withheld_when_already_installed(self):
         voice = _online(
-            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            "en_US-amy-medium",
+            "amy",
+            _language("en_US", "English"),
             standard_variant_installed=True,
         )
         assert logic.download_button_state(voice).std_enabled is False
 
     def test_fast_download_withheld_when_voice_has_no_rt_variant(self):
         voice = _online(
-            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            "en_US-amy-medium",
+            "amy",
+            _language("en_US", "English"),
             has_rt_variant=False,
         )
         assert logic.download_button_state(voice).rt_enabled is False
 
     def test_fast_download_offered_when_rt_exists_and_is_not_installed(self):
         voice = _online(
-            "en_US-amy-medium", "amy", _language("en_US", "English"),
+            "en_US-amy-medium",
+            "amy",
+            _language("en_US", "English"),
             has_rt_variant=True,
         )
         assert logic.download_button_state(voice).rt_enabled is True
 
     def test_fast_download_withheld_when_rt_already_installed(self):
         voice = _online(
-            "en_US-amy-medium", "amy", _language("en_US", "English"),
-            has_rt_variant=True, fast_variant_installed=True,
+            "en_US-amy-medium",
+            "amy",
+            _language("en_US", "English"),
+            has_rt_variant=True,
+            fast_variant_installed=True,
         )
         assert logic.download_button_state(voice).rt_enabled is False
 
     def test_single_speaker_voice_offers_no_speaker_choice(self):
         voice = _online(
-            "en_US-amy-medium", "amy", _language("en_US", "English"),
-            num_speakers=1, speaker_id_map={"amy": 0},
+            "en_US-amy-medium",
+            "amy",
+            _language("en_US", "English"),
+            num_speakers=1,
+            speaker_id_map={"amy": 0},
         )
         state = logic.download_button_state(voice)
         assert state.speaker_enabled is False
@@ -252,8 +261,11 @@ class TestDownloadButtonState:
 
     def test_multi_speaker_voice_lists_its_speakers_in_map_order(self):
         voice = _online(
-            "en_US-libritts-medium", "libritts", _language("en_US", "English"),
-            num_speakers=3, speaker_id_map={"p3": 0, "p1": 1, "p2": 2},
+            "en_US-libritts-medium",
+            "libritts",
+            _language("en_US", "English"),
+            num_speakers=3,
+            speaker_id_map={"p3": 0, "p1": 1, "p2": 2},
         )
         state = logic.download_button_state(voice)
         assert state.speaker_enabled is True

--- a/tests/test_voice_migration.py
+++ b/tests/test_voice_migration.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Tests for the 4.0.0 voices-directory migration
 (addon/synthDrivers/dengjen_neural_voices/voice_migration.py).
 
@@ -17,9 +16,9 @@ import os
 from unittest.mock import MagicMock
 
 import pytest
-
+from dengjen_neural_voices import voice_migration
 from dengjen_neural_voices.domain import tts_system
-import dengjen_neural_voices.voice_migration as voice_migration
+
 from tests.fake_tts_backend import FakeTTSBackend
 
 # These tests only assert on voice keys and on-disk migration side effects,
@@ -96,9 +95,7 @@ class TestMigrateVoicesDirectoryRetry:
         new_voice = _write_voice(tmp_path / "dengjen", payload=b"newer model")
         _write_voice(tmp_path / "sonata")
         assert voice_migration.migrate_voices_directory(str(tmp_path)) is False
-        assert (
-            new_voice / "en_US-amy-medium.onnx"
-        ).read_bytes() == b"newer model"
+        assert (new_voice / "en_US-amy-medium.onnx").read_bytes() == b"newer model"
         assert (tmp_path / "sonata" / "voices" / "piper").is_dir()
 
     def test_a_move_blocked_by_open_files_can_succeed_on_a_later_attempt(
@@ -107,6 +104,7 @@ class TestMigrateVoicesDirectoryRetry:
         _write_voice(tmp_path / "sonata")
 
         with monkeypatch.context() as locked:
+
             def _in_use(src, dst):
                 raise PermissionError("file in use")
 
@@ -228,7 +226,11 @@ class TestMigrationRunsOnVoiceEnumeration:
 
     def test_enumerating_voices_migrates_the_old_directory(self, config_dir):
         _write_voice(config_dir / "sonata")
-        voices = tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(_backend)
+        voices = (
+            tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+                _backend
+            )
+        )
         assert [v.key for v in voices] == ["en_US-amy-medium"]
         assert not (config_dir / "sonata").exists()
 
@@ -238,15 +240,22 @@ class TestMigrationRunsOnVoiceEnumeration:
         _write_voice(config_dir / "sonata")
 
         with monkeypatch.context() as locked:
+
             def _in_use(src, dst):
                 raise PermissionError("file in use")
 
             locked.setattr(voice_migration.os, "rename", _in_use)
             assert (
-                tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(_backend)
+                tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+                    _backend
+                )
                 == []
             )
             assert os.path.isdir(config_dir / "dengjen" / "voices" / "piper")
 
-        voices = tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(_backend)
+        voices = (
+            tts_system.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+                _backend
+            )
+        )
         assert [v.key for v in voices] == ["en_US-amy-medium"]

--- a/tests_contract/conftest.py
+++ b/tests_contract/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 conftest.py for the gRPC contract tests — these talk to the real, vendored
 dengjen-tts-grpc.exe over a real gRPC channel.
@@ -28,7 +27,9 @@ import sys
 
 _TESTS_CONTRACT_DIR = os.path.dirname(__file__)
 REPO_ROOT = os.path.abspath(os.path.join(_TESTS_CONTRACT_DIR, ".."))
-_SYNTH_PKG_DIR = os.path.join(REPO_ROOT, "addon", "synthDrivers", "dengjen_neural_voices")
+_SYNTH_PKG_DIR = os.path.join(
+    REPO_ROOT, "addon", "synthDrivers", "dengjen_neural_voices"
+)
 
 LIB_DIRECTORY = os.path.join(_SYNTH_PKG_DIR, "lib")
 BIN_DIRECTORY = os.path.join(_SYNTH_PKG_DIR, "bin")

--- a/tests_contract/test_grpc_contract.py
+++ b/tests_contract/test_grpc_contract.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Contract test against the real, vendored dengjen-tts-grpc.exe: starts the actual
 engine binary and confirms it answers the GetDengjenVersion handshake over a
@@ -27,9 +26,8 @@ if sys.platform != "win32":
     # any platform other than the one the vendored lib/grpc was built for.
     pytest.skip("dengjen-tts-grpc.exe is a Windows binary", allow_module_level=True)
 
-import grpc
 import espeakng_loader
-
+import grpc
 import grpc_protos.dengjen_grpc_pb2 as msgs
 import grpc_protos.dengjen_grpc_pb2_grpc as pb2_grpc
 
@@ -47,7 +45,9 @@ def _find_free_port():
 
 @pytest.fixture(scope="session")
 def grpc_server():
-    assert os.path.exists(GRPC_SERVER_EXE), f"dengjen-tts-grpc.exe not found at {GRPC_SERVER_EXE}"
+    assert os.path.exists(GRPC_SERVER_EXE), (
+        f"dengjen-tts-grpc.exe not found at {GRPC_SERVER_EXE}"
+    )
 
     port = _find_free_port()
     log_path = os.path.join(tempfile.mkdtemp(), "dengjen-tts-grpc.log")
@@ -60,11 +60,13 @@ def grpc_server():
     # DENGJEN_ESPEAKNG_DATA_DIRECTORY must be the directory that *contains*
     # an `espeak-ng-data` subfolder, not that subfolder itself.
     espeakng_data_dir = os.path.dirname(espeakng_loader.get_data_path())
-    env.update({
-        "DENGJEN_GRPC_SERVER_PORT": str(port),
-        "DENGJEN_ESPEAKNG_DATA_DIRECTORY": espeakng_data_dir,
-        "DENGJEN_GRPC": "info",
-    })
+    env.update(
+        {
+            "DENGJEN_GRPC_SERVER_PORT": str(port),
+            "DENGJEN_ESPEAKNG_DATA_DIRECTORY": espeakng_data_dir,
+            "DENGJEN_GRPC": "info",
+        }
+    )
 
     with open(log_path, "wb") as log_file:
         process = subprocess.Popen(
@@ -138,7 +140,10 @@ CALL_TIMEOUT = 30
 
 
 def _download(url, target_path):
-    with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response, open(target_path, "wb") as f:
+    with (
+        urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response,
+        open(target_path, "wb") as f,
+    ):
         f.write(response.read())
 
 
@@ -159,12 +164,18 @@ def downloaded_voice(tmp_path_factory):
 
 
 class TestVoiceSynthesis:
-    def test_load_voice_and_synthesize_returns_non_empty_audio(self, grpc_server, downloaded_voice):
-        voice_info = grpc_server.LoadVoice(msgs.VoiceConfigLocation(path=downloaded_voice), timeout=CALL_TIMEOUT)
+    def test_load_voice_and_synthesize_returns_non_empty_audio(
+        self, grpc_server, downloaded_voice
+    ):
+        voice_info = grpc_server.LoadVoice(
+            msgs.VoiceConfigLocation(path=downloaded_voice), timeout=CALL_TIMEOUT
+        )
         assert voice_info.voice_key
         assert voice_info.audio.sample_rate > 0
 
-        utterance = msgs.SynthesisRequest(voice_key=voice_info.voice_key, text="xin chào")
+        utterance = msgs.SynthesisRequest(
+            voice_key=voice_info.voice_key, text="xin chào"
+        )
         frames = list(grpc_server.SynthesizeUtterance(utterance, timeout=CALL_TIMEOUT))
 
         assert frames, "expected at least one audio frame from SynthesizeUtterance"

--- a/tests_contract/test_sonata_grpc_backend_contract.py
+++ b/tests_contract/test_sonata_grpc_backend_contract.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Contract test for SonataGrpcBackend against the real, vendored
 dengjen-tts-grpc.exe. Unlike test_grpc_contract.py (which talks to the raw
@@ -39,22 +38,37 @@ if sys.platform != "win32":
 # espeak-ng-data espeakng_loader vendors for test_grpc_contract.py.
 _APP_DIR = tempfile.mkdtemp()
 _SYNTH_DRIVERS_DIR = os.path.join(_APP_DIR, "synthDrivers")
-shutil.copytree(espeakng_loader.get_data_path(), os.path.join(_SYNTH_DRIVERS_DIR, "espeak-ng-data"))
+shutil.copytree(
+    espeakng_loader.get_data_path(), os.path.join(_SYNTH_DRIVERS_DIR, "espeak-ng-data")
+)
 
 sys.modules.setdefault(
     "globalVars",
-    types.SimpleNamespace(appArgs=types.SimpleNamespace(configPath=tempfile.mkdtemp()), appDir=_APP_DIR),
+    types.SimpleNamespace(
+        appArgs=types.SimpleNamespace(configPath=tempfile.mkdtemp()), appDir=_APP_DIR
+    ),
 )
-sys.modules.setdefault("logHandler", types.SimpleNamespace(log=types.SimpleNamespace(
-    info=lambda *a, **k: None, error=lambda *a, **k: None,
-    debug=lambda *a, **k: None, exception=lambda *a, **k: None,
-)))
-sys.modules.setdefault("wx", types.SimpleNamespace(GetTopLevelWindows=lambda: []))
-sys.modules.setdefault("gui", types.SimpleNamespace(messageBox=lambda *a, **k: None, mainFrame=None))
+sys.modules.setdefault(
+    "logHandler",
+    types.SimpleNamespace(
+        log=types.SimpleNamespace(
+            info=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+            debug=lambda *a, **k: None,
+            exception=lambda *a, **k: None,
+        )
+    ),
+)
+sys.modules.setdefault("wx", types.SimpleNamespace(GetTopLevelWindows=list))
+sys.modules.setdefault(
+    "gui", types.SimpleNamespace(messageBox=lambda *a, **k: None, mainFrame=None)
+)
 sys.modules.setdefault(
     "gui.settingsDialogs",
-    types.SimpleNamespace(NVDASettingsDialog=type("NVDASettingsDialog", (), {}),
-                           SpeechSettingsPanel=type("SpeechSettingsPanel", (), {})),
+    types.SimpleNamespace(
+        NVDASettingsDialog=type("NVDASettingsDialog", (), {}),
+        SpeechSettingsPanel=type("SpeechSettingsPanel", (), {}),
+    ),
 )
 
 from tests_contract.conftest import REPO_ROOT
@@ -65,7 +79,9 @@ from tests_contract.conftest import REPO_ROOT
 # real __path__ makes plain relative imports inside adapters/sonata_grpc
 # (`from ...const import ...`, `from ...helpers import ...`) resolve
 # correctly while skipping that __init__.py entirely.
-_SYNTH_PKG_DIR = os.path.join(REPO_ROOT, "addon", "synthDrivers", "dengjen_neural_voices")
+_SYNTH_PKG_DIR = os.path.join(
+    REPO_ROOT, "addon", "synthDrivers", "dengjen_neural_voices"
+)
 _dengjen_pkg = types.ModuleType("dengjen_neural_voices")
 _dengjen_pkg.__path__ = [_SYNTH_PKG_DIR]
 sys.modules.setdefault("dengjen_neural_voices", _dengjen_pkg)
@@ -82,7 +98,10 @@ CALL_TIMEOUT = 30
 
 
 def _download(url, target_path):
-    with urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response, open(target_path, "wb") as f:
+    with (
+        urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response,
+        open(target_path, "wb") as f,
+    ):
         f.write(response.read())
 
 
@@ -110,7 +129,9 @@ class TestSonataGrpcBackendContract:
         assert isinstance(version, str)
         assert version.strip() != ""
 
-    def test_load_voice_and_synthesize_returns_non_empty_audio(self, backend, downloaded_voice):
+    def test_load_voice_and_synthesize_returns_non_empty_audio(
+        self, backend, downloaded_voice
+    ):
         loaded = backend.load_voice(downloaded_voice)
         assert loaded.backend_voice_id
         assert loaded.sample_rate > 0

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """conftest.py for the real-NVDA e2e layer.
 
 Deliberately not part of tests/ or tests_gui/: this tree needs a real NVDA
@@ -15,7 +14,8 @@ import re
 import sys
 import time
 import warnings
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 
@@ -41,7 +41,9 @@ def check_no_unexpected_errors(client, *, since: int = 0) -> None:
     """nvda.log.assert_no_errors(), minus what a headless runner logs by itself."""
     environmental, unexpected = [], []
     for record in client.log.errors(since=since):
-        target = environmental if _RUNNER_ENVIRONMENT.search(record.message) else unexpected
+        target = (
+            environmental if _RUNNER_ENVIRONMENT.search(record.message) else unexpected
+        )
         target.append(record)
 
     if environmental:
@@ -98,7 +100,9 @@ def voice_manager_state(nvda, expr: str) -> Any:
     allow-eval = true in pyproject.toml.
     """
     return nvda.eval(
-        "(lambda wx, dialog: " + expr + ")(__import__('wx'), __import__('wx').GetActiveWindow())"
+        "(lambda wx, dialog: "
+        + expr
+        + ")(__import__('wx'), __import__('wx').GetActiveWindow())"
     )
 
 
@@ -118,7 +122,11 @@ def press_until(
     for attempt in range(attempts):
         nvda.keys.press(gesture)
         try:
-            wait_until(predicate, timeout=timeout, description=description or f"{gesture!r} to land")
+            wait_until(
+                predicate,
+                timeout=timeout,
+                description=description or f"{gesture!r} to land",
+            )
             return
         except AssertionError:
             if attempt == attempts - 1:

--- a/tests_e2e/test_voice_manager.py
+++ b/tests_e2e/test_voice_manager.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """Real-NVDA end-to-end tests: install the built add-on into a real,
 disposable NVDA and drive it exactly as a user would.
 
@@ -30,7 +29,9 @@ VOICE_DOWNLOADED_TITLE = "Voice downloaded"
 #: voice_manager_state() binds -- is that toast, not DengjenVoiceManagerDialog,
 #: for as long as the fetch is in flight. Locating the real dialog by its
 #: notebookCtrl attribute instead sidesteps that race.
-_VOICE_MANAGER_DIALOG = "next(w for w in wx.GetTopLevelWindows() if hasattr(w, 'notebookCtrl'))"
+_VOICE_MANAGER_DIALOG = (
+    "next(w for w in wx.GetTopLevelWindows() if hasattr(w, 'notebookCtrl'))"
+)
 
 
 @pytest.mark.fresh_nvda
@@ -75,8 +76,10 @@ def test_the_no_voice_modal_appears_and_no_declines_it(
     # title also doesn't mention the voice manager, so the old assertion
     # below would pass either way.
     wait_until(
-        lambda: voice_manager_state(nvda, "dialog.GetTitle() if dialog else ''")
-        != NO_VOICE_MODAL_TITLE,
+        lambda: (
+            voice_manager_state(nvda, "dialog.GetTitle() if dialog else ''")
+            != NO_VOICE_MODAL_TITLE
+        ),
         timeout=5,
         description="the no-voice message box to close",
     )
@@ -118,18 +121,24 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     press_until(
         nvda,
         "control+tab",  # Installed tab -> Download tab
-        lambda: voice_manager_state(
-            nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetSelection()"
-        )
-        == 1,
+        lambda: (
+            voice_manager_state(
+                nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetSelection()"
+            )
+            == 1
+        ),
         description="the notebook to switch to the Download tab",
     )
 
     nvda.speech.wait_for("retrieving voices list", timeout=10, since=before)
     wait_until(
-        lambda: voice_manager_state(
-            nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).language_choice.GetCount()"
-        ) > 0,
+        lambda: (
+            voice_manager_state(
+                nvda,
+                f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).language_choice.GetCount()",
+            )
+            > 0
+        ),
         timeout=30,
         description="the online language list to populate",
     )
@@ -143,9 +152,13 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     nvda.keys.press("tab")  # notebook tab strip -> language_choice
     nvda.keys.press("downArrow")  # select the first language
     wait_until(
-        lambda: voice_manager_state(
-            nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).voices_list.GetItemCount()"
-        ) > 0,
+        lambda: (
+            voice_manager_state(
+                nvda,
+                f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).voices_list.GetItemCount()",
+            )
+            > 0
+        ),
         timeout=10,
         description="voices for the selected language to list",
     )
@@ -166,7 +179,9 @@ def downloaded_voice_key(nvda_session, addon_under_test):
         "  None"
         ")",
     )
-    assert rt_index is not None, "no voice for the first language has a fast (RT) variant"
+    assert rt_index is not None, (
+        "no voice for the first language has a fast (RT) variant"
+    )
 
     # on_language_selection_change() sets the list's *internal* focused item
     # (SetItemState(..., LIST_STATE_FOCUSED, ...)) but never calls SetFocus,
@@ -177,14 +192,19 @@ def downloaded_voice_key(nvda_session, addon_under_test):
         nvda.keys.press("downArrow")
 
     online_key = voice_manager_state(
-        nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).voices_list.get_selected().key"
+        nvda,
+        f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetPage(1).voices_list.get_selected().key",
     )
 
-    nvda.keys.press_all("tab", "tab", "tab")  # voices_list -> preview -> std -> rt button
+    nvda.keys.press_all(
+        "tab", "tab", "tab"
+    )  # voices_list -> preview -> std -> rt button
     before = nvda.speech.index()
     nvda.keys.press("space")  # "Download &fast variant"
 
-    nvda.speech.wait_for("voice downloaded|successfully downloaded", timeout=90, since=before)
+    nvda.speech.wait_for(
+        "voice downloaded|successfully downloaded", timeout=90, since=before
+    )
     # Another real Windows messageBox, same swallowed-keystroke risk as the
     # no-voice modal's decline -- a lost "n" here leaves it open and blocks
     # every keystroke the rest of this fixture and test_downloading_the_fast_
@@ -194,8 +214,10 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     press_until(
         nvda,
         "n",  # decline the immediate restart offer; Task 5 restarts explicitly
-        lambda: voice_manager_state(nvda, "dialog.GetTitle() if dialog else ''")
-        != VOICE_DOWNLOADED_TITLE,
+        lambda: (
+            voice_manager_state(nvda, "dialog.GetTitle() if dialog else ''")
+            != VOICE_DOWNLOADED_TITLE
+        ),
         description="the voice-downloaded message box to close",
     )
 
@@ -207,7 +229,9 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     # sighted user landing on the wrong window would Alt+Tab back; do the
     # same for real (never via eval, which stays read-only in this suite),
     # only if focus genuinely isn't on the dialog already.
-    if not voice_manager_state(nvda, "dialog is not None and hasattr(dialog, 'notebookCtrl')"):
+    if not voice_manager_state(
+        nvda, "dialog is not None and hasattr(dialog, 'notebookCtrl')"
+    ):
         press_until(
             nvda,
             "alt+tab",
@@ -234,7 +258,9 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     return f"{lang}-{name}+RT-{quality}"
 
 
-def test_downloading_the_fast_variant_voice_installs_it(nvda, downloaded_voice_key, assert_no_unexpected_errors):
+def test_downloading_the_fast_variant_voice_installs_it(
+    nvda, downloaded_voice_key, assert_no_unexpected_errors
+):
     """Depends on downloaded_voice_key leaving the voice manager dialog open on the Download tab."""
     # DengjenVoiceManagerDialog._invalidate_pages_voice_cache invalidates
     # every notebook page's cache, not just the Installed tab's -- but that
@@ -242,7 +268,9 @@ def test_downloading_the_fast_variant_voice_installs_it(nvda, downloaded_voice_k
     # repopulates a page that isn't showing. Switching to it is what
     # triggers onNotebookPageChanged -> populate_list() -> a real refresh
     # from disk, same as a user checking their download landed.
-    nvda.wait_until_idle(timeout=15)  # let the fixture's trailing UI activity settle first
+    nvda.wait_until_idle(
+        timeout=15
+    )  # let the fixture's trailing UI activity settle first
 
     # control+tab can be sent before OS-level keyboard focus has genuinely
     # returned to the notebook after the fixture dismissed its real Windows
@@ -255,10 +283,12 @@ def test_downloading_the_fast_variant_voice_installs_it(nvda, downloaded_voice_k
     press_until(
         nvda,
         "control+tab",  # Download tab -> Installed tab
-        lambda: voice_manager_state(
-            nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetSelection()"
-        )
-        == 0,
+        lambda: (
+            voice_manager_state(
+                nvda, f"{_VOICE_MANAGER_DIALOG}.notebookCtrl.GetSelection()"
+            )
+            == 0
+        ),
         description="the notebook to switch to the Installed tab",
     )
 
@@ -274,7 +304,9 @@ def test_downloading_the_fast_variant_voice_installs_it(nvda, downloaded_voice_k
     assert_no_unexpected_errors(nvda)
 
 
-def test_the_downloaded_voice_produces_real_speech(nvda, downloaded_voice_key, assert_no_unexpected_errors):
+def test_the_downloaded_voice_produces_real_speech(
+    nvda, downloaded_voice_key, assert_no_unexpected_errors
+):
     nvda.config.set(["speech", "synth"], ADDON_NAME)
     nvda.config.set(["speech", ADDON_NAME, "voice"], downloaded_voice_key)
     nvda.restart()  # NVDA reads config.conf["speech"]["synth"] on startup

--- a/tests_gui/conftest.py
+++ b/tests_gui/conftest.py
@@ -64,7 +64,7 @@ class _SyncExecutor:
         future = Future()
         try:
             future.set_result(fn(*args, **kwargs))
-        except BaseException as exc:  # noqa: BLE001 - mirrors Executor semantics
+        except BaseException as exc:
             future.set_exception(exc)
         return future
 

--- a/tests_gui/conftest.py
+++ b/tests_gui/conftest.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 conftest.py for the GUI smoke tests -- these import the REAL wxPython.
 
@@ -36,8 +35,8 @@ if sys.platform == "win32":
 
     install(stub_wx=False)
 
-    import wx
     import gui
+    import wx
 
 
 @pytest.fixture(scope="session")

--- a/tests_gui/test_components_contracts.py
+++ b/tests_gui/test_components_contracts.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Contract tests for components.py that are not about a specific widget:
 AsyncSnakDialog's done-callback protocol, SnakDialog's Escape handling, and a
@@ -182,9 +181,7 @@ class TestAsyncSnakDialog:
         assert received == [future]
         assert received[0].result() == "voices"
 
-    def test_future_is_the_submitted_future_and_stays_wired(
-        self, components, nvda_gui
-    ):
+    def test_future_is_the_submitted_future_and_stays_wired(self, components, nvda_gui):
         executor = _PendingExecutor()
         received = []
         dialog = components.AsyncSnakDialog(

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -9,6 +9,7 @@ sysTrayIcon.menu is a real wx.Menu here, so Append/DestroyItem are genuinely
 exercised.
 """
 
+import contextlib
 import sys
 from unittest.mock import MagicMock
 
@@ -45,10 +46,8 @@ def one_installed_voice(plugin_module, monkeypatch):
 def plugin(plugin_module, nvda_gui):
     instance = plugin_module.GlobalPlugin()
     yield instance
-    try:
+    with contextlib.suppress(Exception):
         instance.terminate()
-    except Exception:
-        pass
 
 
 class TestMenuLifecycle:

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Menu lifecycle and startup-check tests for globalPlugins/__init__.py against
 real wxPython.
@@ -17,8 +16,6 @@ import pytest
 
 if sys.platform != "win32":
     pytest.skip("real wxPython is Windows-only here", allow_module_level=True)
-
-import wx
 
 
 @pytest.fixture
@@ -116,6 +113,6 @@ class TestVoiceCheck:
         # short-circuit in _perform_voice_check -- and dragging them in would
         # only add flakiness risk for no extra coverage. The flag is set
         # directly here so the test isolates that short-circuit alone.
-        setattr(plugin, "_GlobalPlugin__voice_manager_shown", True)
+        plugin._GlobalPlugin__voice_manager_shown = True
         plugin._perform_voice_check()
         assert not gui.messageBox.called

--- a/tests_gui/test_list_view.py
+++ b/tests_gui/test_list_view.py
@@ -68,7 +68,7 @@ class TestColumnDefn:
 
     def test_unknown_alignment_is_rejected(self, components):
         with pytest.raises(ValueError, match="Unknown alignment directive"):
-            components.ColumnDefn("t", "sideways", 1, "x").alignment_flag
+            _ = components.ColumnDefn("t", "sideways", 1, "x").alignment_flag
 
     def test_annotations_resolve(self, components):
         # `from __future__ import annotations` keeps these as strings, so a

--- a/tests_gui/test_list_view.py
+++ b/tests_gui/test_list_view.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Smoke tests for components.py against real wxPython: ImmutableObjectListView
 actually populates a wx.ListCtrl from ColumnDefns, get_selected maps the
@@ -54,9 +53,18 @@ def list_view(components, nvda_gui):
 
 class TestColumnDefn:
     def test_alignment_maps_to_wx_format_flags(self, components):
-        assert components.ColumnDefn("t", "left", 1, "x").alignment_flag == wx.LIST_FORMAT_LEFT
-        assert components.ColumnDefn("t", "center", 1, "x").alignment_flag == wx.LIST_FORMAT_CENTRE
-        assert components.ColumnDefn("t", "right", 1, "x").alignment_flag == wx.LIST_FORMAT_RIGHT
+        assert (
+            components.ColumnDefn("t", "left", 1, "x").alignment_flag
+            == wx.LIST_FORMAT_LEFT
+        )
+        assert (
+            components.ColumnDefn("t", "center", 1, "x").alignment_flag
+            == wx.LIST_FORMAT_CENTRE
+        )
+        assert (
+            components.ColumnDefn("t", "right", 1, "x").alignment_flag
+            == wx.LIST_FORMAT_RIGHT
+        )
 
     def test_unknown_alignment_is_rejected(self, components):
         with pytest.raises(ValueError, match="Unknown alignment directive"):

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Construction and event-wiring smoke tests for voice_manager.py against real
 wxPython.
@@ -31,9 +30,9 @@ import pytest
 if sys.platform != "win32":
     pytest.skip("real wxPython is Windows-only here", allow_module_level=True)
 
+import gui
 import wx
 from wx.adv import CommandLinkButton
-import gui
 
 
 @pytest.fixture
@@ -61,9 +60,7 @@ def espeak_synth(voice_manager, monkeypatch):
     synth = MagicMock()
     synth.name = "espeak"
     synth.voice = "en"
-    monkeypatch.setattr(
-        voice_manager.synthDriverHandler, "getSynth", lambda: synth
-    )
+    monkeypatch.setattr(voice_manager.synthDriverHandler, "getSynth", lambda: synth)
     return synth
 
 
@@ -251,7 +248,9 @@ class TestOnlinePanelControls:
             return []
 
         monkeypatch.setattr(
-            voice_manager.voice_download, "get_available_voices", fake_get_available_voices
+            voice_manager.voice_download,
+            "get_available_voices",
+            fake_get_available_voices,
         )
         monkeypatch.setattr(
             voice_manager.voice_download, "THREAD_POOL_EXECUTOR", sync_executor
@@ -325,7 +324,9 @@ class TestOnlinePanelControls:
         # for this fixture's file-less voice, would mkdir a real directory
         # under DENGJEN_VOICES_DIR on the runner.
         downloader_cls = MagicMock()
-        monkeypatch.setattr(voice_manager.voice_download, "PiperVoiceDownloader", downloader_cls)
+        monkeypatch.setattr(
+            voice_manager.voice_download, "PiperVoiceDownloader", downloader_cls
+        )
         panel.voices_list.set_objects([online_voices[0]])
         panel.voices_list.set_focused_item(0)
         _fire_button(panel, panel.download_std_btn)
@@ -336,7 +337,9 @@ class TestOnlinePanelControls:
         self, panel, voice_manager, monkeypatch, online_voices
     ):
         downloader_cls = MagicMock()
-        monkeypatch.setattr(voice_manager.voice_download, "PiperRTVoiceDownloader", downloader_cls)
+        monkeypatch.setattr(
+            voice_manager.voice_download, "PiperRTVoiceDownloader", downloader_cls
+        )
         panel.voices_list.set_objects([online_voices[0]])
         panel.voices_list.set_focused_item(0)
         _fire_button(panel, panel.download_rt_btn)
@@ -446,7 +449,9 @@ class TestNotebookPageChanged:
             return online_voices
 
         monkeypatch.setattr(
-            voice_manager.voice_download, "get_available_voices", fake_get_available_voices
+            voice_manager.voice_download,
+            "get_available_voices",
+            fake_get_available_voices,
         )
         monkeypatch.setattr(
             voice_manager.voice_download, "THREAD_POOL_EXECUTOR", sync_executor

--- a/update_cffi.py
+++ b/update_cffi.py
@@ -1,9 +1,9 @@
-import urllib.request
+import glob
 import json
-import zipfile
 import os
 import shutil
-import glob
+import urllib.request
+import zipfile
 
 import vendored_manifest
 
@@ -11,7 +11,7 @@ import vendored_manifest
 url = "https://pypi.org/pypi/cffi/json"
 
 print("Fetching cffi release info from PyPI...")
-req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
 try:
     with urllib.request.urlopen(req) as response:
         data = json.loads(response.read().decode())
@@ -32,7 +32,9 @@ for r in releases:
         break
 
 if not wheel_url:
-    print(f"Could not find a Python 3.13 64-bit Windows wheel for cffi version {version}.")
+    print(
+        f"Could not find a Python 3.13 64-bit Windows wheel for cffi version {version}."
+    )
     exit(1)
 
 print(f"Downloading {wheel_url}...")
@@ -46,11 +48,15 @@ except Exception as e:
 print("Extracting cffi...")
 extract_dir = "cffi_extracted"
 backend_pyd_name = None
-with zipfile.ZipFile(wheel_path, 'r') as z:
+with zipfile.ZipFile(wheel_path, "r") as z:
     for info in z.infolist():
-        if info.filename.startswith("cffi/") or info.filename.startswith("_cffi_backend"):
+        if info.filename.startswith("cffi/") or info.filename.startswith(
+            "_cffi_backend"
+        ):
             z.extract(info, extract_dir)
-            if info.filename.startswith("_cffi_backend") and info.filename.endswith(".pyd"):
+            if info.filename.startswith("_cffi_backend") and info.filename.endswith(
+                ".pyd"
+            ):
                 backend_pyd_name = info.filename
 
 if backend_pyd_name is None:
@@ -70,7 +76,10 @@ if os.path.exists(cffi_target):
     shutil.rmtree(cffi_target)
 
 print(f"Installing new 64-bit Python 3.13 cffi to {target_dir}...")
-shutil.copy(os.path.join(extract_dir, backend_pyd_name), os.path.join(target_dir, backend_pyd_name))
+shutil.copy(
+    os.path.join(extract_dir, backend_pyd_name),
+    os.path.join(target_dir, backend_pyd_name),
+)
 shutil.copytree(os.path.join(extract_dir, "cffi"), cffi_target)
 
 print("Cleaning up...")

--- a/update_cffi.py
+++ b/update_cffi.py
@@ -2,6 +2,7 @@ import glob
 import json
 import os
 import shutil
+import sys
 import urllib.request
 import zipfile
 
@@ -17,7 +18,7 @@ try:
         data = json.loads(response.read().decode())
 except Exception as e:
     print(f"Failed to fetch PyPI data: {e}")
-    exit(1)
+    sys.exit(1)
 
 # Find the latest wheel for cp313 win_amd64
 version = data["info"]["version"]
@@ -35,7 +36,7 @@ if not wheel_url:
     print(
         f"Could not find a Python 3.13 64-bit Windows wheel for cffi version {version}."
     )
-    exit(1)
+    sys.exit(1)
 
 print(f"Downloading {wheel_url}...")
 wheel_path = "cffi.whl"
@@ -43,7 +44,7 @@ try:
     urllib.request.urlretrieve(wheel_url, wheel_path)
 except Exception as e:
     print(f"Download failed: {e}")
-    exit(1)
+    sys.exit(1)
 
 print("Extracting cffi...")
 extract_dir = "cffi_extracted"
@@ -61,7 +62,7 @@ with zipfile.ZipFile(wheel_path, "r") as z:
 
 if backend_pyd_name is None:
     print("Could not find _cffi_backend .pyd in wheel.")
-    exit(1)
+    sys.exit(1)
 
 target_dir = os.path.join("addon", "synthDrivers", "dengjen_neural_voices", "lib")
 

--- a/update_grpc.py
+++ b/update_grpc.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import sys
 import urllib.request
 import zipfile
 
@@ -16,7 +17,7 @@ try:
         data = json.loads(response.read().decode())
 except Exception as e:
     print(f"Failed to fetch PyPI data: {e}")
-    exit(1)
+    sys.exit(1)
 
 # Find the latest wheel for cp313 win_amd64
 version = data["info"]["version"]
@@ -34,7 +35,7 @@ if not wheel_url:
     print(
         f"Could not find a Python 3.13 64-bit Windows wheel for grpcio version {version}."
     )
-    exit(1)
+    sys.exit(1)
 
 print(f"Downloading {wheel_url}...")
 wheel_path = "grpcio.whl"
@@ -42,7 +43,7 @@ try:
     urllib.request.urlretrieve(wheel_url, wheel_path)
 except Exception as e:
     print(f"Download failed: {e}")
-    exit(1)
+    sys.exit(1)
 
 print("Extracting grpc...")
 extract_dir = "grpc_extracted"

--- a/update_grpc.py
+++ b/update_grpc.py
@@ -1,8 +1,8 @@
-import urllib.request
 import json
-import zipfile
 import os
 import shutil
+import urllib.request
+import zipfile
 
 import vendored_manifest
 
@@ -10,7 +10,7 @@ import vendored_manifest
 url = "https://pypi.org/pypi/grpcio/json"
 
 print("Fetching grpcio release info from PyPI...")
-req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
 try:
     with urllib.request.urlopen(req) as response:
         data = json.loads(response.read().decode())
@@ -31,7 +31,9 @@ for r in releases:
         break
 
 if not wheel_url:
-    print(f"Could not find a Python 3.13 64-bit Windows wheel for grpcio version {version}.")
+    print(
+        f"Could not find a Python 3.13 64-bit Windows wheel for grpcio version {version}."
+    )
     exit(1)
 
 print(f"Downloading {wheel_url}...")
@@ -44,12 +46,14 @@ except Exception as e:
 
 print("Extracting grpc...")
 extract_dir = "grpc_extracted"
-with zipfile.ZipFile(wheel_path, 'r') as z:
+with zipfile.ZipFile(wheel_path, "r") as z:
     for info in z.infolist():
         if info.filename.startswith("grpc/"):
             z.extract(info, extract_dir)
 
-target_dir = os.path.join("addon", "synthDrivers", "dengjen_neural_voices", "lib", "grpc")
+target_dir = os.path.join(
+    "addon", "synthDrivers", "dengjen_neural_voices", "lib", "grpc"
+)
 if os.path.exists(target_dir):
     print(f"Removing old 32-bit Python 3.11 grpc from {target_dir}...")
     shutil.rmtree(target_dir)

--- a/update_miniaudio.py
+++ b/update_miniaudio.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import sys
 import urllib.request
 import zipfile
 
@@ -16,7 +17,7 @@ try:
         data = json.loads(response.read().decode())
 except Exception as e:
     print(f"Failed to fetch PyPI data: {e}")
-    exit(1)
+    sys.exit(1)
 
 # Find the latest wheel for cp313 win_amd64
 version = data["info"]["version"]
@@ -34,7 +35,7 @@ if not wheel_url:
     print(
         f"Could not find a Python 3.13 64-bit Windows wheel for miniaudio version {version}."
     )
-    exit(1)
+    sys.exit(1)
 
 print(f"Downloading {wheel_url}...")
 wheel_path = "miniaudio.whl"
@@ -42,7 +43,7 @@ try:
     urllib.request.urlretrieve(wheel_url, wheel_path)
 except Exception as e:
     print(f"Download failed: {e}")
-    exit(1)
+    sys.exit(1)
 
 print("Extracting miniaudio...")
 extract_dir = "miniaudio_extracted"

--- a/update_miniaudio.py
+++ b/update_miniaudio.py
@@ -1,8 +1,8 @@
-import urllib.request
 import json
-import zipfile
 import os
 import shutil
+import urllib.request
+import zipfile
 
 import vendored_manifest
 
@@ -10,7 +10,7 @@ import vendored_manifest
 url = "https://pypi.org/pypi/miniaudio/json"
 
 print("Fetching miniaudio release info from PyPI...")
-req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
 try:
     with urllib.request.urlopen(req) as response:
         data = json.loads(response.read().decode())
@@ -31,7 +31,9 @@ for r in releases:
         break
 
 if not wheel_url:
-    print(f"Could not find a Python 3.13 64-bit Windows wheel for miniaudio version {version}.")
+    print(
+        f"Could not find a Python 3.13 64-bit Windows wheel for miniaudio version {version}."
+    )
     exit(1)
 
 print(f"Downloading {wheel_url}...")
@@ -44,7 +46,7 @@ except Exception as e:
 
 print("Extracting miniaudio...")
 extract_dir = "miniaudio_extracted"
-with zipfile.ZipFile(wheel_path, 'r') as z:
+with zipfile.ZipFile(wheel_path, "r") as z:
     for info in z.infolist():
         if info.filename in ("_miniaudio.pyd", "miniaudio.py"):
             z.extract(info, extract_dir)


### PR DESCRIPTION
Closes #<!-- remove, no linked issue -->

## Summary

1-3 sentences: closes three CI gaps found comparing this repo's workflows against its siblings — no lint job existed at all, no Actions-workflow security linting, and no tracking of the upstream this repo was forked from.

## Changes

- `lint.yml` — new workflow: `lint` job (ruff check + format, matching the sibling nvda-addon-testkit repo's convention since neither ruff nor any other linter was previously configured here) and `audit` job (`pip-audit` against all `requirements-*.txt`, `continue-on-error: true` for its first pass since these pins have never been audited before).
- `zizmor.yml` — ported from dengjen-piper-rs. Note: `build_addon.yml` already runs zizmor indirectly via `pre-commit run --all`; this adds a dedicated always-on job with SARIF upload.
- `upstream-watch.yml` — adapted from dengjen-tashkeel's pattern, tracking [mush42/sonata-nvda](https://github.com/mush42/sonata-nvda), the add-on this repo continues as a maintenance fork (see readme.md). Weekly + on-demand; opens/updates/closes a labeled tracking issue, no auto-merge.

## Test plan

- [x] Syntax check passes (validated with `actionlint` and `zizmor`, zero findings).
- [ ] CI build + test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added automated code quality, formatting, and workflow security checks.
  - Added scheduled monitoring for upstream updates, with tracking when synchronization is needed.
  - Added manual options to run maintenance and security checks on demand.
  - Standardized formatting and type annotations across the project without changing user-facing behavior.
  - Improved maintenance-script error handling while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->