### PR TITLE
chore: prune stale and restating comments

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,5 @@
 reviews:
   path_filters:
-    # Compiled binaries & C-extensions
     - "!**/*.exe"
     - "!**/*.pyd"
     - "!**/*.dll"
@@ -8,16 +7,13 @@ reviews:
     - "!**/*.dylib"
     - "!**/*.pyc"
     - "!**/__pycache__/**"
-    # Vendored 3rd party runtime dependencies
     - "!addon/synthDrivers/dengjen_neural_voices/lib/**"
     - "!addon/synthDrivers/dengjen_neural_voices/bin/**"
-    # Packaged releases & Lockfiles
     - "!packaged_addon/**"
     - "!uv.lock"
-    # Localization catalogs (optional to reduce noise)
+    # Excluded to reduce review noise, not because it needs hiding.
     - "!addon/locale/**"
 
-  # General repository-wide instructions
   instructions: |
     - This is an NVDA screen-reader add-on: Python 3.13, Windows-only runtime (gRPC server, vendored native wheels).
     - Focus strictly on correctness, thread/asyncio safety, and resource lifecycle (subprocess, socket, and file handles).
@@ -26,55 +22,46 @@ reviews:
     - Never suggest edits to vendored code under `lib/`; vendored wheels are refreshed only via `update_grpc.py`, `update_miniaudio.py`, `update_cffi.py`.
     - Keep comments concise: explain the root cause and provide a targeted code fix.
 
-  # Path-specific instructions
   path_instructions:
-    # 1. Synth Driver: speech sequence -> task pipeline
     - path: "addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py"
       instructions: |
         - Verify SynthDriver.speak() correctly transforms every speech-sequence command into a SpeechTask/BreakTask/IndexReachedTask/DoneSpeakingTask; a dropped command means NVDA silently skips speech.
         - Treat empty/falsy args to speak() (empty strings, zero-length sequences) as valid input, not error conditions — do not add truthiness checks that would drop legitimate zero/empty values.
         - Confirm tasks are only ever consumed on the shared asyncio loop; no blocking calls should be introduced on that loop.
 
-    # 2. Async engine & event loop
     - path: "addon/synthDrivers/dengjen_neural_voices/aio.py"
       instructions: |
         - AsyncEngine is a singleton driving a dedicated background thread, event loop, and thread pool; verify any new coroutine scheduling goes through its public submission API rather than touching the loop directly.
         - Check that exceptions raised inside scheduled coroutines/futures are surfaced (logged or propagated), not silently dropped by a bare except.
         - Verify shutdown/teardown paths actually stop the loop and join the thread; a leaked thread keeps NVDA from exiting cleanly.
 
-    # 3. gRPC client & subprocess management
     - path: "addon/synthDrivers/dengjen_neural_voices/adapters/dengjen_grpc/**"
       instructions: |
         - The dengjen-tts-grpc.exe subprocess is spawned detached on a free port; verify port selection has no race and the process handle/stdout/stderr are closed or piped without leaking file descriptors.
         - Confirm the vcruntime140_1.dll presence check happens before every spawn attempt, with a clear user-facing error if missing, not a raw crash.
         - Ensure gRPC channel/connection objects are closed on error paths, not just the happy path.
 
-    # 4. Text-to-speech system & speech task processing
     - path: "addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py"
       instructions: |
         - Verify voice/pitch/rate state mutations are consistent with what is actually sent to the gRPC layer on the next synthesis call (no stale state reuse).
         - Check that process_speech() correctly feeds raw PCM into the sample-rate-keyed WavePlayer instance matching the active voice; a mismatched sample rate produces audible distortion, not an exception.
 
-    # 5. Config & migration
     - path: "addon/synthDrivers/dengjen_neural_voices/{_config.py,voice_migration.py}"
       instructions: |
         - DengjenConfig persists per-voice settings; verify new config fields have safe defaults so existing user profiles do not break on upgrade.
         - Migration from legacy Sonata settings must be idempotent and only run once; verify it does not silently overwrite a user's already-migrated config on subsequent runs.
 
-    # 6. Tray-menu voice manager GUI
     - path: "addon/globalPlugins/dengjen_tts_global_plugin/**"
       instructions: |
         - This module imports directly from the synth driver package; flag any import that would create a circular dependency or reach into synth-driver internals not intended as a public surface.
         - Never suggest ShowModal() in reachable GUI code paths; NVDA/CI expects non-blocking dialog construction.
         - gui.messageBox returns wx.YES/wx.NO/wx.OK/wx.CANCEL — flag any comparison against wx.ID_* constants as a bug.
 
