### PR TITLE
Add C4 architecture diagram

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,4 +1,5 @@
 * xref:index.adoc[Overview]
+* xref:architecture.adoc[Architecture]
 * xref:installation.adoc[Installation]
 * xref:usage.adoc[Usage]
 * xref:troubleshooting.adoc[Troubleshooting]

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -1,0 +1,87 @@
+= Architecture
+
+This page shows dengjen-nvda's own structure as a https://c4model.com/[C4]
+Container, Component, and Code diagram. For how it fits into the wider
+ZirekHQ speech stack, see the
+https://zirekhq.github.io/en/home/architecture.html[org-wide System Context
+diagram].
+
+== Container
+
+dengjen-nvda is not one process but two: NVDA loads the add-on itself
+in-process, and the add-on launches a vendored, separately-built
+`dengjen-tts-grpc.exe` binary (a dengjen-tts frontend) as its own subprocess,
+talking to it over gRPC.
+
+[source,mermaid]
+----
+C4Container
+    System_Ext(nvda, "NVDA", "The screen reader host process")
+
+    System_Boundary(addon, "dengjen-nvda") {
+        Container(synthdriver, "dengjen_neural_voices", "Python 3.13 add-on", "Loaded in-process by NVDA as a synthesizer driver")
+        Container(grpcbin, "dengjen-tts-grpc.exe", "Vendored Rust binary", "Launched via subprocess.Popen; a gRPC-frontend build of dengjen-tts")
+    }
+
+    System_Ext(voices, "Voice catalogue", "External download source for voices")
+
+    Rel(nvda, synthdriver, "Loads / calls SynthDriver API")
+    Rel(synthdriver, grpcbin, "Launches, then calls over gRPC")
+    Rel(synthdriver, voices, "Downloads voices from")
+----
+
+== Component
+
+The add-on itself is a small hexagonal (ports-and-adapters) design: domain
+logic that knows nothing about NVDA or gRPC, one seam (`TTSBackend`) that any
+synthesis backend must satisfy, and two adapters either side of that seam.
+
+[source,mermaid]
+----
+C4Component
+    Container_Boundary(addon, "dengjen_neural_voices") {
+        Component(domain, "domain/tts_system.py", "Python module", "Pure domain logic: voices, speech options. No gRPC, no NVDA imports.")
+        Component(port, "ports/tts_backend.py", "Python Protocol", "TTSBackend -- the one interface a TTS engine adapter must satisfy")
+        Component(grpcadapter, "adapters/sonata_grpc", "Python package", "Implements TTSBackend by launching and talking to dengjen-tts-grpc.exe")
+        Component(nvdaadapter, "adapters/nvda/synth_driver.py", "Python module", "Exposes the domain layer to NVDA's own SynthDriver API")
+    }
+
+    Rel(nvdaadapter, domain, "Uses")
+    Rel(nvdaadapter, port, "Depends on")
+    Rel(grpcadapter, port, "Implements")
+    Rel(nvdaadapter, grpcadapter, "Invokes through the port, not directly")
+----
+
+== Code
+
+`TTSBackend` is a `Protocol`, not a base class -- the `sonata_grpc` adapter
+satisfies it structurally. Its methods are split deliberately: everything NVDA
+calls synchronously from its main thread has to stay blocking; only
+`synthesize()` is a true async generator.
+
+[source,mermaid]
+----
+classDiagram
+    class TTSBackend {
+        <<Protocol>>
+        +initialize()
+        +check_version()
+        +shutdown()
+        +load_voice()
+        +get_synth_options()
+        +set_synth_options()
+        +synthesize() AsyncIterator~bytes~
+    }
+    class SynthOptions {
+        <<frozen dataclass>>
+    }
+    class LoadedVoice {
+        <<frozen dataclass>>
+    }
+    class SonataGrpcAdapter
+
+    TTSBackend <|.. SonataGrpcAdapter
+    TTSBackend ..> SynthOptions : passes
+    TTSBackend ..> LoadedVoice : returns
+    note for SonataGrpcAdapter "Implements TTSBackend by launching and calling dengjen-tts-grpc.exe"
+----

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -46,10 +46,9 @@ C4Component
         Component(nvdaadapter, "adapters/nvda/synth_driver.py", "Python module", "Exposes the domain layer to NVDA's own SynthDriver API")
     }
 
-    Rel(nvdaadapter, domain, "Uses")
-    Rel(nvdaadapter, port, "Depends on")
+    Rel(nvdaadapter, domain, "Creates/manages DengjenVoice")
+    Rel(domain, port, "Calls self.backend, typed as")
     Rel(grpcadapter, port, "Implements")
-    Rel(nvdaadapter, grpcadapter, "Invokes through the port, not directly")
 ----
 
 == Code
@@ -78,10 +77,10 @@ classDiagram
     class LoadedVoice {
         <<frozen dataclass>>
     }
-    class SonataGrpcAdapter
+    class SonataGrpcBackend
 
-    TTSBackend <|.. SonataGrpcAdapter
+    TTSBackend <|.. SonataGrpcBackend
     TTSBackend ..> SynthOptions : passes
     TTSBackend ..> LoadedVoice : returns
-    note for SonataGrpcAdapter "Implements TTSBackend by launching and calling dengjen-tts-grpc.exe"
+    note for SonataGrpcBackend "Implements TTSBackend by launching and calling dengjen-tts-grpc.exe"
 ----


### PR DESCRIPTION
## Summary
- Adds docs/modules/ROOT/pages/architecture.adoc: a C4 Container/Component/Code breakdown of the add-on, rendered with Mermaid.
- Container level shows the real process split -- the Python add-on loaded in-process by NVDA, and the vendored dengjen-tts-grpc.exe subprocess it launches and talks to over gRPC.
- Component level shows the hexagonal design (domain logic, the TTSBackend port, and the sonata_grpc/NVDA adapters either side of it).
- Wires the page into docs/modules/ROOT/nav.adoc.

## Test plan
- [x] Diagrams verified to parse and render as real SVGs (not error boxes) via a local Antora + Mermaid build and headless-browser check.
- [ ] CI passes on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an Architecture section to the documentation navigation.
  - Added architecture documentation covering system diagrams, add-on and subprocess communication, voice downloads, application structure, and synchronous/asynchronous protocol behavior.
  - Updated architecture diagrams to accurately show domain communication through the text-to-speech backend interface.
  - Corrected the documented backend name to match the implemented component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->