### PR TITLE
feat: resume interrupted voice downloads instead of restarting from zero

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
@@ -164,7 +164,7 @@ class KokoroVoiceDownloader(_BaseVoiceDownloader):
             ),
         ]
         total_files = len(files_to_download)
-        temp_dir = Path(self.temp_download_dir.name)
+        download_dir = Path(self.download_dir)
         result = {}
         for files_done, (result_key, relative_path) in enumerate(
             files_to_download, start=1
@@ -173,7 +173,7 @@ class KokoroVoiceDownloader(_BaseVoiceDownloader):
                 int((files_done - 1) / total_files * 100),
                 _("Downloading file: {file}").format(file=relative_path),
             )
-            target_path = temp_dir / result_key
+            target_path = download_dir / result_key
             _download_to_file(relative_path, target_path)
             result[result_key] = target_path
             self.update_progress(int(files_done / total_files * 100))

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -602,6 +602,10 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
             install_voice_from_tar_archive(target_file, DENGJEN_VOICES_DIR)
         except Exception:
             log.exception("Failed to extract voice archive", exc_info=True)
+            # Otherwise a Range request on the next attempt would land past
+            # EOF and get a 416 forever, since this archive has no known
+            # expected_size to catch it as stale beforehand.
+            Path(target_file).unlink(missing_ok=True)
             raise _VoiceInstallError
 
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -5,7 +5,6 @@ import re
 import shutil
 import ssl
 import tarfile
-import tempfile
 import urllib.parse
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
@@ -219,11 +218,11 @@ def _get_with_cert_fallback(url, **kwargs):
 
 
 @contextmanager
-def _yield_response_with_cert_fallback(method, url, **kwargs):
+def _yield_response_with_cert_fallback(method, url, headers=None, **kwargs):
     with ExitStack() as stack:
         try:
             response = stack.enter_context(
-                request.yield_response(method, url, **kwargs)
+                request.yield_response(method, url, headers=headers, **kwargs)
             )
         except HTTPException as e:
             if not _is_os_trust_store_gap(e):
@@ -234,17 +233,23 @@ def _yield_response_with_cert_fallback(method, url, **kwargs):
             )
             response = stack.enter_context(
                 request.yield_response(
-                    method, url, ssl_context=_fallback_ssl_context(), **kwargs
+                    method,
+                    url,
+                    headers=headers,
+                    ssl_context=_fallback_ssl_context(),
+                    **kwargs,
                 )
             )
         yield response
 
 
 @contextmanager
-def _follow_redirects(url, label):
+def _follow_redirects(url, label, headers=None):
 
     for _redirect in range(REDIRECT_LIMIT):
-        with _yield_response_with_cert_fallback("GET", url) as response:
+        with _yield_response_with_cert_fallback(
+            "GET", url, headers=headers
+        ) as response:
             if response.status in REDIRECT_STATUSES:
                 location = response.getheader("Location")
                 if not location:
@@ -252,7 +257,7 @@ def _follow_redirects(url, label):
                 url = urllib.parse.urljoin(url, location)
                 continue
 
-            if response.status != 200:
+            if response.status not in (200, 206):
                 raise RuntimeError(
                     f"Download failed for {label} (status {response.status})"
                 )
@@ -269,9 +274,52 @@ def _follow_redirects(url, label):
     raise RuntimeError(f"Too many redirects while downloading {label}")
 
 
