### PR TITLE
ci: add Conventional-Commits release pipeline

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,8 @@ tag-template: 'v$RESOLVED_VERSION'
 template: |
   $CHANGES
 
+  <!-- release-drafter:managed -->
+
 categories:
   - title: '🐛 Fixes'
     labels:

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -235,7 +235,8 @@ jobs:
       if: steps.draft.outputs.tag != '' && steps.draft.outputs.tag != github.ref_name
       env:
         GH_TOKEN: ${{ github.token }}
-      run: gh release delete "${{ steps.draft.outputs.tag }}" --yes
+        DRAFT_TAG: ${{ steps.draft.outputs.tag }}
+      run: gh release delete "$DRAFT_TAG" --yes
 
     - name: Store submission summary
       run: |

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -190,13 +190,9 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
 
-    # release-drafter accumulates notes on a single open draft (any tag name -- its
-    # $RESOLVED_VERSION placeholder rarely matches the real tag prepare-release.yml computes) as
-    # PRs merge to main. That draft's content is real signal and shouldn't be silently discarded
-    # just because tag-and-release.yml, not a human publishing the draft, is what cuts the tag
-    # now. Matched by a marker in its body (release-drafter.yml's template), not just "the first
-    # open draft" -- a draft created for any other reason must never be mistaken for it and
-    # deleted below.
+    # release-drafter accumulates notes on one draft, tagged with a $RESOLVED_VERSION
+    # placeholder that won't match the real tag. Matched by a marker in the body, not
+    # position -- a draft created for any other reason must never be mistaken for this one.
     - name: Fetch release-drafter draft notes
       id: draft
       env:
@@ -234,10 +230,8 @@ jobs:
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref, '-') }}
 
-    # The draft's notes are now folded into the real release's body above -- delete the draft so
-    # it doesn't linger as an orphaned, superseded entry in the releases list. Guarded by a tag
-    # mismatch check: a draft literally named the same as this tag would mean softprops just
-    # updated it in place (nothing left to delete).
+    # Guarded by a tag-mismatch check: a draft named identically to this tag means softprops
+    # already updated it in place, nothing left to delete.
     - name: Delete superseded release-drafter draft
       if: steps.draft.outputs.tag != '' && steps.draft.outputs.tag != github.ref_name
       env:

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -194,15 +194,22 @@ jobs:
     # $RESOLVED_VERSION placeholder rarely matches the real tag prepare-release.yml computes) as
     # PRs merge to main. That draft's content is real signal and shouldn't be silently discarded
     # just because tag-and-release.yml, not a human publishing the draft, is what cuts the tag
-    # now. There's at most one open draft at a time by construction (release-drafter maintains a
-    # single rolling draft), so grabbing the first is unambiguous.
+    # now. Matched by a marker in its body (release-drafter.yml's template), not just "the first
+    # open draft" -- a draft created for any other reason must never be mistaken for it and
+    # deleted below.
     - name: Fetch release-drafter draft notes
       id: draft
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
-        draft_tag="$(gh release list --json isDraft,tagName -q '[.[] | select(.isDraft)][0].tagName // empty')"
+        draft_tag=""
+        for candidate in $(gh release list --json isDraft,tagName -q '[.[] | select(.isDraft)][].tagName'); do
+          if gh release view "$candidate" --json body -q .body | grep -q '<!-- release-drafter:managed -->'; then
+            draft_tag="$candidate"
+            break
+          fi
+        done
         echo "tag=${draft_tag}" >> "$GITHUB_OUTPUT"
         if [ -n "$draft_tag" ]; then
           gh release view "$draft_tag" --json body -q .body > draft-notes.md

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -189,10 +189,30 @@ jobs:
 
     - name: Display structure of downloaded files
       run: ls -R
-      
+
+    # release-drafter accumulates notes on a single open draft (any tag name -- its
+    # $RESOLVED_VERSION placeholder rarely matches the real tag prepare-release.yml computes) as
+    # PRs merge to main. That draft's content is real signal and shouldn't be silently discarded
+    # just because tag-and-release.yml, not a human publishing the draft, is what cuts the tag
+    # now. There's at most one open draft at a time by construction (release-drafter maintains a
+    # single rolling draft), so grabbing the first is unambiguous.
+    - name: Fetch release-drafter draft notes
+      id: draft
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        draft_tag="$(gh release list --json isDraft,tagName -q '[.[] | select(.isDraft)][0].tagName // empty')"
+        echo "tag=${draft_tag}" >> "$GITHUB_OUTPUT"
+        if [ -n "$draft_tag" ]; then
+          gh release view "$draft_tag" --json body -q .body > draft-notes.md
+        else
+          : > draft-notes.md
+        fi
+
     - name: Calculate sha256
       run: |
