### PR TITLE
chore: add org Project status-sync automation and board link

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -6,8 +6,10 @@ on:
   pull_request:
     types: [opened]
 
+permissions: {}
+
 jobs:
   sync:
-    uses: ZirekHQ/.github/.github/workflows/project-sync.yml@main
+    uses: ZirekHQ/.github/.github/workflows/project-sync.yml@576ae213e3574b3b0ff5bf46bcfc8e3956fd620d # main
     secrets:
       PROJECT_SYNC_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -1,0 +1,13 @@
+name: Project sync
+
+on:
+  issues:
+    types: [opened, assigned]
+  pull_request:
+    types: [opened]
+
+jobs:
+  sync:
+    uses: ZirekHQ/.github/.github/workflows/project-sync.yml@main
+    secrets:
+      PROJECT_SYNC_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # Dengjen Neural Voices for NVDA
 
+[Project board](https://github.com/orgs/ZirekHQ/projects/1) — live roadmap and status for this repo's issues.
+
 > **Project history**
 >
 > Musharraf Omer ([@mush42](https://github.com/mush42)) created the original add-on and [announced on the NVDA Add-ons list](https://nvda-addons.groups.io/g/nvda-addons/message/27636) that commercial contract conflicts prevent him from continuing to maintain it. This project has continued it since, keeping the add-on working on current NVDA releases, with compatibility updates alongside bug fixes to the voice manager and the synthesizer driver. All credit for the original work belongs to Musharraf Omer.


### PR DESCRIPTION
Wires this repo into the shared ZirekHQ Roadmap project (ZirekHQ/projects/1) via the reusable workflow in ZirekHQ/.github: new issues get added with Status Todo, assigning moves them to In Progress, and PRs closing an issue move it to In Review. Adds a board link to the readme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a link to the live project roadmap and issue status board.

- **Chores**
  - Updated project board synchronization workflow permissions and version pinning to improve workflow consistency and security.
  - Existing synchronization triggers and secret forwarding remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->