-def _stream_to_file(response, target_file, total_size, progress_callback, hasher=None):
-    downloaded_til_now = 0
-    with open(target_file, "wb") as file_buffer:
+def _resumable_partial_size(target_file, expected_size):
+    """Bytes of `target_file` already on disk that a Range request can resume from.
+
+    Returns 0 (start fresh) when nothing exists yet, or when a known
+    `expected_size` shows the leftover is stale/complete already.
+    """
+    if not os.path.exists(target_file):
+        return 0
+    existing_size = os.path.getsize(target_file)
+    if expected_size and existing_size >= expected_size:
+        return 0
+    return existing_size
+
+
+CONTENT_RANGE_TOTAL_REGEX = re.compile(r"bytes \d+-\d+/(\d+)")
+
+
+def _archive_total_size(response, resume_offset):
+    """The archive's full size, for a request that may itself be a resume.
+
+    A 206 reports only the remaining bytes via Content-Length, so the total
+    comes from Content-Range's `.../<total>` instead; a fresh 200 reports the
+    full size directly.
+    """
+    if response.status == 206:
+        match = CONTENT_RANGE_TOTAL_REGEX.match(response.getheader("Content-Range", ""))
+        return int(match.group(1)) if match else resume_offset
+    return int(response.getheader("Content-Length", 0))
+
+
+def _stream_to_file(
+    response, target_file, total_size, progress_callback, hasher=None, resume_offset=0
+):
+    """Streams `response` into `target_file`, resuming a prior partial download.
+
+    A resume is only honored when the server actually answered with 206 —
+    a 200 despite a Range request means it sent the full body from byte 0,
+    so any partial bytes already on disk are discarded and hashed anew.
+    """
+    is_resuming = resume_offset > 0 and response.status == 206
+    downloaded_til_now = resume_offset if is_resuming else 0
+    if is_resuming and hasher is not None:
+        with open(target_file, "rb") as existing:
+            for chunk in iter(partial(existing.read, DOWNLOAD_CHUNK_SIZE), b""):
+                hasher.update(chunk)
+    with open(target_file, "ab" if is_resuming else "wb") as file_buffer:
         for chunk in iter(partial(response.read, DOWNLOAD_CHUNK_SIZE), b""):
             file_buffer.write(chunk)
             if hasher is not None:
@@ -289,7 +337,9 @@ class _BaseVoiceDownloader:
     def __init__(self, voice: PiperVoice, success_callback):
         self.voice = voice
         self.success_callback = success_callback
-        self.temp_download_dir = tempfile.TemporaryDirectory()
+        # Stable across instances, so _resumable_partial_size can find a prior attempt's file here.
+        self.download_dir = os.path.join(DENGJEN_VOICES_DIR, ".downloads", voice.key)
+        os.makedirs(self.download_dir, exist_ok=True)
         self.progress_dialog = None
 
     def update_progress(self, progress):
@@ -338,6 +388,7 @@ class _BaseVoiceDownloader:
         del self.progress_dialog
 
         if not has_error:
+            shutil.rmtree(self.download_dir, ignore_errors=True)
             self.success_callback()
             retval = gui.messageBox(
                 self._success_message(),
@@ -413,7 +464,7 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
                 _("Downloading file: {file}").format(file=file.name),
             )
             result = self._do_download_file(
-                file, self.temp_download_dir.name, self.update_progress
+                file, self.download_dir, self.update_progress
             )
             retvals.append(result)
 
@@ -424,22 +475,35 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
         target_file = os.path.join(download_dir, file.file_path.replace("/", os.sep))
         os.makedirs(os.path.dirname(target_file), exist_ok=True)
 
+        resume_offset = _resumable_partial_size(target_file, file.size_in_bytes)
+        headers = {"Range": f"bytes={resume_offset}-"} if resume_offset else None
+
         hasher = md5(usedforsecurity=False)
-        with _follow_redirects(file.download_url, file.file_path) as response:
+        with _follow_redirects(
+            file.download_url, file.file_path, headers=headers
+        ) as response:
             _stream_to_file(
                 response,
                 target_file,
                 file.size_in_bytes,
                 progress_callback,
                 hasher,
+                resume_offset=resume_offset,
             )
 
         return (file, target_file, hasher.hexdigest())
 
     def _install(self, result):
-        hashes = {file.name: (file.md5hash, md5hash) for (file, __, md5hash) in result}
-        if not all(expected == actual for expected, actual in hashes.values()):
-            log.error("File hashes do not match")
+        mismatched = [
+            (file, target_file)
+            for file, target_file, md5hash in result
+            if file.md5hash != md5hash
+        ]
+        if mismatched:
+            log.error(f"File hashes do not match: {[f.name for f, __ in mismatched]}")
+            for __, target_file in mismatched:
+                # Otherwise the next attempt would "resume" from corrupt bytes.
+                Path(target_file).unlink(missing_ok=True)
             raise _VoiceInstallError
 
         voice_dir = Path(DENGJEN_VOICES_DIR).joinpath(self.voice.key)