-        touch changelog.md
+        cat draft-notes.md > changelog.md
         echo -e "\nSHA256: " >> changelog.md
         sha256sum -- *.nvda-addon >> changelog.md
 
@@ -206,6 +226,16 @@ jobs:
         body_path: changelog.md
         fail_on_unmatched_files: true
         prerelease: ${{ contains(github.ref, '-') }}
+
+    # The draft's notes are now folded into the real release's body above -- delete the draft so
+    # it doesn't linger as an orphaned, superseded entry in the releases list. Guarded by a tag
+    # mismatch check: a draft literally named the same as this tag would mean softprops just
+    # updated it in place (nothing left to delete).
+    - name: Delete superseded release-drafter draft
+      if: steps.draft.outputs.tag != '' && steps.draft.outputs.tag != github.ref_name
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release delete "${{ steps.draft.outputs.tag }}" --yes
 
     - name: Store submission summary
       run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,69 @@
+name: Prepare release
+
+# Proposes a release; merging the opened PR is what actually cuts one -- tag-and-release.yml
+# tags that merge commit and publishes the GitHub Release automatically.
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: main
+          persist-credentials: true
+          fetch-depth: 0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+
+      - name: Compute next version
+        id: next
+        run: |
+          set -uo pipefail
+          # `run:` steps execute as `bash -e {0}` regardless of `set` above -- a bare assignment
+          # would abort here on next-version.sh's exit 1, before rc is ever inspected.
+          if version="$(bash scripts/next-version.sh)"; then
+            rc=0
+          else
+            rc=$?
+          fi
+          if [ "$rc" -eq 0 ]; then
+            echo "version=${version}" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -eq 1 ]; then
+            echo "::notice::Nothing release-worthy since the last tag -- skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::scripts/next-version.sh failed (exit ${rc})"
+            exit "$rc"
+          fi
+
+      - name: Bump version
+        if: steps.next.outputs.skip != 'true'
+        run: bash scripts/bump-version.sh "${STEPS_NEXT_OUTPUTS_VERSION}"
+        env:
+          STEPS_NEXT_OUTPUTS_VERSION: ${{ steps.next.outputs.version }}
+
+      - name: Open release PR
+        if: steps.next.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.next.outputs.version }}
+        run: |
+          set -euo pipefail
+          branch="chore/bump-${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add buildVars.py
+          git commit -m "chore: bump workspace version -> ${VERSION}"
+          git push -u origin "$branch"
+          gh pr create --title "chore: bump workspace version -> ${VERSION}" \
+            --body "Computed by \`prepare-release.yml\` from Conventional Commit subjects since the last tag (see \`scripts/next-version.sh\`). **Merging this releases v${VERSION}**: \`tag-and-release.yml\` tags this merge commit \`v${VERSION}\`, which fires \`build_addon.yml\`'s tag trigger and publishes the GitHub Release (reusing whatever notes \`release-drafter\` has accumulated on its open draft, if any). Review the version and the diff before merging -- the only manual step left after that is one approval click for the \`environment: release\` gate." \
+            --base main --head "$branch"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,0 +1,112 @@
+name: Tag and release
+
+# Fires on every push to main, but only acts on the commit that lands prepare-release.yml's
+# version-bump PR (identified by its exact commit subject). Every other push to main is a no-op.
+#
+# Tagging is the one irreversible step here -- build_addon.yml already triggers off `push:
+# tags: ["v*"]` and publishes the GitHub Release, so pushing the tag is the release, not a
+# precursor to one. That's why the environment:release approval gates the tag push itself,
+# rather than gating some downstream publish step the way dengjen-tts's release.yml does.
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      new_tag:
+        description: "Override the vX.Y.Z tag"
+        required: false
+        type: string
+      dry_run:
+        description: "Dry Run: resolve the version but don't push a tag"
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    # head_commit is absent on workflow_dispatch, hence the event_name check first. It's also
+    # the single new commit a squash/rebase merge produces; a push landing more than one new
+    # commit at once (not this repo's normal PR flow) would only inspect the last of them.
+    if: "github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: bump workspace version -> ')"
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve addon version
+        id: version
+        env:
+          NEW_TAG: ${{ inputs.new_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${NEW_TAG:-}" ]; then
+            version="${NEW_TAG#v}"
+            if ! echo "$version" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+              echo "::error::new_tag '${NEW_TAG}' doesn't look like a vX.Y.Z tag" >&2
+              exit 1
+            fi
+          else
+            version="$(grep -oE 'addon_version="[0-9]+\.[0-9]+\.[0-9]+"' buildVars.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+            if [ -z "$version" ]; then
+              echo "::error::Couldn't find addon_version=\"X.Y.Z\" in buildVars.py" >&2
+              exit 1
+            fi
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+  approve:
+    name: Approve release
+    needs: resolve
+    if: inputs.dry_run != true
+    runs-on: ubuntu-latest
+    environment: release
+    permissions: {}
+    steps:
+      - env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: echo "Approved v${VERSION} for release"
+
+  # always() is paired with an explicit success-or-skipped check, not a bare "run regardless" --
+  # needed because `approve` is legitimately skipped, not failed, on a dry run.
+  tag:
+    name: Push release tag
+    needs: [resolve, approve]
+    if: always() && needs.resolve.result == 'success' && (needs.approve.result == 'success' || needs.approve.result == 'skipped') && inputs.dry_run != true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: true
+
+      - name: Push release tag
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        # Checked against origin, not the local clone -- checkout's shallow fetch wouldn't reliably reflect a tag pushed by an earlier attempt.
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          existing="$(git ls-remote origin "refs/tags/v${VERSION}" | cut -f1)"
+          if [ -n "$existing" ]; then
+            if [ "$existing" != "$GITHUB_SHA" ]; then
+              echo "::error::v${VERSION} already exists on origin and points at ${existing}, not this commit (${GITHUB_SHA})" >&2
+              exit 1
+            fi
+            echo "v${VERSION} already exists on origin and points at this commit -- reusing it"
+          elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            git tag "v${VERSION}"
+            git push origin "v${VERSION}"
+          else
+            echo "::error::Refusing to create v${VERSION} from ${GITHUB_REF} -- release tags are only created from main" >&2
+            exit 1
+          fi

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -83,6 +83,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # GITHUB_TOKEN pushing the tag below is deliberately excluded from triggering
+      # build_addon.yml's own `push: tags:` listener (GitHub's recursion guard on
+      # actions-authored pushes), so nothing would build or publish the release
+      # without the explicit dispatch step -- actions: write is what lets that
+      # dispatch start a new run.
+      actions: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -110,3 +116,16 @@ jobs:
             echo "::error::Refusing to create v${VERSION} from ${GITHUB_REF} -- release tags are only created from main" >&2
             exit 1
           fi
+
+      - name: Trigger build_addon.yml
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        # Dispatched against the real v${VERSION} tag, not main -- workflow_dispatch runs the
+        # workflow file's own content as it exists at --ref, and github.ref resolves to
+        # refs/tags/v${VERSION} either way, satisfying upload_release's own
+        # `startsWith(github.ref, 'refs/tags/')` gate the same as a real tag push would have.
+        # Runs unconditionally after the step above, including the "tag already exists --
+        # reusing it" branch: a prior run that pushed the tag but failed before reaching this
+        # step must still get the dispatch on retry.
+        run: gh workflow run build_addon.yml --ref "v${VERSION}"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -1,12 +1,8 @@
 name: Tag and release
 
-# Fires on every push to main, but only acts on the commit that lands prepare-release.yml's
-# version-bump PR (identified by its exact commit subject). Every other push to main is a no-op.
-#
-# Tagging is the one irreversible step here -- build_addon.yml already triggers off `push:
-# tags: ["v*"]` and publishes the GitHub Release, so pushing the tag is the release, not a
-# precursor to one. That's why the environment:release approval gates the tag push itself,
-# rather than gating some downstream publish step the way dengjen-tts's release.yml does.
+# build_addon.yml's push:tags listener already publishes the GitHub Release, so pushing the tag
+# here IS the release -- that's why environment:release gates the tag push itself, unlike
+# dengjen-tts's release.yml, which gates a downstream publish step instead.
 on:
   push:
     branches:
@@ -83,11 +79,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # GITHUB_TOKEN pushing the tag below is deliberately excluded from triggering
-      # build_addon.yml's own `push: tags:` listener (GitHub's recursion guard on
-      # actions-authored pushes), so nothing would build or publish the release
-      # without the explicit dispatch step -- actions: write is what lets that
-      # dispatch start a new run.
+      # actions: write is for the explicit dispatch below -- a GITHUB_TOKEN-authored
+      # tag push doesn't trigger build_addon.yml's push:tags listener (GitHub's
+      # recursion guard), so nothing would build without it.
       actions: write
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -121,11 +115,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.resolve.outputs.version }}
-        # Dispatched against the real v${VERSION} tag, not main -- workflow_dispatch runs the
-        # workflow file's own content as it exists at --ref, and github.ref resolves to
-        # refs/tags/v${VERSION} either way, satisfying upload_release's own
-        # `startsWith(github.ref, 'refs/tags/')` gate the same as a real tag push would have.
-        # Runs unconditionally after the step above, including the "tag already exists --
-        # reusing it" branch: a prior run that pushed the tag but failed before reaching this
-        # step must still get the dispatch on retry.
+        # Dispatched against the tag ref, not main, so github.ref resolves to refs/tags/v${VERSION}
+        # and satisfies upload_release's tag-prefix gate. Runs unconditionally, including on the
+        # tag-reuse branch, so a retry after a prior failed dispatch still gets one.
         run: gh workflow run build_addon.yml --ref "v${VERSION}"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+new_version="${1:?usage: scripts/bump-version.sh <new-version>}"
