### PR TITLE
feat: add Kokoro voice backend and generalize model-switching support

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -68,7 +68,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         if self.__voice_manager_shown:
             return
         if not any(
-            DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+            DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir(
                 DengjenGrpcBackend()
             )
         ):

--- a/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
@@ -1,0 +1,229 @@
+"""Kokoro-82M download/install: the second ModelCatalog implementation.
+
+Unlike Piper (many independent per-voice files, browsed and downloaded one
+at a time), Kokoro is one shared onnx model + one shared vocab + 54 small
+per-preset voice-embedding files, installed as a single unit. Presets are
+selected afterwards via NVDA's existing multi-speaker "Speaker" setting --
+see domain/tts_system.py's DengjenVoice.speaker.
+
+Source: onnx-community/Kokoro-82M-v1.0-ONNX on HuggingFace (Apache-2.0,
+mirroring hexgrad/Kokoro-82M). File paths and the voice-embedding byte
+layout (510 tokens x 256 dims x 4 bytes = 522240 bytes/file) are verified
+against zirekhq/dengjen-tts's crates/dengjen/models/kokoro/src/{config,
+voice_style}.rs, which is what actually loads this config.json.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import addonHandler
+from logHandler import log
+
+addonHandler.initTranslation()
+
+from dengjen_neural_voices.const import DENGJEN_KOKORO_VOICES_DIR
+from dengjen_neural_voices.domain import voice_metadata
+
+from .voice_download import (
+    _BaseVoiceDownloader,
+    _follow_redirects,
+    _stream_to_file,
+    _VoiceInstallError,
+)
+
+KOKORO_REPO_RESOLVE_URL = (
+    "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main"
+)
+KOKORO_MODEL_FILE = (
+    "onnx/model.onnx"  # full precision -- quantized variants crash dengjen-tts-grpc.exe
+)
+KOKORO_LOCAL_MODEL_FILENAME = "model.onnx"  # KOKORO_MODEL_FILE's name once downloaded
+KOKORO_VOCAB_FILE = "tokenizer.json"
+KOKORO_VOICE_KEY = "kokoro-multilingual"
+KOKORO_SAMPLE_RATE = 24000
+
+# Verified via the HuggingFace API's model-info siblings listing (54 files
+# under voices/, one per preset). First letter = language (a=American
+# English, b=British English, e=Spanish, f=French, h=Hindi, i=Italian,
+# j=Japanese, p=Brazilian Portuguese, z=Mandarin); second = f/m for gender.
+KOKORO_PRESET_NAMES = [
+    "af_alloy",
+    "af_aoede",
+    "af_bella",
+    "af_heart",
+    "af_jessica",
+    "af_kore",
+    "af_nicole",
+    "af_nova",
+    "af_river",
+    "af_sarah",
+    "af_sky",
+    "am_adam",
+    "am_echo",
+    "am_eric",
+    "am_fenrir",
+    "am_liam",
+    "am_michael",
+    "am_onyx",
+    "am_puck",
+    "am_santa",
+    "bf_alice",
+    "bf_emma",
+    "bf_isabella",
+    "bf_lily",
+    "bm_daniel",
+    "bm_fable",
+    "bm_george",
+    "bm_lewis",
+    "ef_dora",
+    "em_alex",
+    "em_santa",
+    "ff_siwis",
+    "hf_alpha",
+    "hf_beta",
+    "hm_omega",
+    "hm_psi",
+    "if_sara",
+    "im_nicola",
+    "jf_alpha",
+    "jf_gongitsune",
+    "jf_nezumi",
+    "jf_tebukuro",
+    "jm_kumo",
+    "pf_dora",
+    "pm_alex",
+    "pm_santa",
+    "zf_xiaobei",
+    "zf_xiaoni",
+    "zf_xiaoxiao",
+    "zf_xiaoyi",
+    "zm_yunjian",
+    "zm_yunxi",
+    "zm_yunxia",
+    "zm_yunyang",
+]
+
+
+def build_kokoro_config(preset_names):
+    return {
+        "model_type": "kokoro",
+        "model_path": KOKORO_LOCAL_MODEL_FILENAME,
+        "voices_dir": "voices",
+        "vocab_path": KOKORO_VOCAB_FILE,
+        "sample_rate": KOKORO_SAMPLE_RATE,
+        "voices": list(preset_names),
+    }
+
+
+def _download_to_file(relative_path, target_path):
+    """Streams straight to disk (never holds a whole asset in memory) -- the
+    full-precision model alone is ~326MB, and 56 files held as bytes
+    simultaneously would be material memory pressure inside NVDA."""
+    url = f"{KOKORO_REPO_RESOLVE_URL}/{relative_path}"
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    with _follow_redirects(url, relative_path) as response:
+        total_size = int(response.getheader("Content-Length", 0))
+        _stream_to_file(response, target_path, total_size, lambda _percent: None)
+
+
+class KokoroVoiceDownloader(_BaseVoiceDownloader):
+    """Downloads the shared model + vocab + every preset embedding in one
+    install. `voice` is unused by the base class beyond `.key` (used in
+    progress/success/failure message formatting)."""
+
+    class _Descriptor:
+        key = KOKORO_VOICE_KEY
+
+    def __init__(self, success_callback):
+        super().__init__(self._Descriptor(), success_callback)
+
+    def _progress_title(self):
+        return _("Downloading Kokoro multilingual voice")
+
+    def _success_message(self):
+        return _(
+            "Successfully downloaded the Kokoro multilingual voice.\n"
+            "To use this voice, you need to restart NVDA.\n"
+            "Do you want to restart NVDA now?"
+        )
+
+    def _failure_message(self):
+        return _(
+            "Cannot download the Kokoro voice.\n"
+            "Please check your connection and try again."
+        )
+
+    def _download_work(self):
+        files_to_download = [
+            (KOKORO_LOCAL_MODEL_FILENAME, KOKORO_MODEL_FILE),
+            (KOKORO_VOCAB_FILE, KOKORO_VOCAB_FILE),
+            *(
+                (f"voices/{name}.bin", f"voices/{name}.bin")
+                for name in KOKORO_PRESET_NAMES
+            ),
+        ]
+        total_files = len(files_to_download)
+        temp_dir = Path(self.temp_download_dir.name)
+        result = {}
+        for files_done, (result_key, relative_path) in enumerate(
+            files_to_download, start=1
+        ):
+            self.progress_dialog.Update(
+                int((files_done - 1) / total_files * 100),
+                _("Downloading file: {file}").format(file=relative_path),
+            )
+            target_path = temp_dir / result_key
+            _download_to_file(relative_path, target_path)
+            result[result_key] = target_path
+            self.update_progress(int(files_done / total_files * 100))
+        return result
+
+    def _install(self, result):
+        install_dir = Path(DENGJEN_KOKORO_VOICES_DIR) / KOKORO_VOICE_KEY
+        try:
+            (install_dir / "voices").mkdir(parents=True, exist_ok=True)
+
+            shutil.copy(
+                result[KOKORO_LOCAL_MODEL_FILENAME],
+                install_dir / KOKORO_LOCAL_MODEL_FILENAME,
+            )
+            shutil.copy(result[KOKORO_VOCAB_FILE], install_dir / KOKORO_VOCAB_FILE)
+            for name in KOKORO_PRESET_NAMES:
+                shutil.copy(
+                    result[f"voices/{name}.bin"], install_dir / "voices" / f"{name}.bin"
+                )
+
+            # voice_metadata written before config.json: KokoroCatalog.is_installed()
+            # checks only for config.json, so it must be the last thing that lands --
+            # otherwise a metadata-write failure would leave a directory that looks
+            # installed but that voice discovery can never load.
+            voice_metadata.write(
+                install_dir,
+                voice_metadata.VoiceMetadata(
+                    model_type="kokoro",
+                    name="Kokoro Multilingual",
+                    language="en",
+                    description=(
+                        "Kokoro-82M neural voice, 54 presets across multiple "
+                        "languages -- pick one via the Speaker setting."
+                    ),
+                ),
+            )
+            (install_dir / "config.json").write_text(
+                json.dumps(build_kokoro_config(KOKORO_PRESET_NAMES)), encoding="utf-8"
+            )
+        except OSError as exc:
+            log.exception("Failed to install the Kokoro voice", exc_info=True)
+            raise _VoiceInstallError from exc
+
+
+class KokoroCatalog:
+    model_type = "kokoro"
+
+    def is_installed(self) -> bool:
+        config_path = Path(DENGJEN_KOKORO_VOICES_DIR) / KOKORO_VOICE_KEY / "config.json"
+        return config_path.exists()
+
+    def install(self, success_callback) -> None:
+        KokoroVoiceDownloader(success_callback).download()

--- a/addon/globalPlugins/dengjen_tts_global_plugin/model_catalog.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/model_catalog.py
@@ -1,0 +1,40 @@
+"""ModelCatalog: the seam a `dengjen-tts` model backend implements so the
+voice manager can check install state without hardcoding Piper's shape.
+
+Piper's own browsing/preview/download UI (OnlineDengjenVoicesPanel) predates
+this protocol and isn't rebuilt on top of it -- PiperCatalog exists to prove
+the protocol against a second, structurally different backend (Kokoro, see
+kokoro_download.py), not to replace working UI.
+"""
+
+from pathlib import Path
+from typing import Protocol
+
+from dengjen_neural_voices.const import DENGJEN_VOICES_DIR
+
+
+class ModelCatalog(Protocol):
+    model_type: str
+
+    def is_installed(self) -> bool: ...
+
+    def install(self, success_callback) -> None: ...
+
+
+class PiperCatalog:
+    model_type = "piper"
+
+    def is_installed(self) -> bool:
+        voices_dir = Path(DENGJEN_VOICES_DIR)
+        return voices_dir.is_dir() and any(voices_dir.iterdir())
+
+    def install(self, success_callback) -> None:
+        raise NotImplementedError(
+            "Piper voices are installed per-voice via OnlineDengjenVoicesPanel, "
+            "not through ModelCatalog.install()"
+        )
+
+
+from .kokoro_download import KokoroCatalog
+
+AVAILABLE_CATALOGS: tuple[ModelCatalog, ...] = (PiperCatalog(), KokoroCatalog())

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -24,6 +24,8 @@ from logHandler import log
 
 addonHandler.initTranslation()
 
+from dengjen_neural_voices.domain import voice_metadata
+
 from . import DENGJEN_VOICES_DIR, DengjenGrpcBackend, DengjenTextToSpeechSystem, helpers
 
 with helpers.import_bundled_library():
@@ -308,23 +310,25 @@ class _BaseVoiceDownloader:
         )
 
     def done_callback(self, result):
-
-        wx.CallAfter(self._on_download_complete, result)
-
-    def _on_download_complete(self, result):
+        # Runs on the worker thread (a future's add_done_callback fires on
+        # whichever thread completes it -- see download()). _install does
+        # the actual disk I/O here rather than after the wx.CallAfter below,
+        # so writing a large voice to disk doesn't block the wx event loop.
+        # progress_dialog.Update() from this thread already matches how
+        # _download_work reports download progress.
         has_error = isinstance(result, Exception)
         install_error = None
         if not has_error:
-            self.progress_dialog.Update(
-                0,
-                _("Installing voice"),
-            )
+            self.progress_dialog.Update(0, _("Installing voice"))
             try:
                 self._install(result)
             except _VoiceInstallError as exc:
                 has_error = True
                 install_error = exc
 
+        wx.CallAfter(self._on_download_complete, has_error, install_error, result)
+
+    def _on_download_complete(self, has_error, install_error, result):
         self.progress_dialog.Hide()
         self.progress_dialog.Destroy()
         del self.progress_dialog
@@ -436,6 +440,17 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
 
         voice_dir = Path(DENGJEN_VOICES_DIR).joinpath(self.voice.key)
         voice_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            voice_metadata.write(
+                voice_dir,
+                voice_metadata.VoiceMetadata(
+                    model_type="piper",
+                    name=self.voice.name,
+                    language=self.voice.language.code,
+                ),
+            )
+        except OSError:
+            log.exception("Failed to write voice.json sidecar", exc_info=True)
         copy_failed = False
         for file, src, __ in result:
             dst = os.path.join(voice_dir, file.name)
@@ -601,6 +616,19 @@ def install_voice_from_tar_archive(tar_path, voices_dir):
                 set_attrs=False,
                 filter="data",
             )
+        # Written after extraction: config_files matches any *.json in the
+        # archive, so a root-level voice.json in the archive would otherwise
+        # overwrite this canonical sidecar instead of the other way around.
+        lang, name, _quality = voice_key.split("-")
+        try:
+            voice_metadata.write(
+                Path(voice_folder_name),
+                voice_metadata.VoiceMetadata(
+                    model_type="piper", name=name.replace("+RT", ""), language=lang
+                ),
+            )
+        except OSError:
+            log.exception("Failed to write voice.json sidecar", exc_info=True)
         return voice_key
 
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -23,6 +23,7 @@ from . import (
     DengjenTextToSpeechSystem,
     aio,
     helpers,
+    model_catalog,
     voice_download,
     voice_migration,
 )
@@ -55,7 +56,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
                     _("Quality"),
                     "center",
                     30,
-                    lambda v: v.properties["quality"].title(),
+                    lambda v: v.properties.get("quality", "").title(),
                 ),
                 ColumnDefn(_("Language"), "right", 20, operator.attrgetter("language")),
             ],
@@ -97,7 +98,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
 
     def update_voices_list(self, set_focus=False, invalidate_synth_voices_cache=False):
         voices = list(
-            DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
+            DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir(
                 DengjenGrpcBackend()
             )
         )
@@ -466,6 +467,43 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         self.__already_populated.set()
 
 
+class KokoroVoicesPanel(SizedPanel):
+    def __init__(self, parent):
+        super().__init__(parent, -1)
+        self._catalog = next(
+            c for c in model_catalog.AVAILABLE_CATALOGS if c.model_type == "kokoro"
+        )
+        wx.StaticText(
+            self,
+            -1,
+            _(
+                "Kokoro is a single multilingual voice with 54 presets, "
+                "installed as one unit. After installing, choose a preset "
+                "from NVDA's Speaker setting."
+            ),
+        )
+        self.install_btn = wx.Button(self, -1, _("&Install Kokoro voice"))
+        self.status_label = wx.StaticText(self, -1, "")
+        self.Bind(wx.EVT_BUTTON, self.on_install, self.install_btn)
+
+    def populate_list(self, force_online=False):
+        installed = self._catalog.is_installed()
+        self.install_btn.Enable(not installed)
+        self.status_label.SetLabel(
+            _("Already installed") if installed else _("Not installed")
+        )
+
+    def invalidate_cache(self):
+        pass  # no fetched-list cache to clear -- is_installed() always re-checks disk
+
+    def on_install(self, event):
+        def success_callback():
+            self.Parent._invalidate_pages_voice_cache()
+            wx.CallAfter(self.populate_list)
+
+        self._catalog.install(success_callback)
+
+
 class DengjenVoiceManagerDialog(SimpleDialog):
     def __init__(self):
         super().__init__(
@@ -486,6 +524,10 @@ class DengjenVoiceManagerDialog(SimpleDialog):
             (
                 _("Download"),
                 OnlineDengjenVoicesPanel(self.notebookCtrl),
+            ),
+            (
+                _("Kokoro"),
+                KokoroVoicesPanel(self.notebookCtrl),
             ),
         ]
         for label, panel in panel_info:

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -391,3 +391,38 @@ msgstr "El complemento Voces Neuronales Sonata sigue instalado, por lo que las v
 msgid "Old add-on still installed"
 msgstr "El complemento antiguo sigue instalado"
 
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:87
+msgid "Downloading Kokoro multilingual voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:90
+msgid "Successfully downloaded the Kokoro multilingual voice.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:97
+msgid "Cannot download the Kokoro voice.\n"
+"Please check your connection and try again."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:479
+msgid "Kokoro is a single multilingual voice with 54 presets, installed as one unit. After installing, choose a preset from NVDA's Speaker setting."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:485
+msgid "&Install Kokoro voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Already installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Not installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:529
+msgid "Kokoro"
+msgstr ""

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -391,3 +391,38 @@ msgstr "L'extension Voix neuronales de Sonata est toujours installée : vos voix
 msgid "Old add-on still installed"
 msgstr "L'ancienne extension est toujours installée"
 
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:87
+msgid "Downloading Kokoro multilingual voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:90
+msgid "Successfully downloaded the Kokoro multilingual voice.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:97
+msgid "Cannot download the Kokoro voice.\n"
+"Please check your connection and try again."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:479
+msgid "Kokoro is a single multilingual voice with 54 presets, installed as one unit. After installing, choose a preset from NVDA's Speaker setting."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:485
+msgid "&Install Kokoro voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Already installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Not installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:529
+msgid "Kokoro"
+msgstr ""

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -391,3 +391,38 @@ msgstr "Pêveka Dengên Neuronî yên Sonata hê jî sazkirî ye, loma dengên k
 msgid "Old add-on still installed"
 msgstr "Pêveka kevn hê jî sazkirî ye"
 
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:87
+msgid "Downloading Kokoro multilingual voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:90
+msgid "Successfully downloaded the Kokoro multilingual voice.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:97
+msgid "Cannot download the Kokoro voice.\n"
+"Please check your connection and try again."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:479
+msgid "Kokoro is a single multilingual voice with 54 presets, installed as one unit. After installing, choose a preset from NVDA's Speaker setting."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:485
+msgid "&Install Kokoro voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Already installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Not installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:529
+msgid "Kokoro"
+msgstr ""

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -391,3 +391,38 @@ msgstr "Дополнение Нейронные голоса Sonata всё ещ�
 msgid "Old add-on still installed"
 msgstr "Старое дополнение всё ещё установлено"
 
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:87
+msgid "Downloading Kokoro multilingual voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:90
+msgid "Successfully downloaded the Kokoro multilingual voice.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:97
+msgid "Cannot download the Kokoro voice.\n"
+"Please check your connection and try again."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:479
+msgid "Kokoro is a single multilingual voice with 54 presets, installed as one unit. After installing, choose a preset from NVDA's Speaker setting."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:485
+msgid "&Install Kokoro voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Already installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Not installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:529
+msgid "Kokoro"
+msgstr ""

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -391,3 +391,38 @@ msgstr "Sonata Sinir Ağı Sesleri eklentisi hâlâ kurulu, bu yüzden indirdiğ
 msgid "Old add-on still installed"
 msgstr "Eski eklenti hâlâ kurulu"
 
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:87
+msgid "Downloading Kokoro multilingual voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:90
+msgid "Successfully downloaded the Kokoro multilingual voice.\n"
+"To use this voice, you need to restart NVDA.\n"
+"Do you want to restart NVDA now?"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\kokoro_download.py:97
+msgid "Cannot download the Kokoro voice.\n"
+"Please check your connection and try again."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:479
+msgid "Kokoro is a single multilingual voice with 54 presets, installed as one unit. After installing, choose a preset from NVDA's Speaker setting."
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:485
+msgid "&Install Kokoro voice"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Already installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:493
+msgid "Not installed"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\voice_manager.py:529
+msgid "Kokoro"
+msgstr ""

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
@@ -212,9 +212,7 @@ class SynthDriver(NvdaSynthDriver):
                 exc_info=True,
             )
             return
-        voices = DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir(
-            backend
-        )
+        voices = DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir(backend)
         if not any(voices):
             log.error(
                 "No installed voices were found for Dengjen. Synthesizer will not be available."
@@ -517,7 +515,7 @@ class SynthDriver(NvdaSynthDriver):
         rv = OrderedDict()
         if std_key in self._voice_map:
             rv["standard"] = VoiceInfo("standard", "Standard", self.language)
-        if rt_key in self._voice_map:
+        if rt_key != std_key and rt_key in self._voice_map:
             rv["fast"] = VoiceInfo("fast", "Fast", self.language)
         return rv
 
@@ -528,9 +526,13 @@ class SynthDriver(NvdaSynthDriver):
         all_voices = OrderedDict()
         for voice in self.voices:
             voice_id = self._get_variant_independent_voice_id(voice.key)
-            quality = voice.properties["quality"]
+            quality = voice.properties.get("quality")
             lang = languageHandler.normalizeLanguage(voice.language).replace("_", "-")
-            display_name = f"{voice.name} ({lang}) - {quality}"
+            display_name = (
+                f"{voice.name} ({lang}) - {quality}"
+                if quality
+                else f"{voice.name} ({lang})"
+            )
             all_voices[voice_id] = VoiceInfo(voice_id, display_name, voice.language)
         return all_voices
 

--- a/addon/synthDrivers/dengjen_neural_voices/const.py
+++ b/addon/synthDrivers/dengjen_neural_voices/const.py
@@ -6,6 +6,7 @@ __all__ = [
     "DEFAULT_PITCH",
     "DEFAULT_RATE",
     "DEFAULT_VOLUME",
+    "DENGJEN_KOKORO_VOICES_DIR",
     "DENGJEN_VOICES_BASE_DIR",
     "DENGJEN_VOICES_DIR",
     "FALLBACK_SPEAKER_NAME",
@@ -22,6 +23,7 @@ IGNORED_PUNCS = frozenset(",(){}[]`\"'")
 PIPER_VOICES_VERSION = "v1.0"
 DENGJEN_VOICES_BASE_DIR = os.path.join(globalVars.appArgs.configPath, "dengjen")
 DENGJEN_VOICES_DIR = os.path.join(DENGJEN_VOICES_BASE_DIR, "voices", "piper")
+DENGJEN_KOKORO_VOICES_DIR = os.path.join(DENGJEN_VOICES_BASE_DIR, "voices", "kokoro")
 BATCH_SIZE = max((os.cpu_count() or 2) // 2, 2)
 FALLBACK_SPEAKER_NAME = "default"
 DEFAULT_RATE = 50

--- a/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
+++ b/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
@@ -23,12 +23,17 @@ from ..const import (
     DEFAULT_PITCH,
     DEFAULT_RATE,
     DEFAULT_VOLUME,
+    DENGJEN_KOKORO_VOICES_DIR,
     DENGJEN_VOICES_DIR,
     FALLBACK_SPEAKER_NAME,
     IGNORED_PUNCS,
 )
 from ..ports.tts_backend import TTSBackend
 from ..voice_migration import migrate_voices_directory
+from .voice_metadata import VOICE_METADATA_FILENAME
+from .voice_metadata import read_or_migrate as _read_or_migrate_voice_metadata
+
+MODEL_TYPES_WITH_PROSODY_CONTROLS = frozenset({"piper", "melotts"})
 
 
 class VoiceNotFoundError(LookupError):
@@ -85,6 +90,7 @@ class DengjenVoice:
     description: str
     location: str
     backend: TTSBackend
+    model_type: str = "piper"
     properties: Mapping[str, int] | None = field(default_factory=dict)
     remote_id: str | None = None
     supports_streaming_output: bool = False
@@ -93,29 +99,38 @@ class DengjenVoice:
     def from_path(cls, path, backend):
         path = Path(path)
         key = path.name
-        try:
-            lang, name, quality = key.split("-")
-        except ValueError:
-            raise ValueError(f"Invalid voice path: {path}")
+        metadata = _read_or_migrate_voice_metadata(path)
+        properties = {}
+        if metadata.model_type == "piper":
+            try:
+                _, _, quality = key.split("-")
+                properties["quality"] = quality.lower()
+            except ValueError:
+                pass  # non-3-part key: no quality metadata, not an error
         return cls(
             key=key,
-            name=name.replace("+RT", ""),
-            language=normalizeLanguage(lang),
-            description="",
+            name=metadata.name,
+            language=normalizeLanguage(metadata.language),
+            description=metadata.description,
             location=path,
             backend=backend,
-            properties={"quality": quality.lower()},
+            model_type=metadata.model_type,
+            properties=properties,
         )
 
     def load(self):
         if self.remote_id:
             return
-        try:
-            self.config_path = next(self.location.glob("*.json"))
-        except StopIteration:
+        candidates = [
+            p for p in self.location.glob("*.json") if p.name != VOICE_METADATA_FILENAME
+        ]
+        if not candidates:
             raise RuntimeError(
                 f"Could not load voice from `{os.fspath(self.location)}`"
             )
+        self.config_path = next(
+            iter(sorted(candidates, key=lambda p: p.name != "config.json"))
+        )
         loaded = self.backend.load_voice(str(self.config_path))
         self.remote_id = loaded.backend_voice_id
         self.supports_streaming_output = loaded.supports_streaming_output
@@ -132,54 +147,61 @@ class DengjenVoice:
             loaded.defaults.speaker if self.is_multi_speaker else None
         )
 
-    def _get_synth_option(self, name):
+    def _get_prosody_option(self, name):
+        if self.model_type not in MODEL_TYPES_WITH_PROSODY_CONTROLS:
+            return None
         options = self.backend.get_synth_options(self.remote_id)
         return getattr(options, name)
 
-    def _set_synth_option(self, **kwargs):
+    def _set_prosody_option(self, **kwargs):
+        if self.model_type not in MODEL_TYPES_WITH_PROSODY_CONTROLS:
+            return
         self.backend.set_synth_options(self.remote_id, **kwargs)
 
     @property
     def speaker(self):
         if self.is_multi_speaker:
-            return self._get_synth_option("speaker")
+            options = self.backend.get_synth_options(self.remote_id)
+            return options.speaker
         return FALLBACK_SPEAKER_NAME
 
     @speaker.setter
     def speaker(self, value):
         if self.is_multi_speaker:
-            self._set_synth_option(speaker=value)
+            self.backend.set_synth_options(self.remote_id, speaker=value)
 
     @property
     def noise_scale(self):
-        return self._get_synth_option("noise_scale")
+        return self._get_prosody_option("noise_scale")
 
     @noise_scale.setter
     def noise_scale(self, value):
-        self._set_synth_option(noise_scale=value)
+        self._set_prosody_option(noise_scale=value)
 
     @property
     def length_scale(self):
-        return self._get_synth_option("length_scale")
+        return self._get_prosody_option("length_scale")
 
     @length_scale.setter
     def length_scale(self, value):
-        self._set_synth_option(length_scale=value)
+        self._set_prosody_option(length_scale=value)
 
     @property
     def noise_w(self):
-        return self._get_synth_option("noise_w")
+        return self._get_prosody_option("noise_w")
 
     @noise_w.setter
     def noise_w(self, value):
-        self._set_synth_option(noise_w=value)
+        self._set_prosody_option(noise_w=value)
 
     @property
     def is_fast(self):
-        return "+RT" in self.key
+        return self.model_type == "piper" and "+RT" in self.key
 
     @property
     def variant(self):
+        if self.model_type != "piper":
+            return "standard"
         return "fast" if self.is_fast else "standard"
 
     @property
@@ -369,7 +391,10 @@ class DengjenTextToSpeechSystem:
     @staticmethod
     def get_voice_variants(voice_key):
         std_key = voice_key.replace("+RT", "")
-        lang, name, quality = std_key.split("-")
+        try:
+            lang, name, quality = std_key.split("-")
+        except ValueError:
+            return voice_key, voice_key
         rt_key = f"{lang}-{name}+RT-{quality}"
         return std_key, rt_key
 
@@ -387,6 +412,15 @@ class DengjenTextToSpeechSystem:
             cls.load_voices_from_directory(DENGJEN_VOICES_DIR, backend),
             key=operator.attrgetter("key"),
         )
+
+    @classmethod
+    def load_all_voices_from_nvda_config_dir(cls, backend):
+        migrate_voices_directory()
+        rv = []
+        for voices_dir in (DENGJEN_VOICES_DIR, DENGJEN_KOKORO_VOICES_DIR):
+            Path(voices_dir).mkdir(parents=True, exist_ok=True)
+            rv.extend(cls.load_voices_from_directory(voices_dir, backend))
+        return sorted(rv, key=operator.attrgetter("key"))
 
     @classmethod
     def load_voices_from_directory(

--- a/addon/synthDrivers/dengjen_neural_voices/domain/voice_metadata.py
+++ b/addon/synthDrivers/dengjen_neural_voices/domain/voice_metadata.py
@@ -1,0 +1,57 @@
+"""The addon-owned voice.json sidecar.
+
+Decouples NVDA-facing voice identity (name/language/model_type) from each
+`dengjen-tts` model backend's own config format, and from Piper's
+`lang-name-quality` directory-name convention -- both of which are owned by
+the engine/catalog, not by us. Voices installed before this module existed
+have no sidecar; read_or_migrate() falls back to the legacy directory-name
+parse `DengjenVoice.from_path` used to do inline, and writes the sidecar so
+later reads skip the fallback.
+"""
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+VOICE_METADATA_FILENAME = "voice.json"
+
+
+@dataclass(frozen=True)
+class VoiceMetadata:
+    model_type: str
+    name: str
+    language: str
+    description: str = ""
+
+
+def write(voice_dir: Path, metadata: VoiceMetadata) -> None:
+    (voice_dir / VOICE_METADATA_FILENAME).write_text(
+        json.dumps(asdict(metadata)), encoding="utf-8"
+    )
+
+
+def _migrate_legacy_piper_directory_name(voice_dir: Path) -> VoiceMetadata:
+    try:
+        lang, name, _quality = voice_dir.name.split("-")
+    except ValueError:
+        raise ValueError(f"Invalid voice path: {voice_dir}")
+    return VoiceMetadata(
+        model_type="piper", name=name.replace("+RT", ""), language=lang
+    )
+
+
+def read_or_migrate(voice_dir: Path) -> VoiceMetadata:
+    sidecar_path = voice_dir / VOICE_METADATA_FILENAME
+    if sidecar_path.exists():
+        data = json.loads(sidecar_path.read_text(encoding="utf-8"))
+        try:
+            return VoiceMetadata(**data)
+        except TypeError:
+            pass  # wrong-shaped sidecar: fall through to the legacy-name migration below
+
+    metadata = _migrate_legacy_piper_directory_name(voice_dir)
+    try:
+        write(voice_dir, metadata)
+    except OSError:
+        pass
+    return metadata

--- a/docs/modules/ROOT/pages/architecture.adoc
+++ b/docs/modules/ROOT/pages/architecture.adoc
@@ -51,6 +51,22 @@ C4Component
     Rel(grpcadapter, port, "Implements")
 ----
 
+== Adding a model backend
+
+`dengjen-tts` (the vendored gRPC engine) can support more model types than
+Piper -- it already ships Kokoro and MeloTTS. Wiring a new one into this
+add-on needs:
+
+1. A `ModelCatalog` implementation (`addon/globalPlugins/dengjen_tts_global_plugin/model_catalog.py`'s `Protocol`) with `model_type`, `is_installed()`, and `install()`, following `kokoro_download.py`'s `KokoroCatalog` as a template.
+2. That catalog's installer writes two files per voice directory: the model backend's own `config.json` (whatever shape `dengjen-tts`'s loader for that `model_type` expects -- check `crates/dengjen/models/<type>/src/config.rs` in `zirekhq/dengjen-tts`), and a `voice.json` sidecar via `domain/voice_metadata.write()` carrying `{model_type, name, language, description}` -- the only fields `DengjenVoice.from_path()` reads.
+3. If the new model type has per-utterance parameters the existing gRPC `ProsodyControls` message doesn't carry, that needs a change in `zirekhq/dengjen-tts` first (a different repo) -- not an addon-side concern.
+4. If the new model type's prosody parameters *do* map onto the existing `noise_scale`/`length_scale`/`noise_w` fields (as MeloTTS's `inference` block does), add its `model_type` string to `domain/tts_system.py`'s `MODEL_TYPES_WITH_PROSODY_CONTROLS`.
+5. Add a `DENGJEN_<TYPE>_VOICES_DIR` constant to `const.py` and register it in `DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir()` (`domain/tts_system.py`) -- that method iterates a fixed tuple of directories, not a dynamic scan of `voices/*`, so a new backend's directory has to be added there explicitly or its installed voices are invisible to NVDA.
+
+No install directory is shared between model types: each gets its own
+`DENGJEN_VOICES_BASE_DIR/voices/<model_type>/` (see `const.py`), scanned
+only once its constant is registered per step 5 above.
+
 == Code
 
 `TTSBackend` is a `Protocol`, not a base class -- the `sonata_grpc` adapter

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,16 @@ With `Dengjen Neural Voices` selected as your synthesizer, the following appear 
 
 Above 50, the sliders scale up to twice the voice's default for `Length scale` and three times the default for `Noise scale` and `Noise w`. Because 50 always means "this voice's default", a given slider position keeps its meaning when you switch to a different voice.
 
+### Kokoro voices
+
+In addition to Piper voices, this add-on supports Kokoro, a multilingual
+neural voice with 54 built-in presets across English, French, Spanish,
+Hindi, Italian, Japanese, Portuguese, and Mandarin. Install it from the
+Dengjen voice manager's "Kokoro" tab (a single ~340MB download, unlike
+Piper's per-voice downloads); once installed, it appears in NVDA's Voice
+list like any other voice, and its 54 presets are selectable via NVDA's
+"Speaker" setting.
+
 # A note on voice quality
 
 The currently available voices are trained using freely available TTS datasets, which are generally of low quality (mostly public domain audio books or research quality recordings).

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -388,6 +388,17 @@ def install(*, stub_wx: bool = True) -> None:
         package="dengjen_neural_voices.domain",
     )
 
+    # Manual sys.modules registration above bypasses the import system's own
+    # step of setting `tts_system` as an attribute of `domain`, which a
+    # string-path monkeypatch.setattr("...domain.tts_system.X", ...) needs.
+    _domain_pkg = sys.modules.setdefault(
+        "dengjen_neural_voices.domain", types.ModuleType("dengjen_neural_voices.domain")
+    )
+    _domain_pkg.__path__ = [os.path.join(_SYNTH_PKG_DIR, "domain")]
+    _domain_pkg.__package__ = "dengjen_neural_voices.domain"
+    _domain_pkg.tts_system = sys.modules["dengjen_neural_voices.domain.tts_system"]
+    _pkg.domain = _domain_pkg
+
     _pkg.DengjenTextToSpeechSystem = sys.modules[
         "dengjen_neural_voices.domain.tts_system"
     ].DengjenTextToSpeechSystem

--- a/tests/test_kokoro_download.py
+++ b/tests/test_kokoro_download.py
@@ -1,0 +1,133 @@
+"""
+Tests for kokoro_download.py: generates the exact config.json dengjen-tts's
+kokoro::config::load_config expects, and drives the download/install via the
+existing _BaseVoiceDownloader machinery. Network is never exercised here --
+_do_download_file/_stream_to_file are exercised by voice_download.py's own
+tests already; these tests cover kokoro_download.py's own logic only.
+"""
+
+import json
+import os
+
+import pytest
+
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
+
+kokoro_download = load_module_from_path(
+    "dengjen_tts_global_plugin._kokoro_download_under_test",
+    os.path.join(GLOBAL_PLUGIN_PKG_DIR, "kokoro_download.py"),
+    package="dengjen_tts_global_plugin",
+)
+
+build_kokoro_config = kokoro_download.build_kokoro_config
+KOKORO_PRESET_NAMES = kokoro_download.KOKORO_PRESET_NAMES
+KokoroVoiceDownloader = kokoro_download.KokoroVoiceDownloader
+KokoroCatalog = kokoro_download.KokoroCatalog
+
+
+class TestBuildKokoroConfig:
+    def test_matches_the_engine_schema_exactly(self):
+        config = build_kokoro_config(["af_heart", "am_adam"])
+
+        assert config == {
+            "model_type": "kokoro",
+            "model_path": "model.onnx",
+            "voices_dir": "voices",
+            "vocab_path": "tokenizer.json",
+            "sample_rate": 24000,
+            "voices": ["af_heart", "am_adam"],
+        }
+
+    def test_preset_list_has_fifty_four_unique_names(self):
+        assert len(KOKORO_PRESET_NAMES) == 54
+        assert len(set(KOKORO_PRESET_NAMES)) == 54
+        assert "af_heart" in KOKORO_PRESET_NAMES
+        assert "zm_yunyang" in KOKORO_PRESET_NAMES
+
+
+class TestKokoroVoiceDownloaderInstall:
+    def _write_temp(self, tmp_path, name, data):
+        path = tmp_path / "downloaded" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+        return path
+
+    def test_install_writes_config_and_sidecar_and_all_downloaded_files(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(kokoro_download, "DENGJEN_KOKORO_VOICES_DIR", str(tmp_path))
+        downloader = KokoroVoiceDownloader(success_callback=lambda: None)
+        model_bytes = b"\x00" * 16
+        vocab_bytes = b'{"model": {"vocab": {"$": 0}}}'
+        voice_bytes = {
+            name: bytes([i % 256]) * 4 for i, name in enumerate(KOKORO_PRESET_NAMES)
+        }
+        # _install now takes file paths (streamed to disk by _download_work),
+        # not in-memory bytes -- write the fake downloads to a temp dir first.
+        result = {
+            "model.onnx": self._write_temp(tmp_path, "model.onnx", model_bytes),
+            "tokenizer.json": self._write_temp(tmp_path, "tokenizer.json", vocab_bytes),
+            **{
+                f"voices/{name}.bin": self._write_temp(
+                    tmp_path, f"voices/{name}.bin", data
+                )
+                for name, data in voice_bytes.items()
+            },
+        }
+
+        downloader._install(result)
+
+        install_dir = tmp_path / "kokoro-multilingual"
+        assert (install_dir / "model.onnx").read_bytes() == model_bytes
+        assert (install_dir / "tokenizer.json").read_bytes() == vocab_bytes
+        for name, data in voice_bytes.items():
+            assert (install_dir / "voices" / f"{name}.bin").read_bytes() == data
+        config = json.loads((install_dir / "config.json").read_text())
+        assert config["voices"] == KOKORO_PRESET_NAMES
+        sidecar = json.loads((install_dir / "voice.json").read_text())
+        assert sidecar["model_type"] == "kokoro"
+
+    def test_config_json_is_written_last_so_a_metadata_failure_leaves_nothing_installed(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(kokoro_download, "DENGJEN_KOKORO_VOICES_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            kokoro_download.voice_metadata,
+            "write",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+        )
+        downloader = KokoroVoiceDownloader(success_callback=lambda: None)
+        result = {
+            "model.onnx": self._write_temp(tmp_path, "model.onnx", b"\x00"),
+            "tokenizer.json": self._write_temp(tmp_path, "tokenizer.json", b"{}"),
+            **{
+                f"voices/{name}.bin": self._write_temp(
+                    tmp_path, f"voices/{name}.bin", b""
+                )
+                for name in KOKORO_PRESET_NAMES
+            },
+        }
+
+        with pytest.raises(kokoro_download._VoiceInstallError):
+            downloader._install(result)
+
+        install_dir = tmp_path / "kokoro-multilingual"
+        assert not (install_dir / "config.json").exists()
+
+
+class TestKokoroCatalog:
+    def test_model_type_is_kokoro(self):
+        assert KokoroCatalog().model_type == "kokoro"
+
+    def test_is_installed_false_when_directory_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            kokoro_download, "DENGJEN_KOKORO_VOICES_DIR", str(tmp_path / "absent")
+        )
+        assert KokoroCatalog().is_installed() is False
+
+    def test_is_installed_true_once_config_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(kokoro_download, "DENGJEN_KOKORO_VOICES_DIR", str(tmp_path))
+        install_dir = tmp_path / "kokoro-multilingual"
+        install_dir.mkdir()
+        (install_dir / "config.json").write_text("{}")
+        assert KokoroCatalog().is_installed() is True

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,35 @@
+"""
+Tests for model_catalog.py: the ModelCatalog protocol two model backends
+(Piper, Kokoro) implement so voice_manager.py can check install state
+generically instead of hardcoding Piper's shape.
+"""
+
+import os
+
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
+
+model_catalog = load_module_from_path(
+    "dengjen_tts_global_plugin._model_catalog_under_test",
+    os.path.join(GLOBAL_PLUGIN_PKG_DIR, "model_catalog.py"),
+    package="dengjen_tts_global_plugin",
+)
+
+PiperCatalog = model_catalog.PiperCatalog
+
+
+class TestPiperCatalog:
+    def test_model_type_is_piper(self):
+        assert PiperCatalog().model_type == "piper"
+
+    def test_is_installed_true_when_a_piper_voice_directory_exists(
+        self, tmp_path, monkeypatch
+    ):
+        (tmp_path / "en-john-medium").mkdir()
+        monkeypatch.setattr(model_catalog, "DENGJEN_VOICES_DIR", str(tmp_path))
+
+        assert PiperCatalog().is_installed() is True
+
+    def test_is_installed_false_for_empty_directory(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(model_catalog, "DENGJEN_VOICES_DIR", str(tmp_path))
+
+        assert PiperCatalog().is_installed() is False

--- a/tests/test_synth_driver.py
+++ b/tests/test_synth_driver.py
@@ -139,9 +139,9 @@ class TestConstruction:
     def test_loads_voices_from_disk_only_once(
         self, configured_voice, fake_backend, monkeypatch
     ):
-        """A previous version called load_piper_voices_from_nvda_config_dir()
+        """A previous version called load_all_voices_from_nvda_config_dir()
         twice back to back in __init__ for no reason."""
