### PR TITLE
fix: bind each speech task to its own voice's WavePlayer

### DIFF
--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
@@ -71,14 +71,20 @@ def _bootstrap_backend():  # pragma: no cover
 
 
 class DoneSpeakingTask:
-    __slots__ = ["on_index_reached", "player"]
+    """Waits on every player used by the sequence, not just one -- a
+    mid-sequence LangChangeCommand can switch to a voice with a different
+    sample rate, and each rate gets its own WavePlayer (see
+    _get_or_create_player)."""
 
-    def __init__(self, player, on_index_reached):
-        self.player = player
+    __slots__ = ["on_index_reached", "players"]
+
+    def __init__(self, players, on_index_reached):
+        self.players = players
         self.on_index_reached = on_index_reached
 
     async def __call__(self):
-        await run_in_executor(self.player.idle)
+        for player in self.players:
+            await run_in_executor(player.idle)
         await run_in_executor(self.on_index_reached, None)
 
 
@@ -263,6 +269,7 @@ class SynthDriver(NvdaSynthDriver):
         text_list = []
         index_command_list = []
         default_lang = self.tts.language
+        players_used = {self._player}
         for item in speech_sequence:
             item_type = type(item)
             if item_type is IndexCommand:
@@ -278,13 +285,14 @@ class SynthDriver(NvdaSynthDriver):
             break_task = self._apply_speech_command(item, default_lang)
             if break_task is not None:
                 speech_seq.append(break_task)
+            players_used.add(self._player)
         if any(text_list):
             speech_seq.append(self._create_speech_task(text_list))
         if any(index_command_list):
             speech_seq.append(
                 IndexReachedTask(self._on_index_reached, index_command_list)
             )
-        speech_seq.append(DoneSpeakingTask(self._player, self._on_index_reached))
+        speech_seq.append(DoneSpeakingTask(players_used, self._on_index_reached))
         return speech_seq
 
     def _create_speech_task(self, text_list):
@@ -302,6 +310,8 @@ class SynthDriver(NvdaSynthDriver):
             )
         if item_type is LangChangeCommand:
             self.tts.language = default_lang if item.isDefault else item.lang
+            voice = self.tts.speech_options.voice
+            self._player = self._get_or_create_player(voice.sample_rate)
         elif item_type is RateCommand:
             self.tts.rate = item.newValue
         elif item_type is VolumeCommand:

--- a/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
+++ b/addon/synthDrivers/dengjen_neural_voices/adapters/nvda/synth_driver.py
@@ -201,6 +201,7 @@ class SynthDriver(NvdaSynthDriver):
         self.tts = None
         self._player = None
         self._players = {}
+        self._active_players = set()
         self._noise_scale_factor = None
         self._length_scale_factor = None
         self._noise_w_factor = None
@@ -239,6 +240,7 @@ class SynthDriver(NvdaSynthDriver):
         self._player = self._get_or_create_player(
             self.tts.speech_options.voice.sample_rate
         )
+        self._active_players = {self._player}
         self.availableLanguages = {v.language for v in self.voices}
         self._voice_map = {v.key: v for v in self.voices}
         self._standard_voice_map = {v.standard_variant_key: v for v in self.voices}
@@ -253,6 +255,7 @@ class SynthDriver(NvdaSynthDriver):
             player.close()
         self._players.clear()
         self._player = None
+        self._active_players = set()
 
     def speak(self, speechSequence):
         with self.tts.create_synthesis_context():
@@ -293,6 +296,11 @@ class SynthDriver(NvdaSynthDriver):
                 IndexReachedTask(self._on_index_reached, index_command_list)
             )
         speech_seq.append(DoneSpeakingTask(players_used, self._on_index_reached))
+        # cancel()/pause() can fire at any point while this sequence plays,
+        # potentially before a later task's mid-sequence voice switch has
+        # actually started playing -- they need every player this sequence
+        # might touch, not just whichever self._player ends up as.
+        self._active_players = players_used
         return speech_seq
 
     def _create_speech_task(self, text_list):
