### PR TITLE
fix: retry wait_until past a transient RpcError instead of aborting

### DIFF
--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -19,6 +19,9 @@ from typing import Any
 
 import pytest
 
+if sys.platform == "win32":
+    from nvda_testkit.errors import AuthError, RpcError
+
 collect_ignore_glob = [] if sys.platform == "win32" else ["test_*.py"]
 
 
@@ -74,15 +77,29 @@ def wait_until(
     state" primitive -- speech.wait_for/log.wait_for only see NVDA's own
     speech and log output, which a background thread silently filling a
     wx.Choice never produces. This is the fallback for exactly that case.
+
+    A predicate built on voice_manager_state can raise RpcError if it catches
+    NVDA between two windows (e.g. next() over GetTopLevelWindows() finding
+    none yet) -- treated as "not ready" like a falsy return. AuthError, a
+    stale-token RpcError subclass no amount of retrying fixes, still raises
+    immediately.
     """
     deadline = time.monotonic() + timeout
     last: Any = None
     while time.monotonic() < deadline:
-        last = predicate()
-        if last:
-            return last
+        try:
+            last = predicate()
+        except AuthError:
+            raise
+        except RpcError as exc:
+            last = exc
+        else:
+            if last:
+                return last
         time.sleep(interval)
-    raise AssertionError(f"timed out waiting for {description}; last seen: {last!r}")
+    raise AssertionError(
+        f"timed out waiting for {description}; last seen: {last!r}"
+    ) from (last if isinstance(last, Exception) else None)
 
 
 def voice_manager_state(nvda, expr: str) -> Any:

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -86,6 +86,7 @@ def wait_until(
     """
     deadline = time.monotonic() + timeout
     last: Any = None
+    last_rpc_error: RpcError | None = None
     while time.monotonic() < deadline:
         try:
             last = predicate()
@@ -93,13 +94,14 @@ def wait_until(
             raise
         except RpcError as exc:
             last = exc
+            last_rpc_error = exc
         else:
             if last:
                 return last
         time.sleep(interval)
     raise AssertionError(
         f"timed out waiting for {description}; last seen: {last!r}"
-    ) from (last if isinstance(last, Exception) else None)
+    ) from last_rpc_error
 
 
 def voice_manager_state(nvda, expr: str) -> Any:

--- a/tests_e2e/test_wait_until.py
+++ b/tests_e2e/test_wait_until.py
@@ -49,6 +49,26 @@ def test_times_out_with_the_last_rpc_error_attached(monkeypatch):
     assert excinfo.value.__cause__ is exc
 
 
+def test_a_later_falsy_result_does_not_drop_an_earlier_rpc_error(monkeypatch):
+    exc = RpcError("NVDA between windows")
+    attempts = iter([exc, False])
+
+    def predicate():
+        item = next(attempts)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    clock = iter([0, 0, 0, 10])
+    monkeypatch.setattr("time.monotonic", lambda: next(clock))
+
+    with pytest.raises(AssertionError) as excinfo:
+        wait_until(predicate, timeout=5, description="the flaky state")
+
+    assert excinfo.value.__cause__ is exc
+
+
 def test_an_auth_error_is_not_retried(monkeypatch):
     exc = AuthError("stale token")
     calls = 0

--- a/tests_e2e/test_wait_until.py
+++ b/tests_e2e/test_wait_until.py
@@ -1,0 +1,66 @@
+"""Regression coverage for wait_until's RpcError tolerance (issue #174).
+
+Pure-Python: wait_until only ever calls the predicate it's given, so these
+drive it with fakes instead of a real NVDA -- unlike test_voice_manager.py,
+nothing here needs the nvda fixture.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+if sys.platform == "win32":
+    from nvda_testkit.errors import AuthError, RpcError
+
+from .conftest import wait_until
+
+
+def test_retries_past_a_transient_rpc_error(monkeypatch):
+    attempts = iter(
+        [RpcError("NVDA between windows"), RpcError("still between"), "ready"]
+    )
+
+    def predicate():
+        item = next(attempts)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    assert wait_until(predicate, timeout=5, description="the flaky state") == "ready"
+
+
+def test_times_out_with_the_last_rpc_error_attached(monkeypatch):
+    exc = RpcError("NVDA between windows")
+
+    def predicate():
+        raise exc
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+    clock = iter([0, 0, 10])
+    monkeypatch.setattr("time.monotonic", lambda: next(clock))
+
+    with pytest.raises(AssertionError, match="the flaky state") as excinfo:
+        wait_until(predicate, timeout=5, description="the flaky state")
+
+    assert excinfo.value.__cause__ is exc
+
+
+def test_an_auth_error_is_not_retried(monkeypatch):
+    exc = AuthError("stale token")
+    calls = 0
+
+    def predicate():
+        nonlocal calls
+        calls += 1
+        raise exc
+
+    monkeypatch.setattr("time.sleep", lambda _seconds: None)
+
+    with pytest.raises(AuthError):
+        wait_until(predicate, timeout=5, description="a fresh NVDA connection")
+
+    assert calls == 1


### PR DESCRIPTION
Closes #174.

## Summary

`wait_until`'s polling loop propagated any exception from `predicate()` immediately instead of treating it as "not ready yet." A predicate built on `voice_manager_state` (e.g. `_VOICE_MANAGER_DIALOG`'s `next(w for w in wx.GetTopLevelWindows() if hasattr(w, 'notebookCtrl'))`) can raise `RpcError` if it catches NVDA between two windows mid dialog-transition — a single unlucky poll aborted the whole wait. This became reachable once #173 made the Kokoro install path actually complete fast enough for a real dialog transition to land mid-poll.

## Changes

- `tests_e2e/conftest.py`: `wait_until` now catches `RpcError` and keeps polling, recording it as `last` so a genuinely-stuck predicate still reports something useful on timeout (chained via `from`). `AuthError` (a stale-token `RpcError` subclass — "almost always a stale NVDA from a previous run," per the testkit's own docstring) still raises immediately, since retrying can't fix it.
- `tests_e2e/test_wait_until.py` (new): three regression tests against fake predicates — retries past transient `RpcError`s to success, times out with the last `RpcError` attached as `__cause__`, and confirms `AuthError` is not retried.

## Test plan

- [x] Syntax check passes (`ruff check`, `ruff format --check`).
- [ ] CI build + test green.
- [x] Logic sanity-checked against a standalone script with a matching fake exception hierarchy (all three cases behave as intended) — `tests_e2e/` itself can't run outside Windows CI (excluded from local collection entirely, and this repo's own CONTRIBUTING.md treats it as CI-only even on a Windows dev machine), so the new test's first real run is this PR's e2e job.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry handling for transient RPC errors when waiting for conditions.
  - Authentication errors now surface immediately instead of being retried.
  - Timeout failures retain the final RPC error to provide clearer diagnostics.

- **Tests**
  - Added regression coverage for retry behavior, timeout error reporting, and immediate authentication-error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->