-        real_load = driver_module.DengjenTextToSpeechSystem.load_piper_voices_from_nvda_config_dir.__func__
+        real_load = driver_module.DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir.__func__
         calls = []
 
         def counting_load(cls, backend):
@@ -150,7 +150,7 @@ class TestConstruction:
 
         monkeypatch.setattr(
             driver_module.DengjenTextToSpeechSystem,
-            "load_piper_voices_from_nvda_config_dir",
+            "load_all_voices_from_nvda_config_dir",
             classmethod(counting_load),
         )
         d = SynthDriver()
@@ -568,3 +568,31 @@ class TestSetVoiceSuccess:
 
         assert driver._SynthDriver__voice == "alex"
         assert driver.tts.voice == "en_US-alex-medium"
+
+
+@pytest.fixture
+def kokoro_voice_dir(tmp_path, monkeypatch):
+    """A second, Kokoro-shaped voice directory alongside the Piper one."""
+    kokoro_dir = tmp_path / "kokoro"
+    monkeypatch.setattr(tts_system, "DENGJEN_KOKORO_VOICES_DIR", str(kokoro_dir))
+    voice_dir = kokoro_dir / "kokoro-multilingual"
+    voice_dir.mkdir(parents=True)
+    (voice_dir / "config.json").write_text("{}", encoding="utf-8")
+    (voice_dir / "voice.json").write_text(
+        '{"model_type": "kokoro", "name": "Kokoro", "language": "en"}',
+        encoding="utf-8",
+    )
+    return kokoro_dir
+
+
+class TestConstructionWithAKokoroVoicePresent:
+    def test_does_not_crash_building_the_voice_list(
+        self, configured_voice, kokoro_voice_dir, fake_backend
+    ):
+        d = SynthDriver()
+        try:
+            assert sorted(d.availableVoices) == sorted(
+                [VOICE_KEY, "kokoro-multilingual"]
+            )
+        finally:
+            d.terminate()