-    # 7. Build & SCons
     - path: "{sconstruct,buildVars.py,site_scons/**}"
       instructions: |
         - addon_version must remain strict 3-part semver; flag any change that would break that format.
         - Prefer changes routed through buildVars.py over direct edits to sconstruct unless the build graph itself must change.
 
-    # 8. Tests
     - path: "tests/**"
       instructions: |
         - This is the stub/unit suite (runs on Linux and Windows); NVDA base classes must be stubbed as plain empty classes, never MagicMock() — subclassing a mock makes class bodies no-ops and silently disables the test.

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,7 @@
 [run]
-# A single repo-root source keeps coverage.xml paths repo-root-relative, which is
-# what Sonar resolves against. Listing the addon package dirs here would also
-# report never-imported modules at 0%, but it makes coverage emit paths relative
-# to each source root (bare `__init__.py`), which Sonar cannot resolve.
+# source=. keeps coverage.xml paths repo-root-relative, which is what Sonar
+# resolves against. Listing each package dir instead would catch never-imported
+# modules at 0% too, but breaks paths (bare `__init__.py`) that Sonar can't resolve.
 source = .
 omit =
     .venv/*

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,7 @@
 # Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
 
-# Try to ensure that po files in the repo does not include
-# source code line numbers.
-# Every person expected to commit po files should change their personal config file as described here:
+# Strips source line numbers from committed po files; requires each committer
+# to define the `cleanpo` filter in their own git config -- see
 # https://mail.gnome.org/archives/kupfer-list/2010-June/msg00002.html
 *.po filter=cleanpo

--- a/.github/scripts/checkTranslation.py
+++ b/.github/scripts/checkTranslation.py
@@ -68,7 +68,6 @@ def getScoreFromApi(fileNameToSearch: str, langId: str) -> float:
     projectId = int(projectIdEnv)
 
     try:
-        # Clean and prepare search patterns.
         # Example: 'addon/locale/fr/LC_MESSAGES/myAddon.po' -> base_target: 'myAddon'.
         baseTarget = (
             fileNameToSearch.replace("\\", "/").split("/")[-1].rsplit(".", 1)[0].lower()
@@ -101,8 +100,7 @@ def getScoreFromApi(fileNameToSearch: str, langId: str) -> float:
             for item in data:
                 langApi = item["data"]["languageId"]
 
-                # Flexible matching (e.g., 'fr' will match 'fr' or 'fr-FR' from API).
-                # Also handles underscore to dash conversion for Crowdin compatibility
+                # Startswith, not equality: Crowdin may report 'fr' as 'fr-FR' etc.
                 if langApi.lower().startswith(langId.lower().replace("_", "-")):
                     progress = float(item["data"]["translationProgress"])
                     return progress

--- a/.github/scripts/crowdinSync.ps1
+++ b/.github/scripts/crowdinSync.ps1
@@ -4,9 +4,6 @@ $ErrorActionPreference = 'Stop'
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
-# main is protected (PRs + status checks required), so remember where we
-# started to detect new commits and publish them via a branch + PR instead
-# of pushing directly.
 $baseBranch = git symbolic-ref --short HEAD
 $baseCommit = git rev-parse HEAD
 

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -3,8 +3,6 @@ name: build addon
 on:
   push:
     tags: ["v*"]
-    # To build on main/master branch, uncomment the following line:
-    # branches: [ main , master ]
 
   pull_request:
     branches: [ main, master ]
@@ -74,22 +72,16 @@ jobs:
       - name: Run tests
         run: pytest
 
-      # Separate invocation, not folded into `pytest` above: testpaths=tests
-      # already keeps this out of that run, and tests_contract/'s conftest.py
-      # imports the real grpc package (incompatible with tests/conftest.py's
-      # MagicMock stub of it). dengjen-tts-grpc.exe is a Windows binary, so this
-      # only does anything on the windows-latest leg of the matrix; the test
-      # module self-skips on other platforms.
+      # Separate from `pytest` above (testpaths=tests excludes this already):
+      # tests_contract/'s conftest.py imports the real grpc package, incompatible
+      # with tests/conftest.py's MagicMock stub of it. Windows-only since the exe is.
       - name: Run gRPC contract tests
         if: runner.os == 'Windows'
         run: pytest tests_contract/ -v
 
-      # Separate invocation for the same reason as the contract tests above:
-      # tests_gui/ imports the real wxPython that tests/conftest.py replaces
-      # with a module stub, and a stub cannot be a base class for the
-      # wx.ListCtrl / SizedDialog subclasses in components.py. wxPython ships
-      # no Linux wheels on PyPI, so this is the Windows leg only; the test
-      # modules self-skip elsewhere.
+      # Same reason as the contract tests: tests_gui/ needs the real wxPython,
+      # which tests/conftest.py replaces with a stub (a stub can't be a base
+      # class for the wx subclasses in components.py); wxPython ships no Linux wheels.
       - name: Run GUI smoke tests
         if: runner.os == 'Windows'
         run: |
@@ -116,10 +108,9 @@ jobs:
     permissions:
       contents: read
     needs: ["build"]
-    # Real network calls to Hugging Face for voice downloads (added in a
-    # later task) make this slower and flakier than the deterministic
-    # suites, so it's kept out of the `test` gate deliberately rather than
-    # blocking merges on a flaky external dependency.
+    # Real network calls to Hugging Face for voice downloads make this slower
+    # and flakier than the deterministic suites, so it stays out of the
+    # `test` gate rather than blocking merges on a flaky external dependency.
     continue-on-error: true
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/crowdinL10n.yml
+++ b/.github/workflows/crowdinL10n.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Install gettext
         run: |
           choco install -y gettext
-          # Add gettext to PATH for current and future steps
           $gettextPath = "C:\Program Files\gettext-iconv\bin"
           echo "$gettextPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Get add-on info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,12 +29,9 @@ jobs:
       - run: ruff check .
       - run: ruff format --check .
 
-  # No pip-audit precedent yet in any sibling Python repo (nvda-addon-testkit
-  # doesn't have one either), so pinned dependencies haven't been triaged
-  # against advisories before. Kept non-blocking on this first pass -- mirrors
-  # how the Rust repos' `deny` job separates cheap license/bans/sources checks
-  # from the full `audit` gate -- so findings surface without failing PRs
-  # until someone has looked at them; tighten to a hard gate once that happens.
+  # No pip-audit precedent yet, so pinned dependencies haven't been triaged
+  # against advisories before. Kept non-blocking on this first pass so findings
+  # surface without failing PRs until someone has looked at them.
   audit:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sonar-fork-coverage.yml
+++ b/.github/workflows/sonar-fork-coverage.yml
@@ -1,20 +1,8 @@
 name: Sonar fork coverage
 
-# The Sonar job in sonar.yml is deliberately skipped for fork PRs because
-# forks are never given SONAR_TOKEN. This workflow builds what a real scan
-# needs -- a full checkout (including git history, for Sonar's blame/new-code
-# detection) plus a coverage report -- using only the read-only, secret-less
-# token that `pull_request` gets for fork PRs, and packages it as a plain tar
-# archive artifact.
-#
-# sonar-fork-scan.yml (triggered by a maintainer commenting `/sonar` on the
-# PR after reviewing the diff) extracts that archive with plain `tar`, never a
-# git operation, so it never runs git fetch/checkout against fork content and
-# never executes anything from the fork -- the archive is only read
-# statically by the Sonar scanner. This workflow must never gain
-# `secrets:` access and must never do anything beyond running the PR's own
-# test suite, exactly as any other fork `pull_request` job already safely
-# does.
+# Forks never get SONAR_TOKEN, so sonar.yml skips them. This workflow builds
+# the checkout + coverage report with only the safe, secret-less fork
+# `pull_request` token, and must never gain `secrets:` access.
 
 on:
   pull_request:
@@ -27,10 +15,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Mirrors sonar.yml's job of the same name: tests_contract/ and tests_gui/ are
-  # Windows-only, so without this the modules only they reach would land in the
-  # fork's report at 0% (#89). Runs the fork's own tests with no secrets, exactly
-  # as build_addon.yml's windows-latest leg already does for every fork PR.
+  # tests_contract/ and tests_gui/ are Windows-only, so without this leg those
+  # modules land in the fork's coverage report at 0% (#89).
   windows_coverage:
     name: Windows coverage for fork scan
     runs-on: windows-latest
@@ -89,11 +75,9 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
-          # Pinned to the actual PR head, not actions/checkout's default
-          # ephemeral merge commit -- otherwise the scanner analyzes a
-          # commit SHA that doesn't match the PR, and SonarCloud can't
-          # attach its status to the commit branch protection actually
-          # checks.
+          # Pinned to the PR head, not actions/checkout's default ephemeral merge
+          # commit -- otherwise the scanner analyzes a SHA that doesn't match the
+          # PR, and SonarCloud can't attach status to the commit branch protection checks.
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Sonar needs full history for new-code detection and blame
           persist-credentials: false

--- a/.github/workflows/sonar-fork-scan.yml
+++ b/.github/workflows/sonar-fork-scan.yml
@@ -1,35 +1,8 @@
 name: Sonar fork scan
 
-# Automated SonarCloud analysis of arbitrary fork PRs doesn't have a safe
-# implementation: SONAR_TOKEN is needed to post results, but no matter how
-# fork source reaches a job holding SONAR_TOKEN, that job must not execute
-# anything derived from the fork. A previous version of this workflow chained
-# automatically off sonar-fork-coverage.yml via workflow_run and used
-# actions/checkout on the PR head -- actions/checkout itself refuses that
-# combination by default ("pwn request" protection), and a purpose-built
-# action for this exact problem (matrix-org/sonarcloud-workflow-action) was
-# archived with the stated reason: "there is [no] foolproof way to run
-# Sonarcloud against attacker-controlled PRs."
-#
-# So this is comment-triggered: a maintainer reviews the diff, then comments
-# `/sonar` on the PR. Only OWNER/MEMBER/COLLABORATOR authors can trigger it
-# (checked below), and the job resolves the PR's *current* head itself rather
-# than trusting a caller-supplied SHA -- there is no separate "pin the SHA you
-# reviewed" input to keep in sync, at the cost of a small window between
-# commenting and the job starting in which a new push would get scanned
-# instead of what was reviewed.
-#
-# Unlike a plain checkout-and-build of the fork's code (e.g. a workflow that
-# checks out the fork head and runs its own build scripts in a job that holds
-# SONAR_TOKEN), this job still never executes anything derived from the fork:
-# it downloads the tar archive sonar-fork-coverage.yml built (test suite
-# already executed there, safely, with no secrets) and extracts it with plain
-# `tar`, never a git operation against fork content. The scanner only reads
-# the result statically.
-#
-# Until a maintainer comments `/sonar`, the required "SonarCloud Code
-# Analysis" check on a fork PR stays pending -- merge via admin override if a
-# scan isn't warranted (e.g. docs-only changes), rather than faking green.
+# No safe way to auto-scan fork PRs: a job holding SONAR_TOKEN must never
+# execute fork-derived code. So this triggers only on a maintainer's
+# `/sonar` comment and only `tar`-extracts sonar-fork-coverage.yml's artifact.
 
 on:
   issue_comment:
@@ -38,27 +11,17 @@ on:
 permissions: {}
 
 concurrency:
-  # Every comment on the PR fires this trigger, not just /sonar ones -- so a
-  # group keyed on PR number alone would let an unrelated comment (including
-  # SonarCloud's own "Quality Gate Passed" bot comment, posted *by* our own
-  # run) cancel a scan that's mid-flight. Non-/sonar comments each get their
-  # own group, keyed on the comment id, so only genuine /sonar comments ever
-  # compete for the slot -- which is what cancel-in-progress is actually for:
-  # a second /sonar superseding a stale first one.
+  # Every PR comment fires this trigger, not just /sonar ones. Non-/sonar
+  # comments get their own per-comment-id group so an unrelated comment (even
+  # our own bot's result comment) can't cancel a scan mid-flight.
   group: sonar-fork-scan-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, '/sonar') && 'sonar' || github.event.comment.id }}
   cancel-in-progress: true
 
 jobs:
   acknowledge:
-    # The only thing standing between a fork PR and SONAR_TOKEN, so it gates
-    # the scan job via `needs` rather than repeating this condition there,
-    # where the two copies could drift apart.
-    #
-    # No reaction/comment back here: this repo's default GITHUB_TOKEN
-    # permissions are read-only (org/repo setting), so a job-level
-    # `permissions: issues: write` can't actually widen the token -- any
-    # write call 403s. Rather than carry a permission this repo deliberately
-    # withholds, this job does nothing but gate.
+    # This condition is the only thing standing between a fork PR and
+    # SONAR_TOKEN -- the scan job depends on it via `needs` rather than
+    # repeating the check, so the two can't drift out of sync.
     if: >-
       github.event.issue.pull_request != null
       && startsWith(github.event.comment.body, '/sonar')
@@ -122,13 +85,9 @@ jobs:
           mkdir -p workspace
           tar -xzf "$ARCHIVE_DIR/workspace.tar.gz" -C workspace
 
-      # SonarCloud's GitHub integration normally posts the
-      # "SonarCloud Code Analysis" status itself, but it attaches to whatever
-      # commit the Actions *run* is associated with -- main's tip, since this
-      # is triggered by issue_comment, not the PR's head. It has no way to
-      # know to target the PR from sonar.pullrequest.key alone. So this waits
-      # for the real quality gate result and posts the status to the actual
-      # head SHA itself, rather than relying on that automatic posting.
+      # SonarCloud's own GitHub status-posting attaches to whatever commit the
+      # triggering event points to -- main's tip here, since this runs off
+      # issue_comment, not the PR head -- so this posts to the real head SHA itself.
       - name: SonarQube scan
         id: sonar
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -14,10 +14,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # tests_contract/ (real dengjen-tts-grpc.exe) and tests_gui/ (real wxPython) only
-  # run on Windows, so the modules they exercise are invisible to the ubuntu
-  # coverage run below. This job measures them and hands the raw data over as
-  # an artifact for the scan job to combine (#89).
+  # tests_contract/ (real dengjen-tts-grpc.exe) and tests_gui/ (real wxPython)
+  # only run on Windows, invisible to the ubuntu coverage run below. This job
+  # measures them and hands the data to the scan job to combine (#89).
   windows_coverage:
     name: Windows coverage
     runs-on: windows-latest
@@ -42,10 +41,9 @@ jobs:
           pip install --only-binary :all: -r requirements-test.txt
           pip install --only-binary :all: -r requirements-test-gui.txt
 
-      # Three invocations for the reasons build_addon.yml spells out: each tree
-      # needs a different set of real-vs-stubbed modules, so they cannot share a
-      # process. Each writes its own COVERAGE_FILE because a bare `pytest --cov`
-      # erases whatever data files it finds first.
+      # Three invocations for the reasons build_addon.yml spells out (each tree
+      # needs different real-vs-stubbed modules). Each needs its own COVERAGE_FILE:
+      # a bare `pytest --cov` erases whatever data files it finds first.
       - name: Run tests with coverage
         env:
           COVERAGE_FILE: .coverage.windows.tests

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          # Only touch issues that have been parked pending a reproducer.
           # Everything else (active bugs, feature requests, etc.) stays open
           # until someone explicitly acts on it.
           only-issue-labels: needs-reproducer

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,15 +1,8 @@
 name: Upstream Watch
 
-# Tracks divergence from mush42/sonata-nvda, the upstream this repo was
-# forked from (see readme.md: the original author, Musharraf Omer (@mush42),
-# announced that commercial contract conflicts prevent him from continuing
-# to maintain the open-source add-on; this repo continues the project as a
-# fork). This repo's own git history is that fork lineage, so it shares
-# commit ancestry with mush42/sonata-nvda directly -- the compare API below
-# works the same way it would for any GitHub fork. Rather than auto-merging
-# upstream/main -- which would risk clobbering this fork's own divergence --
-# this just keeps one tracking issue current so a human decides when and how
-# to pull changes in.
+# Tracks divergence from mush42/sonata-nvda, the upstream this fork continues
+# (see readme.md). Deliberately files a tracking issue instead of auto-merging
+# upstream/main, to avoid clobbering this fork's own divergence.
 
 on:
   schedule:

--- a/addon/synthDrivers/dengjen_neural_voices/helpers.py
+++ b/addon/synthDrivers/dengjen_neural_voices/helpers.py
@@ -30,11 +30,9 @@ def update_displaied_params_on_voice_change(synth):
             if isinstance(win, NVDASettingsDialog)
         )
     except StopIteration:
-        # No gui displaied
         return
     current_panel = setting_dialog.currentCategory
     if not isinstance(current_panel, SpeechSettingsPanel):
-        # No gui displaied
         return
     voice_panel = current_panel.voicePanel
     speakers = list(synth.availableSpeakers.values())

--- a/requirements-test-e2e.txt
+++ b/requirements-test-e2e.txt
@@ -1,5 +1,3 @@
-# nvda-addon-testkit for the real-NVDA e2e layer (Windows leg only).
-#
 # Installs a disposable portable NVDA, installs the built .nvda-addon into
 # it, and drives it via pytest. See tests_e2e/conftest.py for why this tree
 # is kept out of every other suite's collection.

--- a/requirements-test-gui.txt
+++ b/requirements-test-gui.txt
@@ -1,5 +1,3 @@
-# Real wxPython for the tests_gui/ smoke layer (Windows leg only).
-#
 # Pinned to NVDA master's own pin, so the wx under test is the wx the add-on
 # actually runs against -- see pyproject.toml in nvaccess/nvda.
 #

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,17 +1,12 @@
-# Tooling for the test matrix and the Sonar coverage run.
 pytest==9.1.1
 pytest-cov==7.1.0
 
-# The vendored `grpc` under synthDrivers/dengjen_neural_voices/lib/ eagerly
-# imports grpc.aio, which needs this. NVDA's own bundled Python already has
-# it (pulled in by some other dependency), so production never hits this;
-# a bare CI Python does. Only tests_contract/ (Windows-only) exercises the
-# real grpc package -- everywhere else it's a MagicMock stub.
+# The vendored `grpc` eagerly imports grpc.aio, which needs this; NVDA's own
+# bundled Python already has it, so only a bare CI Python needs it explicitly.
+# Only tests_contract/ (Windows-only) exercises the real grpc, not a stub.
 typing_extensions==4.16.0
 
-# dengjen-tts-grpc.exe needs real espeak-ng-data to phonemize text for synthesis.
-# Production gets this for free from NVDA's own bundled eSpeak NG driver;
-# this vendors the same data as a plain pip package so
-# tests_contract/test_grpc_contract.py's synthesis test has something to
-# point DENGJEN_ESPEAKNG_DATA_DIRECTORY at.
+# dengjen-tts-grpc.exe needs real espeak-ng-data to phonemize text; production
+# gets this for free from NVDA's bundled eSpeak NG driver, so this vendors the
+# same data for tests_contract/test_grpc_contract.py's synthesis test.
 espeakng-loader==0.2.4

--- a/sconstruct
+++ b/sconstruct
@@ -10,17 +10,14 @@ from pathlib import Path
 from collections.abc import Iterable
 from typing import Final
 
-# While names imported below are available by default in every SConscript
-# Linters aren't aware about them.
-# To avoid PyRight `reportUndefinedVariable` errors about them they are imported explicitly.
-# When using other  Scons functions please add them to the line below.
+# SCons injects these names into every SConscript at runtime; PyRight doesn't
+# know that and flags them as undefined, so they're imported here explicitly.
+# Add any other SCons builtins used below to this import.
 from SCons.Script import EnsurePythonVersion, Variables, BoolVariable, Environment, Copy
 
-# Imports for type hints
 from SCons.Node import FS
 
-# Add-on localization exchange facility and the template requires Python 3.10.
-# For best practice, use Python 3.11 or later to align with NVDA development.
+# The add-on localization exchange facility requires Python 3.10 at minimum.
 EnsurePythonVersion(3, 10)
 
 # Bytecode should not be written for build vars module to keep the repository root folder clean.
@@ -30,7 +27,7 @@ import buildVars  # NOQA: E402
 
 
 def validateVersionNumber(key: str, val: str, _):
-	# Used to make sure version major.minor.patch are integers to comply with NV Access add-on store.
+	# NV Access add-on store requires version numbers to be major.minor.patch integers.
 	# Ignore all this if version number is not specified.
 	if val == "0.0.0":
 		return
@@ -85,7 +82,6 @@ addon = env.NVDAAddon(addonFile, env.Dir(addonDir), excludePatterns=buildVars.ex
 
 langDirs: list[FS.Dir] = [env.Dir(d) for d in env.Glob(localeDir/"*/") if d.isdir()]
 