+if ! echo "$new_version" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'; then
+  echo "::error::'${new_version}' doesn't look like a semver version (X.Y.Z)" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+old_version="$(grep -oE 'addon_version="[0-9]+\.[0-9]+\.[0-9]+"' buildVars.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)"
+if [ -z "$old_version" ]; then
+  echo "::error::Couldn't find addon_version=\"X.Y.Z\" in buildVars.py" >&2
+  exit 1
+fi
+
+sed -i.bak "s/addon_version=\"${old_version}\"/addon_version=\"${new_version}\"/" buildVars.py
+rm -f buildVars.py.bak
+
+python3 -c "import ast; ast.parse(open('buildVars.py').read())"
+
+echo "Bumped ${old_version} -> ${new_version}:"
+git diff --stat -- buildVars.py

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+last_tag="$(git tag --list 'v*' --merged HEAD --sort=-v:refname | grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' | head -1 || true)"
+if [ -z "$last_tag" ]; then
+  echo "::error::No vX.Y.Z tag found to compute the next version from" >&2
+  exit 2
+fi
+
+version="${last_tag#v}"
+major="${version%%.*}"
+rest="${version#*.}"
+minor="${rest%%.*}"
+patch="${rest#*.}"
+
+subjects="$(git log "${last_tag}..HEAD" --pretty='%s')"
+bodies="$(git log "${last_tag}..HEAD" --pretty='%b')"
+
+if [ -z "$subjects" ]; then
+  echo "::notice::No commits since ${last_tag} -- nothing to release" >&2
+  exit 1
+fi
+
+bump=""
+while IFS= read -r subject; do
+  [ -z "$subject" ] && continue
+
+  if echo "$subject" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:'; then
+    bump="major"
+    break
+  fi
+  if echo "$subject" | grep -qE '^feat(\([^)]*\))?:'; then
+    [ "$bump" != "major" ] && bump="minor"
+    continue
+  fi
+  if echo "$subject" | grep -qE '^(docs|chore|style|refactor|test)(\([^)]*\))?:'; then
+    continue
+  fi
+  [ -z "$bump" ] && bump="patch"
+done <<< "$subjects"
+
+if echo "$bodies" | grep -qE '^BREAKING[ -]CHANGE:'; then
+  bump="major"
+fi
+
+if [ -z "$bump" ]; then
+  echo "::notice::Only docs/chore/style/refactor/test commits since ${last_tag} -- nothing to release" >&2
+  exit 1
+fi
+
+case "$bump" in
+  major) echo "$((major + 1)).0.0" ;;
+  minor) echo "${major}.$((minor + 1)).0" ;;
+  patch) echo "${major}.${minor}.$((patch + 1))" ;;
+esac