--- a/tests/test_tts_system.py
+++ b/tests/test_tts_system.py
@@ -146,6 +146,113 @@ class TestDengjenVoiceFromPath:
     def test_fast_variant_key(self, single_voice):
         assert single_voice.fast_variant_key == "en-test+RT-medium"
 
+    def test_parses_standard_key_sets_piper_model_type(self, backend):
+        v = DengjenVoice.from_path("/tmp/en-john-medium", backend)
+        assert v.model_type == "piper"
+
+    def test_from_path_reads_sidecar_for_non_piper_directory_name(
+        self, backend, tmp_path
+    ):
+        voice_dir = tmp_path / "kokoro-multilingual"
+        voice_dir.mkdir()
+        (voice_dir / "voice.json").write_text(
+            '{"model_type": "kokoro", "name": "Kokoro Multilingual", '
+            '"language": "en", "description": "54 presets"}',
+            encoding="utf-8",
+        )
+
+        v = DengjenVoice.from_path(voice_dir, backend)
+
+        assert v.model_type == "kokoro"
+        assert v.name == "Kokoro Multilingual"
+        assert v.language == "en"
+
+
+class TestDengjenVoiceLoadIgnoresTheSidecar:
+    def test_picks_the_engine_config_even_when_the_sidecar_sorts_first(
+        self, backend, tmp_path
+    ):
+        voice_dir = tmp_path / "en-john-medium"
+        voice_dir.mkdir()
+        # Write the sidecar FIRST, matching the real install order (both
+        # PiperVoiceDownloader._install and install_voice_from_tar_archive
+        # write voice.json before the payload) -- this is also the FAT/
+        # exFAT filesystem-ordering failure mode this test guards against.
+        (voice_dir / "voice.json").write_text(
+            '{"model_type": "piper", "name": "john", "language": "en"}',
+            encoding="utf-8",
+        )
+        (voice_dir / "en-john-medium.onnx.json").write_text(
+            '{"some": "engine config"}', encoding="utf-8"
+        )
+
+        v = DengjenVoice.from_path(voice_dir, backend)
+        v.load()
+
+        assert v.config_path.name == "en-john-medium.onnx.json"
+
+
+class TestDengjenVoiceFastVariantGating:
+    def test_piper_voice_reports_is_fast_from_key(self, backend):
+        v = DengjenVoice.from_path("/tmp/en-john+RT-medium", backend)
+        assert v.is_fast is True
+
+    def test_non_piper_voice_is_never_fast(self, backend, tmp_path):
+        voice_dir = tmp_path / "kokoro-multilingual"
+        voice_dir.mkdir()
+        (voice_dir / "voice.json").write_text(
+            '{"model_type": "kokoro", "name": "Kokoro", "language": "en"}',
+            encoding="utf-8",
+        )
+        v = DengjenVoice.from_path(voice_dir, backend)
+        assert v.is_fast is False
+
+
+class TestDengjenVoiceProsodyControlGating:
+    def test_piper_voice_reads_noise_scale_from_backend(self, backend):
+        v = _make_voice(backend)
+        assert v.noise_scale == pytest.approx(0.667)
+
+    def test_kokoro_voice_noise_scale_is_a_harmless_no_op(self, backend, tmp_path):
+        voice_dir = tmp_path / "kokoro-multilingual"
+        voice_dir.mkdir()
+        (voice_dir / "voice.json").write_text(
+            '{"model_type": "kokoro", "name": "Kokoro", "language": "en"}',
+            encoding="utf-8",
+        )
+        v = DengjenVoice.from_path(voice_dir, backend)
+        v.remote_id = "fake-remote-id"
+
+        assert v.noise_scale is None
+        assert backend.get_synth_options_calls == []
+
+        v.noise_scale = 0.9  # must not raise, must not reach the backend
+
+        assert backend.set_synth_options_calls == []
+
+
+class TestSpeakerBypassesTheProsodyControlGate:
+    def test_speaker_reaches_the_backend_for_a_non_prosody_model_type(self, backend):
+        v = _make_voice(
+            backend,
+            key="kokoro-multilingual",
+            name="Kokoro",
+            is_multi_speaker=True,
+            speakers={"0": "af_heart", "1": "am_adam"},
+        )
+        v.model_type = "kokoro"
+
+        assert v.speaker == "default"
+        assert backend.get_synth_options_calls == [v.remote_id]
+
+        v.speaker = "af_heart"
+
+        assert backend.set_synth_options_calls == [
+            (v.remote_id, {"speaker": "af_heart"})
+        ]
+        # noise_scale must still be gated off for this model_type
+        assert v.noise_scale is None
+
 
 class TestSilenceProvider:
     def test_generates_correct_byte_length(self):