@@ -503,7 +567,7 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
         result = self._do_download_archive(
             self.rt_download_url,
             voice_name,
-            self.temp_download_dir.name,
+            self.download_dir,
             self.update_progress,
         )
         return result
@@ -513,19 +577,29 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
         cls, download_url, voice_name, download_dir, progress_callback
     ):
         target_file = os.path.join(download_dir, voice_name)
-        with _follow_redirects(download_url, voice_name) as response:
+        resume_offset = _resumable_partial_size(target_file, expected_size=0)
+        headers = {"Range": f"bytes={resume_offset}-"} if resume_offset else None
+
+        with _follow_redirects(download_url, voice_name, headers=headers) as response:
+            expected_size = _archive_total_size(response, resume_offset)
             _stream_to_file(
                 response,
                 target_file,
-                int(response.getheader("Content-Length", 0)),
+                expected_size,
                 progress_callback,
+                resume_offset=resume_offset,
             )
 
-        return target_file
+        return target_file, expected_size
 
     def _install(self, result):
+        target_file, expected_size = result
+        if expected_size and os.path.getsize(target_file) != expected_size:
+            log.error("Downloaded archive size does not match the expected size")
+            Path(target_file).unlink(missing_ok=True)
+            raise _VoiceInstallError
         try:
-            install_voice_from_tar_archive(result, DENGJEN_VOICES_DIR)
+            install_voice_from_tar_archive(target_file, DENGJEN_VOICES_DIR)
         except Exception:
             log.exception("Failed to extract voice archive", exc_info=True)
             raise _VoiceInstallError

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -1219,6 +1219,7 @@ class TestPiperRTVoiceDownloader:
 
         downloader.done_callback((str(not_a_tar), not_a_tar.stat().st_size))
 
+        assert not not_a_tar.exists()
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -658,6 +658,104 @@ class TestCertVerificationFallback:
         assert isinstance(context, ssl.SSLContext)
 
 
+class TestResumablePartialSize:
+    """`_resumable_partial_size` decides whether a leftover file from a
+    previous attempt is safe to resume from (issue #167)."""
+
+    def test_returns_zero_when_no_partial_exists(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        assert voice_download._resumable_partial_size(str(target), 100) == 0
+
+    def test_returns_existing_size_when_smaller_than_expected(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"x" * 40)
+        assert voice_download._resumable_partial_size(str(target), 100) == 40
+
+    def test_discards_a_partial_at_or_past_the_expected_size(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"x" * 100)
+        assert voice_download._resumable_partial_size(str(target), 100) == 0
+
+    def test_resumes_regardless_of_size_when_expected_size_is_unknown(self, tmp_path):
+        target = tmp_path / "voice.tar.gz"
+        target.write_bytes(b"x" * 100)
+        assert voice_download._resumable_partial_size(str(target), 0) == 100
+
+
+class TestStreamToFileResume:
+    """`_stream_to_file` appends to a partial file when the server honors the
+    Range request (206), and restarts from scratch when it doesn't (issue #167)."""
+
+    def test_appends_and_extends_the_hash_when_the_server_sends_206(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"already-")
+        response = _FakeResponse(status=206, body=b"downloaded")
+        hasher = hashlib.md5(usedforsecurity=False)
+
+        voice_download._stream_to_file(
+            response, str(target), 18, MagicMock(), hasher, resume_offset=8
+        )
+
+        assert target.read_bytes() == b"already-downloaded"
+        assert hasher.hexdigest() == hashlib.md5(b"already-downloaded").hexdigest()
+
+    def test_overwrites_from_scratch_when_the_server_ignores_the_range(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"stale-partial-bytes")
+        response = _FakeResponse(status=200, body=b"full-body")
+        hasher = hashlib.md5(usedforsecurity=False)
+
+        voice_download._stream_to_file(
+            response, str(target), 9, MagicMock(), hasher, resume_offset=20
+        )
+
+        assert target.read_bytes() == b"full-body"
+        assert hasher.hexdigest() == hashlib.md5(b"full-body").hexdigest()
+
+
+class TestFollowRedirectsRangeSupport:
+    """`_follow_redirects` forwards a Range header for resumed downloads and
+    accepts 206 Partial Content as a terminal (non-redirect) status (issue #167)."""
+
+    def test_forwards_headers_to_the_underlying_request(self, monkeypatch):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=b"rest-of-file",
+                ),
+            ]
+        )
+        monkeypatch.setattr(voice_download, "request", fake_request)
+
+        with voice_download._follow_redirects(
+            "https://example.com/voice.onnx",
+            "voice.onnx",
+            headers={"Range": "bytes=8-"},
+        ) as response:
+            assert response.read() == b"rest-of-file"
+
+        assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=8-"}
+
+    def test_accepts_206_as_a_terminal_status(self, monkeypatch):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=b"rest-of-file",
+                ),
+            ]
+        )
+        monkeypatch.setattr(voice_download, "request", fake_request)
+
+        with voice_download._follow_redirects(
+            "https://example.com/voice.onnx", "voice.onnx"
+        ) as response:
+            assert response.status == 206
+
+
 class TestPiperVoiceDownloaderFileTransfer:
     """`_do_download_file` is where redirect/content-type/hash bugs would
     actually surface — HuggingFace serves every file through a redirect."""