@@ -323,12 +331,12 @@ class SynthDriver(NvdaSynthDriver):
     def cancel(self):
         if self._current_task is not None:
             asyncio_cancel_task(self._current_task)
-        if self._player is not None:
-            self._player.stop()
+        for player in self._active_players:
+            player.stop()
 
     def pause(self, switch):
-        if self._player is not None:
-            self._player.pause(switch)
+        for player in self._active_players:
+            player.pause(switch)
 
     def _on_index_reached(self, index):
         if index is not None:
@@ -517,6 +525,7 @@ class SynthDriver(NvdaSynthDriver):
         DengjenConfig.setdefault(self.voice, {})["variant"] = value
         voice = self.tts.speech_options.voice
         self._player = self._get_or_create_player(voice.sample_rate)
+        self._active_players = {self._player}
 
         self._reapply_scale_settings()
 

--- a/tests/test_synth_driver.py
+++ b/tests/test_synth_driver.py
@@ -29,6 +29,7 @@ import pytest
 import ui
 from dengjen_neural_voices.const import FALLBACK_SPEAKER_NAME
 from dengjen_neural_voices.domain import tts_system
+from dengjen_neural_voices.ports.tts_backend import LoadedVoice, SynthOptions
 from logHandler import log
 from speech.commands import BreakCommand, IndexCommand, LangChangeCommand
 
@@ -223,6 +224,44 @@ class TestBuildSpeechTasks:
         ]
         tasks = driver._build_speech_tasks(seq)
         assert [type(t) for t in tasks] == [SpeechTask, SpeechTask, DoneSpeakingTask]
+
+    def test_a_mid_sequence_lang_change_switches_to_the_new_voices_player(
+        self, configured_voice, fake_backend
+    ):
+        """A voice switched to mid-sequence (e.g. NVDA's language
+        auto-detection) can have a different sample rate -- Kokoro's fixed
+        24000Hz differs from Piper's common rates, so this regresses easily
+        once both are installed. Each task must carry its own voice's
+        player, and DoneSpeakingTask must wait on every player used."""
+        second_voice_dir = _write_voice(configured_voice, key="fr_FR-test-medium")
+        second_config_path = str(next(second_voice_dir.glob("*.json")))
+        fake_backend.voices_by_config_path[second_config_path] = LoadedVoice(
+            backend_voice_id="fake-remote-id-fr",
+            supports_streaming_output=False,
+            sample_rate=24000,
+            speakers={},
+            defaults=SynthOptions(
+                speaker=None, length_scale=1.0, noise_scale=0.667, noise_w=0.8
+            ),
+        )
+        driver = SynthDriver()
+        try:
+            first_player = driver._player
+            seq = ["hello", _lang_change_command("fr_FR"), "bonjour"]
+
+            tasks = driver._build_speech_tasks(seq)
+
+            speech_tasks = [t for t in tasks if isinstance(t, SpeechTask)]
+            assert len(speech_tasks) == 2
+            assert speech_tasks[0].player is first_player
+            second_player = driver._players[24000]
+            assert speech_tasks[1].player is second_player
+            assert second_player is not first_player
+            done_task = tasks[-1]
+            assert isinstance(done_task, DoneSpeakingTask)
+            assert set(done_task.players) == {first_player, second_player}
+        finally:
+            driver.terminate()
 
 
 class TestLifecycle:

--- a/tests/test_synth_driver.py
+++ b/tests/test_synth_driver.py
@@ -290,6 +290,72 @@ class TestLifecycle:
         driver.pause(True)
         driver._player.pause.assert_called_once_with(True)
 