@@ -306,6 +413,12 @@ class TestGetVoiceVariants:
         assert rt == "en-john+RT-medium"
 
 
+class TestGetVoiceVariantsOnNonPiperKeys:
+    def test_returns_the_key_unchanged_for_a_non_three_part_key(self):
+        result = DengjenTextToSpeechSystem.get_voice_variants("kokoro-multilingual")
+        assert result == ("kokoro-multilingual", "kokoro-multilingual")
+
+
 class TestSpeakerSingleVoice:
     def test_speaker_returns_fallback_for_single_speaker(self, tts):
         assert tts.speaker == FALLBACK_SPEAKER_NAME
@@ -364,3 +477,36 @@ class TestConstants:
     def test_fallback_speaker_name_is_string(self):
         assert isinstance(FALLBACK_SPEAKER_NAME, str)
         assert FALLBACK_SPEAKER_NAME
+
+
+class TestLoadAllVoicesFromNvdaConfigDir:
+    def test_merges_piper_and_kokoro_directories(self, backend, tmp_path, monkeypatch):
+        piper_dir = tmp_path / "piper"
+        kokoro_dir = tmp_path / "kokoro"
+        piper_dir.mkdir()
+        kokoro_dir.mkdir()
+        (piper_dir / "en-john-medium").mkdir()
+        (kokoro_dir / "kokoro-multilingual").mkdir()
+        (kokoro_dir / "kokoro-multilingual" / "voice.json").write_text(
+            '{"model_type": "kokoro", "name": "Kokoro", "language": "en"}',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "dengjen_neural_voices.domain.tts_system.DENGJEN_VOICES_DIR",
+            str(piper_dir),
+        )
+        monkeypatch.setattr(
+            "dengjen_neural_voices.domain.tts_system.DENGJEN_KOKORO_VOICES_DIR",
+            str(kokoro_dir),
+        )
+        monkeypatch.setattr(
+            "dengjen_neural_voices.domain.tts_system.migrate_voices_directory",
+            lambda: None,
+        )
+
+        voices = DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir(backend)
+
+        assert sorted(v.key for v in voices) == [
+            "en-john-medium",
+            "kokoro-multilingual",
+        ]

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -1092,3 +1092,45 @@ class TestDownloadWiresProgressDialogToInstall:
         assert std_message != rt_message
         assert "fast variant" not in std_message
         assert "fast variant" in rt_message