-# Allow all NVDA's gettext po files to be compiled in source/locale, and manifest files to be generated
 moByLang: dict[str, FS.File] = {}
 for dir in langDirs:
 	poFile = dir.File(os.path.join("LC_MESSAGES", "nvda.po"))
@@ -103,8 +99,7 @@ pythonFiles = expandGlobs(buildVars.pythonSources)
 for file in pythonFiles:
 	env.Depends(addon, file)
 
-# Convert markdown files to html
-# We need at least doc in English and should enable the Help button for the add-on in Add-ons Manager
+# Need at least the English doc, to enable the Help button in Add-ons Manager.
 if (cssFile := Path("style.css")).is_file():
 	cssPath = docsDir / cssFile
 	cssTarget = env.Command(str(cssPath), str(cssFile), Copy("$TARGET", "$SOURCE"))
@@ -116,8 +111,8 @@ if (readmeFile := Path("readme.md")).is_file():
 	env.Depends(addon, readmeTarget)
 
 for mdFile in env.Glob(docsDir/"*/*.md"):
-	# the title of the html file is translated based on the contents of something in the moFile for a language.
-	# Thus, we find the moFile for this language and depend on it if it exists.
+	# The html title is translated from the moFile's catalog, so look up this
+	# language's moFile and depend on it if one exists.
 	lang = mdFile.dir.name
 	moFile = moByLang.get(lang)
 	htmlFile = env.md2html(mdFile, moFile=moFile, mdExtensions=buildVars.markdownExtensions)