@@ -758,6 +856,63 @@ class TestPiperVoiceDownloaderFileTransfer:
         with pytest.raises(RuntimeError, match="Download failed"):
             PiperVoiceDownloader._do_download_file(file, str(tmp_path), callback)
 
+    def test_resumes_a_partial_file_by_sending_a_range_header(
+        self, tmp_path, monkeypatch
+    ):
+        already = b"piper-mod"
+        rest = b"el-bytes"
+        body = already + rest
+        (tmp_path / "en").mkdir()
+        (tmp_path / "en" / "en_US-lessac-medium.onnx").write_bytes(already)
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=rest,
+                ),
+            ]
+        )
+        monkeypatch.setattr(voice_download, "request", fake_request)
+        file = self._file(body)
+
+        __, target, digest = PiperVoiceDownloader._do_download_file(
+            file, str(tmp_path), MagicMock()
+        )
+
+        with open(target, "rb") as f:
+            assert f.read() == body
+        assert digest == hashlib.md5(body).hexdigest()
+        assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=9-"}
+
+    def test_discards_a_stale_partial_at_or_past_the_expected_size(
+        self, tmp_path, monkeypatch
+    ):
+        body = b"piper-model-bytes"
+        (tmp_path / "en").mkdir()
+        target_path = tmp_path / "en" / "en_US-lessac-medium.onnx"
+        target_path.write_bytes(b"x" * len(body))
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=body,
+                ),
+            ]
+        )
+        monkeypatch.setattr(voice_download, "request", fake_request)
+        file = self._file(body)
+
+        __, target, digest = PiperVoiceDownloader._do_download_file(
+            file, str(tmp_path), MagicMock()
+        )
+
+        with open(target, "rb") as f:
+            assert f.read() == body
+        assert digest == hashlib.md5(body).hexdigest()
+        assert fake_request.yield_calls[0]["headers"] is None
+
     def test_download_voice_files_collects_a_result_per_file(
         self, tmp_path, monkeypatch
     ):
@@ -785,6 +940,46 @@ class TestPiperVoiceDownloaderFileTransfer:
         results = downloader.download_voice_files()
         assert len(results) == 2
         assert downloader.progress_dialog.Update.called
+
+
+class TestBaseVoiceDownloaderDownloadDir:
+    """A stable, voice-keyed download directory (not a fresh temp dir per
+    attempt) is what lets a partial file survive to the next retry (issue #167)."""
+
+    def test_creates_a_stable_download_directory_under_the_voices_dir(
+        self, tmp_path, monkeypatch
+    ):
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        voice = _piper_voice(key="en_US-lessac-medium")
+
+        downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
+
+        expected_dir = voices_dir / ".downloads" / "en_US-lessac-medium"
+        assert downloader.download_dir == str(expected_dir)
+        assert expected_dir.is_dir()
+
+    def test_removes_the_download_directory_after_a_successful_install(
+        self, tmp_path, monkeypatch
+    ):
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        voice = _piper_voice(key="en_US-lessac-medium")
+        downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
+        downloader.progress_dialog = MagicMock()
+        body = b"model-bytes"
+        src = tmp_path / "downloaded.onnx"
+        src.write_bytes(body)
+        digest = hashlib.md5(body).hexdigest()
+        file = PiperVoiceFile(
+            file_path="en/en_US-lessac-medium.onnx",
+            size_in_bytes=len(body),
+            md5hash=digest,
+        )
+
+        downloader.done_callback([(file, str(src), digest)])
+
+        assert not os.path.exists(downloader.download_dir)
 
 
 class TestPiperVoiceDownloaderDoneCallback:
@@ -836,10 +1031,48 @@ class TestPiperVoiceDownloaderDoneCallback:
 
         downloader.done_callback([(file, src, "mismatched-hash")])
 
-        assert not voices_dir.exists()
+        assert not (voices_dir / "en_US-lessac-medium").exists()
+        assert os.path.isdir(downloader.download_dir)
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
         assert "Cannot download" in messagebox_mock.call_args.args[0]
+
+    def test_hash_mismatch_deletes_only_the_offending_partial(
+        self, tmp_path, monkeypatch
+    ):
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(voice_download.gui, "messageBox", MagicMock())
+
+        voice = _piper_voice(key="en_US-lessac-medium")
+        downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
+        downloader.progress_dialog = MagicMock()
+
+        good_body, bad_body = b"good-bytes", b"bad-bytes"
+        good_src = os.path.join(downloader.download_dir, "good.onnx")
+        bad_src = os.path.join(downloader.download_dir, "bad.onnx")
+        with open(good_src, "wb") as f:
+            f.write(good_body)
+        with open(bad_src, "wb") as f:
+            f.write(bad_body)
+        good_file = PiperVoiceFile(
+            file_path="en/good.onnx",
+            size_in_bytes=len(good_body),
+            md5hash=hashlib.md5(good_body).hexdigest(),
+        )
+        bad_file = PiperVoiceFile(
+            file_path="en/bad.onnx", size_in_bytes=len(bad_body), md5hash="mismatched"
+        )
+
+        downloader.done_callback(
+            [
+                (good_file, good_src, hashlib.md5(good_body).hexdigest()),
+                (bad_file, bad_src, hashlib.md5(bad_body).hexdigest()),
+            ]
+        )
+
+        assert not os.path.exists(bad_src)
+        assert os.path.exists(good_src)
 
     def test_copy_failure_reports_failure_without_crashing(self, tmp_path, monkeypatch):
         voices_dir = tmp_path / "voices"
@@ -860,7 +1093,7 @@ class TestPiperVoiceDownloaderDoneCallback:
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 
-    def test_an_exception_result_is_reported_without_touching_disk(
+    def test_an_exception_result_is_reported_without_installing_anything(
         self, tmp_path, monkeypatch
     ):
         voices_dir = tmp_path / "voices"
@@ -874,7 +1107,7 @@ class TestPiperVoiceDownloaderDoneCallback:
 
         downloader.done_callback(RuntimeError("network exploded"))
 
-        assert not voices_dir.exists()
+        assert not (voices_dir / "en_US-lessac-medium").exists()
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 
@@ -896,7 +1129,7 @@ class TestPiperRTVoiceDownloader:
             ]
         )
         monkeypatch.setattr(voice_download, "request", fake_request)