+
+
+class TestVoiceJsonSidecarWrittenOnInstall:
+    def test_install_writes_voice_json_sidecar(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(tmp_path))
+        language = PiperVoiceLanguage(
+            code="en_US",
+            family="English",
+            region="US",
+            name_native="English",
+            name_english="English",
+            country_english="United States",
+        )
+        voice = PiperVoice(
+            key="en_US-libritts-high",
+            name="libritts",
+            quality=PiperVoiceQualityLevel.High,
+            num_speakers=1,
+            speaker_id_map={},
+            language=language,
+            files=[
+                PiperVoiceFile(
+                    file_path="en/en_US/libritts/high/en_US-libritts-high.onnx",
+                    size_in_bytes=4,
+                    md5hash="37b59afd592725f9305e484a5d7f5168",
+                )
+            ],
+        )
+        downloader = PiperVoiceDownloader(voice, success_callback=lambda: None)
+        onnx_file = voice.files[0]
+        src = os.path.join(downloader.temp_download_dir.name, onnx_file.name)
+        with open(src, "wb") as f:
+            f.write(b"\x00\x01\x02\x03")
+
+        downloader._install(
+            [(onnx_file, src, hashlib.md5(b"\x00\x01\x02\x03").hexdigest())]
+        )
+
+        sidecar = tmp_path / "en_US-libritts-high" / "voice.json"
+        assert sidecar.exists()
+        data = json.loads(sidecar.read_text())
+        assert data["model_type"] == "piper"