@@ -126,7 +121,6 @@ for mdFile in env.Glob(docsDir/"*/*.md"):
 		env.Depends(htmlFile, moFile)
 	env.Depends(addon, htmlFile)
 
-# Pot target
 i18nFiles = expandGlobs(buildVars.i18nSources)
 gettextvars: dict[str, str] = {
 	"gettext_package_bugs_address": "nvda-translations@groups.io",
@@ -141,9 +135,7 @@ mergePot = env.gettextMergePotFile("${addon_name}-merge.pot", i18nFiles, **gette
 env.Alias("mergePot", mergePot)
 env.Depends(mergePot, i18nFiles)
 
-# Generate Manifest path
 manifest = env.NVDAManifest(env.File(addonDir/"manifest.ini"), "manifest.ini.tpl")
-# Ensure manifest is rebuilt if buildVars is updated.
 env.Depends(manifest, "buildVars.py")
 
 env.Depends(addon, manifest)

--- a/site_scons/site_tools/NVDATool/docs.py
+++ b/site_scons/site_tools/NVDATool/docs.py
@@ -40,7 +40,6 @@ def md2html(
     for k, v in headerDic.items():
         mdText = mdText.replace(k, v, 1)
     htmlText = markdown.markdown(mdText, extensions=mdExtensions)
-    # Optimization: build resulting HTML text in one go instead of writing parts separately.
     docText = "\n".join(
         (
             "<!DOCTYPE html>",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,31 +8,14 @@ sonar.tests=tests,tests_contract,tests_gui,tests_e2e
 # sized_controls), generated gRPC stubs, and the shipped engine binaries.
 sonar.exclusions=addon/synthDrivers/dengjen_neural_voices/lib/**,addon/synthDrivers/dengjen_neural_voices/adapters/dengjen_grpc/grpc_protos/**,addon/synthDrivers/dengjen_neural_voices/bin/**,addon/globalPlugins/dengjen_tts_global_plugin/sized_controls.py
 
-# Absent from coverage.xml, so Sonar's Zero Coverage Sensor would otherwise
-# report it at 0% and drag every new-code measurement down. It stays in
-# sonar.sources: still analysed for issues, only removed from the coverage
-# metric.
-#
-# adapters/dengjen_grpc/__init__.py's module-level gRPC calls (initialize(),
-# check_grpc_server(), load_voice(), etc.) are reached by no test tree that
-# reports coverage here. tests_contract/test_grpc_contract.py runs the real
-# dengjen-tts-grpc.exe but deliberately talks to the generated grpc_protos stubs
-# directly, bypassing this module, because it pulls in globalVars, logHandler
-# and NVDA's subprocess lifecycle (see tests_contract/conftest.py).
-# tests/test_dengjen_grpc_backend.py imports the module for real but
-# monkeypatches these functions individually, so their bodies still never run
-# on Linux. So merging the Windows legs' coverage in (#89) does not cover it
-# -- that took __init__.py, voice_manager.py and components.py off this list,
-# but not this one.
+# adapters/dengjen_grpc/ is reached by no test tree that reports coverage
+# here (contract tests bypass it via grpc_protos directly; unit tests
+# monkeypatch its functions) -- stays in sonar.sources, only excluded from coverage.
 sonar.coverage.exclusions=addon/synthDrivers/dengjen_neural_voices/adapters/dengjen_grpc/**
 
-# S8544 wants pip installs to resolve against a lock file. Our direct CI tooling
-# is already ==-pinned in requirements-bootstrap/-build/-test.txt; going further
-# means --require-hashes plus generated lock files covering every transitive dep
-# on both Linux and Windows, which is not worth the maintenance here. It is a
-# MAJOR VULNERABILITY, so leaving it open would hold new_security_rating at C and
-# fail the required gate on any PR touching these files. Scoped to the workflows
-# so S8541, S7637 and S6573 stay enforced there.
+# S8544 wants pip installs to resolve against a lock file; our CI tooling is
+# already ==-pinned, and full lock files across Linux+Windows isn't worth it
+# here. Scoped to workflows/ so S8541, S7637, S6573 stay enforced there.
 sonar.issue.ignore.multicriteria=pipLock
 sonar.issue.ignore.multicriteria.pipLock.ruleKey=githubactions:S8544
 sonar.issue.ignore.multicriteria.pipLock.resourceKey=.github/workflows/**/*

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -34,6 +34,7 @@ import types
 from concurrent.futures import Future as _Future
 from unittest.mock import MagicMock
 
+
 def _stub_module(name: str, **attrs) -> types.ModuleType:
     """Create a plain module stub and register it in sys.modules."""
     mod = types.ModuleType(name)

--- a/tests/nvda_stubs.py
+++ b/tests/nvda_stubs.py
@@ -34,11 +34,6 @@ import types
 from concurrent.futures import Future as _Future
 from unittest.mock import MagicMock
 
-# ---------------------------------------------------------------------------
-# Helper utilities
-# ---------------------------------------------------------------------------
-
-
 def _stub_module(name: str, **attrs) -> types.ModuleType:
     """Create a plain module stub and register it in sys.modules."""
     mod = types.ModuleType(name)

--- a/tests/test_synth_driver.py
+++ b/tests/test_synth_driver.py
@@ -318,10 +318,9 @@ class TestProcessSpeechSequence:
 
         exception_mock = MagicMock()
         monkeypatch.setattr(driver_module.log, "exception", exception_mock)
-        # nvda_stubs aliases the module's CancelledError to the builtin
-        # Exception (so a plain raise can stand in for a real cancellation
-        # elsewhere); narrow it back to the real type here so a ValueError
-        # can actually reach the generic-exception branch under test.
+        # nvda_stubs aliases CancelledError to the builtin Exception (so a plain
+        # raise can stand in for a real cancellation); narrow it back to the real
+        # type here so a ValueError can reach the generic-exception branch under test.
         monkeypatch.setattr(driver_module, "CancelledError", asyncio.CancelledError)
 
         asyncio.run(driver_module._process_speech_sequence([blows_up, never_runs]))

--- a/tests_contract/test_synthesis_latency_contract.py
+++ b/tests_contract/test_synthesis_latency_contract.py
@@ -180,12 +180,9 @@ class TestSynthesisLatencyContract:
         strict=False,
     )
     def test_no_unrequested_tail_silence_between_requests(self, backend, loaded_voice):
-        # A standard (non-streaming) voice loads through dengjen-tts's plain
-        # VitsModel, not VitsStreamingModel -- supports_streaming_output is
-        # false for every such voice regardless of quality, so it never
-        # returns more than one chunk per synthesize() call. The boundary a
-        # screen-reader user would actually hear a gap at is therefore
-        # between two consecutive synthesize() calls, not within one.
+        # Standard voices use VitsModel, not VitsStreamingModel, so
+        # supports_streaming_output is false and synthesize() never returns more
+        # than one chunk -- the audible gap is between two calls, not within one.
         @aio.asyncio_coroutine_to_concurrent_future
         async def _synthesize(text):
             chunks = []


### PR DESCRIPTION
## Summary

Comment audit across the repo: removed comments that only restated the code or defended a design choice nobody was questioning, and trimmed lengthy rationale comments to their load-bearing facts (three-line cap). No code logic changed.

## Changes

- Removed comments that restated the following line or a magic sentinel already obvious from context (`.coderabbit.yaml` section labels, `sconstruct` navigation comments, `helpers.py`'s "No gui displaied", `crowdinSync.ps1`'s duplicate of a comment stated again later in the file, `docs.py`'s "Optimization:" note).
- Trimmed dense multi-paragraph rationale to ≤3 lines while keeping the non-obvious fact: `sonar-fork-scan.yml`, `sonar-fork-coverage.yml`, `sonar.yml`, `build_addon.yml`, `sonar-project.properties`, `.coveragerc`, `lint.yml`, `upstream-watch.yml`.
- Dropped commented-out code (`build_addon.yml`'s `# branches: [ main , master ]`).
- Left docstrings, license headers, `SAFETY:`/lint-suppression pragmas, and translator (`# Translators:`) comments untouched — out of scope for this pass.

## Test plan

- [x] All touched Python files pass `py_compile`.
- [x] All touched YAML files pass `yaml.safe_load`.
- [ ] CI build + test green.