### PR DESCRIPTION
Adds dengjen-tts's prepare-release -> tag-and-release pattern, replacing manual version selection (release-drafter's $RESOLVED_VERSION, hand-picked at publish time) with one computed from Conventional Commit subjects.

- **prepare-release.yml** (new, manual dispatch): computes the next version, bumps `buildVars.py`'s `addon_version`, opens a version-bump PR.
- **tag-and-release.yml** (new): tags the merged bump commit idempotently (checks origin before tagging, reuses on retry). The `environment: release` approval gates the tag push itself, not a downstream publish step -- `build_addon.yml`'s existing `push: tags` trigger already builds and publishes the GitHub Release once the tag lands, so here tagging *is* the release.
- **build_addon.yml**: now folds release-drafter's already-accumulated draft notes into the real release body before deleting the superseded draft, so switching away from manual-draft-publish doesn't throw that content away.

Doesn't remove release-drafter itself -- it keeps drafting as PRs merge, this pipeline just consumes its output at release time instead of a human manually publishing the draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated workflows for preparing releases, creating approved version tags, and publishing release notes with checksums.
  - Added support for manual release runs, version overrides, dry runs, and validation of release tags.
  - Added automatic semantic version calculation from merged changes, including breaking changes.
  - Added version update validation with clear transition and change summaries.
- **Bug Fixes**
  - Prevents releases when no release-worthy changes exist or when tags and versions are invalid or conflicting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->