### PR TITLE
chore: bump project-sync.yml pin to pick up fork-guard fix

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -10,6 +10,6 @@ permissions: {}
 
 jobs:
   sync:
-    uses: ZirekHQ/.github/.github/workflows/project-sync.yml@576ae213e3574b3b0ff5bf46bcfc8e3956fd620d # main
+    uses: ZirekHQ/.github/.github/workflows/project-sync.yml@54452127e2c87f8ecfe358fc88e0f1fe411859b3 # main
     secrets:
       PROJECT_SYNC_TOKEN: ${{ secrets.PROJECT_SYNC_TOKEN }}


### PR DESCRIPTION
ZirekHQ/.github#2 added a fork-PR guard and least-privilege permissions to the reusable workflow. SHA-pinned callers don't pick that up automatically, so bump this repo's pin to the new main commit (54452127e2c87f8ecfe358fc88e0f1fe411859b3).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project synchronization workflow to use a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->