-        target = PiperRTVoiceDownloader._do_download_archive(
+        target, expected_size = PiperRTVoiceDownloader._do_download_archive(
             "https://example.com/voice.tar.gz",
             "voice.tar.gz",
             str(tmp_path),
@@ -904,6 +1137,38 @@ class TestPiperRTVoiceDownloader:
         )
         with open(target, "rb") as f:
             assert f.read() == body
+        assert expected_size == len(body)
+
+    def test_do_download_archive_resumes_a_partial_by_sending_a_range_header(
+        self, tmp_path, monkeypatch
+    ):
+        already, rest = b"archive-", b"bytes"
+        (tmp_path / "voice.tar.gz").write_bytes(already)
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={
+                        "Content-Type": "application/octet-stream",
+                        "Content-Range": f"bytes 8-12/{len(already) + len(rest)}",
+                    },
+                    body=rest,
+                ),
+            ]
+        )
+        monkeypatch.setattr(voice_download, "request", fake_request)
+
+        target, expected_size = PiperRTVoiceDownloader._do_download_archive(
+            "https://example.com/voice.tar.gz",
+            "voice.tar.gz",
+            str(tmp_path),
+            MagicMock(),
+        )
+
+        with open(target, "rb") as f:
+            assert f.read() == already + rest
+        assert expected_size == len(already) + len(rest)
+        assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=8-"}
 
     def test_success_installs_the_archive_and_offers_a_restart(
         self, tmp_path, monkeypatch
@@ -929,7 +1194,7 @@ class TestPiperRTVoiceDownloader:
         downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
         downloader.progress_dialog = MagicMock()
 
-        downloader.done_callback(str(tar_path))
+        downloader.done_callback((str(tar_path), tar_path.stat().st_size))
 
         installed = (
             voices_dir / "en_US-lessac+RT-medium" / "en_US-lessac+RT-medium.onnx"
@@ -952,8 +1217,28 @@ class TestPiperRTVoiceDownloader:
         downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
         downloader.progress_dialog = MagicMock()
 
-        downloader.done_callback(str(not_a_tar))
+        downloader.done_callback((str(not_a_tar), not_a_tar.stat().st_size))
 
+        downloader.success_callback.assert_not_called()
+        messagebox_mock.assert_called_once()
+
+    def test_size_mismatch_does_not_install_and_deletes_the_partial(
+        self, tmp_path, monkeypatch
+    ):
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        messagebox_mock = MagicMock()
+        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+
+        archive = tmp_path / "truncated.tar.gz"
+        archive.write_bytes(b"only-part-of-the-archive")
+        voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
+        downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
+        downloader.progress_dialog = MagicMock()
+
+        downloader.done_callback((str(archive), archive.stat().st_size + 1000))
+
+        assert not archive.exists()
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 
@@ -1122,7 +1407,7 @@ class TestVoiceJsonSidecarWrittenOnInstall:
         )
         downloader = PiperVoiceDownloader(voice, success_callback=lambda: None)
         onnx_file = voice.files[0]
-        src = os.path.join(downloader.temp_download_dir.name, onnx_file.name)
+        src = os.path.join(downloader.download_dir, onnx_file.name)
         with open(src, "wb") as f:
             f.write(b"\x00\x01\x02\x03")
 


### PR DESCRIPTION
Closes #167.

## Summary

A dropped connection mid-download forced a full restart: `_stream_to_file` wrote into a fresh temp file with no HTTP Range support, and `_BaseVoiceDownloader` allocated a new `tempfile.TemporaryDirectory()` per attempt. Voice archives run tens of MB to low-GB, so on a slow or flaky connection this could make a large voice practically undownloadable. Downloads now persist to a stable directory and resume via Range on the next manual retry.

## Changes

- `_BaseVoiceDownloader` persists to `DENGJEN_VOICES_DIR/.downloads/<voice_key>/` instead of a fresh temp dir, so a partial file survives to the next retry; removed on a successful install.
- `_stream_to_file` resumes via `Range` when the server answers `206`, and restarts from scratch if it answers `200` instead (server ignored the Range).
- `_follow_redirects`/`_yield_response_with_cert_fallback` forward a `headers=` kwarg and accept `206` as a terminal status.
- Standard voice files keep validating against the catalog's md5 (now correctly seeded across a resume, in `PiperVoiceDownloader`); a mismatch deletes only that file, so the next attempt redownloads just it, not the whole voice.
- The RT archive (no catalog hash available for it) validates against the expected size instead, derived from `Content-Range`'s total on a resumed request or `Content-Length` on a fresh one.

## Test plan

- [x] Syntax check passes (`ruff check`, `ruff format --check`).
- [ ] CI build + test green.
- [x] `pytest tests/` — 473 passed, 17 skipped (full stub-based suite on Linux).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Voice downloads can now resume after an interruption instead of restarting from the beginning.
  - Download progress is retained during transfers, improving recovery from network interruptions.

- **Bug Fixes**
  - Improved handling of partial download responses and redirected requests.
  - Added verification to detect incomplete or corrupted voice files and archives before installation.
  - Stale or mismatched partial downloads are removed automatically when they cannot be safely resumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->