--- a/tests/test_voice_metadata.py
+++ b/tests/test_voice_metadata.py
@@ -1,0 +1,108 @@
+"""
+Tests for domain/voice_metadata.py: the addon-owned voice.json sidecar that
+decouples NVDA-facing voice identity from each engine backend's own config
+format and from Piper's `lang-name-quality` directory-name convention.
+"""
+
+import json
+
+import pytest
+from dengjen_neural_voices.domain.voice_metadata import (
+    VOICE_METADATA_FILENAME,
+    VoiceMetadata,
+    read_or_migrate,
+    write,
+)
+
+
+class TestReadOrMigrate:
+    def test_reads_existing_sidecar(self, tmp_path):
+        voice_dir = tmp_path / "kokoro-multilingual"
+        voice_dir.mkdir()
+        (voice_dir / VOICE_METADATA_FILENAME).write_text(
+            json.dumps(
+                {
+                    "model_type": "kokoro",
+                    "name": "Kokoro Multilingual",
+                    "language": "en",
+                    "description": "54 presets across multiple languages",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        metadata = read_or_migrate(voice_dir)
+
+        assert metadata == VoiceMetadata(
+            model_type="kokoro",
+            name="Kokoro Multilingual",
+            language="en",
+            description="54 presets across multiple languages",
+        )
+
+    def test_migrates_legacy_piper_directory_name(self, tmp_path):
+        voice_dir = tmp_path / "en_US-libritts-high"
+        voice_dir.mkdir()
+
+        metadata = read_or_migrate(voice_dir)
+
+        assert metadata == VoiceMetadata(
+            model_type="piper", name="libritts", language="en_US", description=""
+        )
+
+    def test_migration_self_heals_by_writing_the_sidecar(self, tmp_path):
+        voice_dir = tmp_path / "en_US-libritts-high"
+        voice_dir.mkdir()
+
+        read_or_migrate(voice_dir)
+
+        sidecar = json.loads((voice_dir / VOICE_METADATA_FILENAME).read_text())
+        assert sidecar["model_type"] == "piper"
+        assert sidecar["name"] == "libritts"
+
+    def test_migration_self_heal_failure_does_not_raise(self, tmp_path, monkeypatch):
+        voice_dir = tmp_path / "en_US-libritts-high"
+        voice_dir.mkdir()
+
+        def _raise(*_args, **_kwargs):
+            raise OSError("read-only filesystem")
+
+        monkeypatch.setattr("dengjen_neural_voices.domain.voice_metadata.write", _raise)
+
+        metadata = read_or_migrate(voice_dir)
+
+        assert metadata.name == "libritts"
+
+    def test_falls_back_to_legacy_parse_on_wrong_shaped_sidecar(self, tmp_path):
+        voice_dir = tmp_path / "en_US-libritts-high"
+        voice_dir.mkdir()
+        (voice_dir / VOICE_METADATA_FILENAME).write_text(
+            json.dumps({"model_type": "piper", "unexpected_extra_key": "oops"}),
+            encoding="utf-8",
+        )
+
+        metadata = read_or_migrate(voice_dir)
+
+        assert metadata == VoiceMetadata(
+            model_type="piper", name="libritts", language="en_US", description=""
+        )
+
+    def test_raises_on_directory_name_that_matches_neither_shape(self, tmp_path):
+        voice_dir = tmp_path / "not-a-valid-voice-dir-name-at-all-here"
+        voice_dir.mkdir()
+
+        with pytest.raises(ValueError):
+            read_or_migrate(voice_dir)
+
+
+class TestWrite:
+    def test_write_then_read_round_trips(self, tmp_path):
+        voice_dir = tmp_path / "kokoro-multilingual"
+        voice_dir.mkdir()
+        metadata = VoiceMetadata(
+            model_type="kokoro", name="Kokoro Multilingual", language="en"
+        )
+
+        write(voice_dir, metadata)
+
+        assert read_or_migrate(voice_dir) == metadata

--- a/tests_contract/test_kokoro_voice_contract.py
+++ b/tests_contract/test_kokoro_voice_contract.py
@@ -1,0 +1,182 @@
+"""
+Contract test proving the real, vendored dengjen-tts-grpc.exe loads a
+Kokoro voice config and synthesizes through it end-to-end.
+
+Downloads only 2 of the 54 presets (not all 54) to keep CI light -- the
+engine's config schema doesn't care how many are listed. _build_kokoro_config
+below duplicates kokoro_download.build_kokoro_config's exact shape rather
+than importing it -- see the module-level note in the plan/PR for why.
+
+Gives a coarse smoke-level timing bound, not a tuned regression ceiling
+(unlike test_synthesis_latency_contract.py's Piper numbers) -- issue #31's
+precise real-hardware latency question still needs a manual Windows run.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import time
+import types
+import urllib.request
+
+import espeakng_loader
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("dengjen-tts-grpc.exe is a Windows binary", allow_module_level=True)
+
+
+_APP_DIR = tempfile.mkdtemp()
+_SYNTH_DRIVERS_DIR = os.path.join(_APP_DIR, "synthDrivers")
+shutil.copytree(
+    espeakng_loader.get_data_path(), os.path.join(_SYNTH_DRIVERS_DIR, "espeak-ng-data")
+)
+
+sys.modules.setdefault(
+    "globalVars",
+    types.SimpleNamespace(
+        appArgs=types.SimpleNamespace(configPath=tempfile.mkdtemp()), appDir=_APP_DIR
+    ),
+)
+sys.modules.setdefault(
+    "logHandler",
+    types.SimpleNamespace(
+        log=types.SimpleNamespace(
+            info=lambda *a, **k: None,
+            error=lambda *a, **k: None,
+            debug=lambda *a, **k: None,
+            exception=lambda *a, **k: None,
+        )
+    ),
+)
+sys.modules.setdefault("wx", types.SimpleNamespace(GetTopLevelWindows=list))
+sys.modules.setdefault(
+    "gui", types.SimpleNamespace(messageBox=lambda *a, **k: None, mainFrame=None)
+)
+sys.modules.setdefault(
+    "gui.settingsDialogs",
+    types.SimpleNamespace(
+        NVDASettingsDialog=type("NVDASettingsDialog", (), {}),
+        SpeechSettingsPanel=type("SpeechSettingsPanel", (), {}),
+    ),
+)
+
+from tests_contract.conftest import REPO_ROOT
+
+_SYNTH_PKG_DIR = os.path.join(
+    REPO_ROOT, "addon", "synthDrivers", "dengjen_neural_voices"
+)
+_dengjen_pkg = types.ModuleType("dengjen_neural_voices")
+_dengjen_pkg.__path__ = [_SYNTH_PKG_DIR]
+sys.modules.setdefault("dengjen_neural_voices", _dengjen_pkg)
+
+from dengjen_neural_voices import aio
+from dengjen_neural_voices.adapters.dengjen_grpc import DengjenGrpcBackend
+
+KOKORO_REPO_RESOLVE_URL = (
+    "https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/resolve/main"
+)
+PRESETS_UNDER_TEST = ["af_heart", "am_adam"]
+DOWNLOAD_TIMEOUT = 60
+CALL_TIMEOUT = 30
+SMOKE_CEILING_MS = 2000  # coarse -- see module docstring
+
+
+def _build_kokoro_config(preset_names):
+    """Duplicates kokoro_download.build_kokoro_config's exact shape -- see
+    the module docstring for why this isn't imported instead."""
+    return {
+        "model_type": "kokoro",
+        "model_path": "model.onnx",
+        "voices_dir": "voices",
+        "vocab_path": "tokenizer.json",
+        "sample_rate": 24000,
+        "voices": list(preset_names),
+    }
+
+
+def _download(relative_path, target_path):
+    url = f"{KOKORO_REPO_RESOLVE_URL}/{relative_path}"
+    with (
+        urllib.request.urlopen(url, timeout=DOWNLOAD_TIMEOUT) as response,
+        open(target_path, "wb") as f,
+    ):
+        f.write(response.read())
+
+
+@pytest.fixture(scope="session")
+def kokoro_config_path(tmp_path_factory):
+    install_dir = tmp_path_factory.mktemp("kokoro")
+    (install_dir / "voices").mkdir()
+    _download("onnx/model.onnx", install_dir / "model.onnx")
+    _download("tokenizer.json", install_dir / "tokenizer.json")
+    for name in PRESETS_UNDER_TEST:
+        _download(f"voices/{name}.bin", install_dir / "voices" / f"{name}.bin")
+    config_path = install_dir / "config.json"
+    config_path.write_text(
+        json.dumps(_build_kokoro_config(PRESETS_UNDER_TEST)), encoding="utf-8"
+    )
+    return str(config_path)
+
+
+@pytest.fixture(scope="session")
+def backend():
+    b = DengjenGrpcBackend()
+    b.initialize()
+    yield b
+    b.shutdown()
+
+
+@pytest.fixture(scope="session")
+def loaded_voice(backend, kokoro_config_path):
+    voice = backend.load_voice(kokoro_config_path)
+
+    @aio.asyncio_coroutine_to_concurrent_future
+    async def _warm_up():
+        async for _chunk in backend.synthesize(
+            voice.backend_voice_id,
+            "Hello.",
+            None,
+            None,
+            None,
+            None,
+            voice.supports_streaming_output,
+        ):
+            pass
+
+    _warm_up().result(timeout=CALL_TIMEOUT)
+    return voice
+
+
+class TestKokoroVoiceContract:
+    def test_reports_both_requested_presets_as_speakers(self, loaded_voice):
+        assert set(loaded_voice.speakers.values()) == set(PRESETS_UNDER_TEST)
+        assert 0 in loaded_voice.speakers
+
+    def test_synthesizes_non_empty_audio_within_smoke_ceiling(
+        self, backend, loaded_voice
+    ):
+        @aio.asyncio_coroutine_to_concurrent_future
+        async def _time_to_first_chunk():
+            start = time.perf_counter()
+            async for chunk in backend.synthesize(
+                loaded_voice.backend_voice_id,
+                "Hello, this is a test.",
+                None,
+                None,
+                None,
+                None,
+                loaded_voice.supports_streaming_output,
+            ):
+                assert chunk, "expected a non-empty audio chunk"
+                return time.perf_counter() - start
+            raise AssertionError("expected at least one audio chunk")
+
+        elapsed = _time_to_first_chunk().result(timeout=CALL_TIMEOUT)
+        assert (elapsed * 1000) < SMOKE_CEILING_MS, (
+            f"first-chunk latency {elapsed * 1000:.1f}ms exceeds the "
+            f"{SMOKE_CEILING_MS}ms smoke ceiling -- this is not issue #31's "
+            "precise latency number, just a build-didn't-regress-wildly check"
+        )

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -28,7 +28,7 @@ def plugin_module(gui_plugin_package):
 def no_installed_voices(plugin_module, monkeypatch):
     monkeypatch.setattr(
         plugin_module.DengjenTextToSpeechSystem,
-        "load_piper_voices_from_nvda_config_dir",
+        "load_all_voices_from_nvda_config_dir",
         classmethod(lambda cls, backend: iter([])),
     )
 
@@ -37,7 +37,7 @@ def no_installed_voices(plugin_module, monkeypatch):
 def one_installed_voice(plugin_module, monkeypatch):
     monkeypatch.setattr(
         plugin_module.DengjenTextToSpeechSystem,
-        "load_piper_voices_from_nvda_config_dir",
+        "load_all_voices_from_nvda_config_dir",
         classmethod(lambda cls, backend: iter([MagicMock()])),
     )
 

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -44,11 +44,11 @@ def voice_manager(gui_plugin_package):
 
 @pytest.fixture
 def no_installed_voices(voice_manager, monkeypatch):
-    """load_piper_voices_from_nvda_config_dir touches the NVDA config dir;
+    """load_all_voices_from_nvda_config_dir touches the NVDA config dir;
     pin it to empty so construction never depends on the host machine."""
     monkeypatch.setattr(
         voice_manager.DengjenTextToSpeechSystem,
-        "load_piper_voices_from_nvda_config_dir",
+        "load_all_voices_from_nvda_config_dir",
         classmethod(lambda cls, backend: iter([])),
     )
 
@@ -89,15 +89,15 @@ class TestDialogConstruction:
     def test_dialog_builds(self, dialog):
         assert isinstance(dialog, wx.Dialog)
 
-    def test_it_has_two_notebook_pages(self, dialog):
-        assert dialog.notebookCtrl.GetPageCount() == 2
+    def test_it_has_three_notebook_pages(self, dialog):
+        assert dialog.notebookCtrl.GetPageCount() == 3
 
-    def test_pages_are_labelled_installed_and_download(self, dialog):
+    def test_pages_are_labelled_installed_download_and_kokoro(self, dialog):
         labels = [
             dialog.notebookCtrl.GetPageText(i)
             for i in range(dialog.notebookCtrl.GetPageCount())
         ]
-        assert labels == ["Installed", "Download"]
+        assert labels == ["Installed", "Download", "Kokoro"]
 
     def test_it_has_a_close_button(self, dialog):
         assert dialog.FindWindowById(wx.ID_CANCEL) is not None
@@ -337,8 +337,19 @@ class TestKeyboardAccess:
 
     @pytest.mark.parametrize("page", [0, 1])
     def test_access_keys_do_not_collide_on_a_page(self, dialog, page):
-
-        hidden = _access_keys(dialog.notebookCtrl.GetPage(1 - page))
+        # _access_keys(dialog) recurses the whole tree regardless of which
+        # notebook page is selected, so every *other* page's keys have to be
+        # subtracted -- not just "the one other page" (1 - page), now that a
+        # third (Kokoro) page exists. Kokoro itself isn't parametrized here:
+        # its single button plus the dialog's Close button can't reach this
+        # test's >= 3 minimum, which was calibrated for the two
+        # button-heavy Piper panels.
+        other_pages = (
+            dialog.notebookCtrl.GetPage(i)
+            for i in range(dialog.notebookCtrl.GetPageCount())
+            if i != page
+        )
+        hidden = [key for other in other_pages for key in _access_keys(other)]
         visible = _access_keys(dialog)
         for key in hidden:
             visible.remove(key)


### PR DESCRIPTION
Closes #31.

## Summary

Adds Kokoro-82M as a second voice backend alongside Piper, and generalizes the addon's voice/config abstraction so a future third `dengjen-tts` model backend is a bounded addition rather than a rewrite. The vendored gRPC engine already supported Kokoro before this change; this PR is entirely addon-side.

## Changes

- `domain/voice_metadata.py` (new): an addon-owned `voice.json` sidecar decoupling NVDA-facing voice identity (name/language/model_type) from Piper's `lang-name-quality` directory-name convention and from each engine backend's own config format. Migrate-on-read for existing installs, no forced action.
- `domain/tts_system.py`: `DengjenVoice` gains a `model_type` field; identity comes from the sidecar; Piper-only fast-variant machinery and VITS-only prosody controls (`noise_scale`/`length_scale`/`noise_w`) no-op for other model types, while `speaker` stays ungated (Kokoro's 54 presets are selected entirely via NVDA's existing Speaker setting); `get_voice_variants` tolerates non-Piper key shapes; a new `load_all_voices_from_nvda_config_dir` scans a per-model-type voices directory.
- `const.py`: `DENGJEN_KOKORO_VOICES_DIR`, parallel to the existing Piper voices dir.
- `globalPlugins/dengjen_tts_global_plugin/model_catalog.py` (new): a `ModelCatalog` protocol (`model_type`, `is_installed()`, `install()`) with `PiperCatalog` and `KokoroCatalog` — the extension seam for future backends.
- `globalPlugins/dengjen_tts_global_plugin/kokoro_download.py` (new): downloads Kokoro-82M's shared model/vocab/54 voice-preset embeddings from HuggingFace and generates the exact config schema the real engine's Rust loader expects (verified against `zirekhq/dengjen-tts`'s source during planning).
- `voice_manager.py`: a new "Kokoro" tab with a single install button (kept separate from the existing Piper-specific browsing/download UI, which doesn't fit Kokoro's single-item shape); `voice_download.py` now writes the `voice.json` sidecar on Piper installs too.
- `synth_driver.py`/`voice_manager.py`: two call sites that assumed every voice has a Piper `quality` property, and a `DengjenVoice.load()` config-file lookup that could pick the new sidecar instead of the real engine config, are all guarded now.
- `tests_contract/test_kokoro_voice_contract.py` (new, Windows-only): loads a real Kokoro voice through the vendored engine and synthesizes through it — the closest available proxy for issue #31's original latency question. A precise number still needs a manual Windows run.
- `readme.md` / `architecture.adoc`: user-facing description and an extension-point guide for adding a future model backend.

## Test plan

- [x] Syntax check passes.
- [x] CI build + test green (454 passed, 17 skipped — all Windows-only `tests_gui`/`tests_contract`, unrunnable in this dev environment; `ruff check`/`ruff format --check` both clean).
- [ ] **Manual Windows/NVDA verification still needed**: install Kokoro from the voice manager's new "Kokoro" tab, confirm it appears in NVDA's voice list, and confirm its 54 presets are selectable via the Speaker setting. Not performed — this branch was developed in a Linux-only environment with no access to a real NVDA install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for downloading and installing Kokoro multilingual voices, including 54 speaker presets.
  * Added a dedicated Kokoro tab in the voice manager.
  * Kokoro speakers are available through NVDA’s Speaker setting.
  * Voice discovery now includes both Piper and Kokoro voices.

* **Bug Fixes**
  * Improved compatibility with voices missing quality metadata.
  * Preserved support for existing Piper voice installations during migration.

* **Documentation**
  * Added guidance for Kokoro voices and extending support to additional model types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->