+    def test_cancel_stops_every_player_from_a_mid_sequence_lang_change(
+        self, configured_voice, fake_backend
+    ):
+        """cancel() must stop every player a just-built sequence might still
+        be using, not just self._player -- _build_speech_tasks can leave
+        self._player pointing at a later voice than whichever task is
+        actually mid-playback when cancel() fires."""
+        second_voice_dir = _write_voice(configured_voice, key="fr_FR-test-medium")
+        second_config_path = str(next(second_voice_dir.glob("*.json")))
+        fake_backend.voices_by_config_path[second_config_path] = LoadedVoice(
+            backend_voice_id="fake-remote-id-fr",
+            supports_streaming_output=False,
+            sample_rate=24000,
+            speakers={},
+            defaults=SynthOptions(
+                speaker=None, length_scale=1.0, noise_scale=0.667, noise_w=0.8
+            ),
+        )
+        driver = SynthDriver()
+        try:
+            first_player = driver._player
+            driver._build_speech_tasks(
+                ["hello", _lang_change_command("fr_FR"), "bonjour"]
+            )
+            second_player = driver._players[24000]
+            first_player.stop = MagicMock()
+            second_player.stop = MagicMock()
+
+            driver.cancel()
+
+            first_player.stop.assert_called_once()
+            second_player.stop.assert_called_once()
+        finally:
+            driver.terminate()
+
+    def test_pause_pauses_every_player_from_a_mid_sequence_lang_change(
+        self, configured_voice, fake_backend
+    ):
+        second_voice_dir = _write_voice(configured_voice, key="fr_FR-test-medium")
+        second_config_path = str(next(second_voice_dir.glob("*.json")))
+        fake_backend.voices_by_config_path[second_config_path] = LoadedVoice(
+            backend_voice_id="fake-remote-id-fr",
+            supports_streaming_output=False,
+            sample_rate=24000,
+            speakers={},
+            defaults=SynthOptions(
+                speaker=None, length_scale=1.0, noise_scale=0.667, noise_w=0.8
+            ),
+        )
+        driver = SynthDriver()
+        try:
+            first_player = driver._player
+            driver._build_speech_tasks(
+                ["hello", _lang_change_command("fr_FR"), "bonjour"]
+            )
+            second_player = driver._players[24000]
+            first_player.pause = MagicMock()
+            second_player.pause = MagicMock()
+
+            driver.pause(True)
+
+            first_player.pause.assert_called_once_with(True)
+            second_player.pause.assert_called_once_with(True)
+        finally:
+            driver.terminate()
+
     def test_terminate_closes_every_player_and_clears_them(self, driver):
         extra_player = MagicMock()
         driver._players["extra"] = extra_player


### PR DESCRIPTION
## Summary

A mid-sequence `LangChangeCommand` (NVDA's automatic language-detection/switching) can switch to a voice with a different sample rate, but `self._player` was never updated when that happens — only on an explicit voice change via the Voice setting. Every `SpeechTask`/`BreakTask` built for the rest of that sequence kept using whichever `WavePlayer` was active *before* the switch, so the new voice's correctly-generated PCM got fed into a player configured for the wrong sample rate.

This was already possible with different Piper voices at different quality tiers, but Kokoro's fixed 24000Hz — different from Piper's common rates — makes it far more likely to actually manifest for anyone with both installed and NVDA's language auto-switching on.

Found by CodeRabbit reviewing #164 as an "outside diff range" comment, so it never got an inline thread there and slipped through before that PR merged.

## Changes

- `_apply_speech_command`'s `LangChangeCommand` branch now re-selects `self._player` for the new voice's sample rate, mirroring the exact pattern the explicit voice-change setter already uses.
- `DoneSpeakingTask` now waits on every player used by a sequence (a `set`, built while `_build_speech_tasks` runs), not just one — a sequence can legitimately span more than one now.
- Added a regression test with two voices at different sample rates, verified RED without the fix (fails with `KeyError: 24000` — the second player never gets created) and GREEN with it.

## Test plan

- [x] Syntax check passes.
- [x] `pytest tests/` — 456 passed, 17 skipped (Windows-only suites, unrunnable here), 0 failed.
- [x] `ruff check` / `ruff format --check` both clean.
- [ ] Manual Windows/NVDA verification: install both a Piper voice and Kokoro, enable automatic language switching, and confirm mixed-language text plays at the correct pitch/speed for both. Not performed — no Windows/NVDA access in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech completion handling when switching voices mid-speech.
  * Ensured speech sequences wait for all audio players involved before reporting completion.
  * Preserved accurate voice-specific playback when sample rates change during a sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->