### PR TITLE
feat: ship a bundled voice catalog for offline first runs

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -42,6 +42,9 @@ PIPER_VOICE_DOWNLOAD_URL_PREFIX = (
 )
 PIPER_SAMPLES_URL_PREFIX = "https://rhasspy.github.io/piper-samples/samples"
 PIPER_VOICES_JSON_LOCAL_CACHE = os.path.join(DENGJEN_VOICES_DIR, "piper-voices.json")
+# Snapshot refreshed by update_voice_catalog.py before each release; lets
+# get_available_voices() serve a catalog offline on first run.
+BUNDLED_PIPER_VOICES_JSON = os.path.join(helpers.DATA_DIRECTORY, "piper-voices.json")
 RT_VOICE_LIST_URL = (
     "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
 )
@@ -732,10 +735,16 @@ def _select_not_installed_voices(voices):
     return not_installed
 
 
-def _get_voices_from_cache():
-    """Return the not-installed voices from the on-disk cache, or None if unreadable."""
+def _get_voices_from_cache(path=None):
+    """Return the not-installed voices from a piper-voices.json file, or None if unreadable.
+
+    Defaults to the on-disk user cache; also used to read the bundled
+    fallback catalog by passing BUNDLED_PIPER_VOICES_JSON.
+    """
+    if path is None:
+        path = PIPER_VOICES_JSON_LOCAL_CACHE
     try:
-        with open(PIPER_VOICES_JSON_LOCAL_CACHE, "rb") as file:
+        with open(path, "rb") as file:
             voices = json.load(file)
     except Exception:
         log.exception("Failed to get voices from local file", exc_info=True)
@@ -763,7 +772,17 @@ def get_available_voices(force_online=False):
         cached_voices = _get_voices_from_cache()
         if cached_voices is not None:
             return cached_voices
-    _refresh_voices_cache()
+    try:
+        _refresh_voices_cache()
+    except Exception:
+        # An explicit "Refresh" request should surface the failure rather
+        # than silently serving a stale bundled snapshot.
+        if force_online:
+            raise
+        bundled_voices = _get_voices_from_cache(BUNDLED_PIPER_VOICES_JSON)
+        if bundled_voices is not None:
+            return bundled_voices
+        raise
     voices = _get_voices_from_cache()
     if voices is None:
         raise RuntimeError("Failed to read the voice list cache that was just written")

--- a/addon/synthDrivers/dengjen_neural_voices/data/piper-voices.json
+++ b/addon/synthDrivers/dengjen_neural_voices/data/piper-voices.json
@@ -1,0 +1,7043 @@
+{
+  "ar_JO-kareem-low": {
+    "key": "ar_JO-kareem-low",
+    "name": "kareem",
+    "language": {
+      "code": "ar_JO",
+      "family": "ar",
+      "region": "JO",
+      "name_native": "العربية",
+      "name_english": "Arabic",
+      "country_english": "Jordan"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ar/ar_JO/kareem/low/ar_JO-kareem-low.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "d335cd06fe4045a7ee9d8fb0712afaa9"
+      },
+      "ar/ar_JO/kareem/low/ar_JO-kareem-low.onnx.json": {
+        "size_bytes": 5022,
+        "md5_digest": "465724f7d2d5f2ff061b53acb8e7f7cc"
+      },
+      "ar/ar_JO/kareem/low/MODEL_CARD": {
+        "size_bytes": 274,
+        "md5_digest": "b6f0eaf5a7fd094be22a1bcb162173fb"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ar_JO-kareem-medium": {
+    "key": "ar_JO-kareem-medium",
+    "name": "kareem",
+    "language": {
+      "code": "ar_JO",
+      "family": "ar",
+      "region": "JO",
+      "name_native": "العربية",
+      "name_english": "Arabic",
+      "country_english": "Jordan"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ar/ar_JO/kareem/medium/ar_JO-kareem-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "c0697df8a7fb180079cc5ac523f91a8e"
+      },
+      "ar/ar_JO/kareem/medium/ar_JO-kareem-medium.onnx.json": {
+        "size_bytes": 5024,
+        "md5_digest": "dd70b31eb5a395907241b1e5367ace3a"
+      },
+      "ar/ar_JO/kareem/medium/MODEL_CARD": {
+        "size_bytes": 283,
+        "md5_digest": "9ec7a4a27b89946848dce9b7f5c53cfd"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ca_ES-upc_ona-medium": {
+    "key": "ca_ES-upc_ona-medium",
+    "name": "upc_ona",
+    "language": {
+      "code": "ca_ES",
+      "family": "ca",
+      "region": "ES",
+      "name_native": "Català",
+      "name_english": "Catalan",
+      "country_english": "Spain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ca/ca_ES/upc_ona/medium/ca_ES-upc_ona-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "58ff3b049b6b721a4c353a551ec5ef3a"
+      },
+      "ca/ca_ES/upc_ona/medium/ca_ES-upc_ona-medium.onnx.json": {
+        "size_bytes": 4875,
+        "md5_digest": "035e9eb642ab9fa1354f53a77877ae9b"
+      },
+      "ca/ca_ES/upc_ona/medium/MODEL_CARD": {
+        "size_bytes": 296,
+        "md5_digest": "395c782a56632400f46e7c442c7718bb"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ca_ES-upc_ona-x_low": {
+    "key": "ca_ES-upc_ona-x_low",
+    "name": "upc_ona",
+    "language": {
+      "code": "ca_ES",
+      "family": "ca",
+      "region": "ES",
+      "name_native": "Català",
+      "name_english": "Catalan",
+      "country_english": "Spain"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ca/ca_ES/upc_ona/x_low/ca_ES-upc_ona-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "ca22734cd8c5b01dd1fefbb42067ab06"
+      },
+      "ca/ca_ES/upc_ona/x_low/ca_ES-upc_ona-x_low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "82ccdadad1c203feaff8f77aef9087a3"
+      },
+      "ca/ca_ES/upc_ona/x_low/MODEL_CARD": {
+        "size_bytes": 258,
+        "md5_digest": "1f555643ff6f7d9133679d730f3f6016"
+      }
+    },
+    "aliases": [
+      "ca-upc_ona-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "ca_ES-upc_pau-x_low": {
+    "key": "ca_ES-upc_pau-x_low",
+    "name": "upc_pau",
+    "language": {
+      "code": "ca_ES",
+      "family": "ca",
+      "region": "ES",
+      "name_native": "Català",
+      "name_english": "Catalan",
+      "country_english": "Spain"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ca/ca_ES/upc_pau/x_low/ca_ES-upc_pau-x_low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "504e8a643d5284fbfc95e9e392288b86"
+      },
+      "ca/ca_ES/upc_pau/x_low/ca_ES-upc_pau-x_low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "0f6d8f5c3113d9443b9be1690c7a7d4c"
+      },
+      "ca/ca_ES/upc_pau/x_low/MODEL_CARD": {
+        "size_bytes": 258,
+        "md5_digest": "4ff8699c4439c9f49180457f0becc49e"
+      }
+    },
+    "aliases": [
+      "ca-upc_pau-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "cs_CZ-jirka-low": {
+    "key": "cs_CZ-jirka-low",
+    "name": "jirka",
+    "language": {
+      "code": "cs_CZ",
+      "family": "cs",
+      "region": "CZ",
+      "name_native": "Čeština",
+      "name_english": "Czech",
+      "country_english": "Czech Republic"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "cs/cs_CZ/jirka/low/cs_CZ-jirka-low.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "82b99b7adeaccf9fec011458623405b2"
+      },
+      "cs/cs_CZ/jirka/low/cs_CZ-jirka-low.onnx.json": {
+        "size_bytes": 5022,
+        "md5_digest": "a28c860a87620da2a44ccae38a915aee"
+      },
+      "cs/cs_CZ/jirka/low/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "a37afbc4197ab16ab6e2209e2ecc2ae0"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "cs_CZ-jirka-medium": {
+    "key": "cs_CZ-jirka-medium",
+    "name": "jirka",
+    "language": {
+      "code": "cs_CZ",
+      "family": "cs",
+      "region": "CZ",
+      "name_native": "Čeština",
+      "name_english": "Czech",
+      "country_english": "Czech Republic"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "cs/cs_CZ/jirka/medium/cs_CZ-jirka-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "da2deb0a3f93226a3f9b6e40d43c46ca"
+      },
+      "cs/cs_CZ/jirka/medium/cs_CZ-jirka-medium.onnx.json": {
+        "size_bytes": 5025,
+        "md5_digest": "2762e45c5b084694093c683a5da7cf94"
+      },
+      "cs/cs_CZ/jirka/medium/MODEL_CARD": {
+        "size_bytes": 281,
+        "md5_digest": "85a220211eadd9b89f3dc023d82966b4"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "cy_GB-bu_tts-medium": {
+    "key": "cy_GB-bu_tts-medium",
+    "name": "bu_tts",
+    "language": {
+      "code": "cy_GB",
+      "family": "cy",
+      "region": "GB",
+      "name_native": "Cymraeg",
+      "name_english": "Welsh",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 7,
+    "speaker_id_map": {
+      "benyw-de-pro": 0,
+      "benyw-gogledd-pro": 1,
+      "gwryw-gogledd-pro": 2,
+      "gwryw-gogledd-2": 3,
+      "gwryw-de-1": 4,
+      "gwryw-gogledd-1": 5,
+      "benyw-gogledd-1": 6
+    },
+    "files": {
+      "cy/cy_GB/bu_tts/medium/cy_GB-bu_tts-medium.onnx": {
+        "size_bytes": 77061326,
+        "md5_digest": "81827b7d290b9c478be3b22e07ee028e"
+      },
+      "cy/cy_GB/bu_tts/medium/cy_GB-bu_tts-medium.onnx.json": {
+        "size_bytes": 5145,
+        "md5_digest": "410fcba3c88586d4085be2efd8e57505"
+      },
+      "cy/cy_GB/bu_tts/medium/MODEL_CARD": {
+        "size_bytes": 295,
+        "md5_digest": "9d542d9dd85ce1925837a99200332bb5"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "cy_GB-gwryw_gogleddol-medium": {
+    "key": "cy_GB-gwryw_gogleddol-medium",
+    "name": "gwryw_gogleddol",
+    "language": {
+      "code": "cy_GB",
+      "family": "cy",
+      "region": "GB",
+      "name_native": "Cymraeg",
+      "name_english": "Welsh",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "cy/cy_GB/gwryw_gogleddol/medium/cy_GB-gwryw_gogleddol-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "76ca79c170b0048b190758c3609e9ab9"
+      },
+      "cy/cy_GB/gwryw_gogleddol/medium/cy_GB-gwryw_gogleddol-medium.onnx.json": {
+        "size_bytes": 4975,
+        "md5_digest": "d780e83a324e9ce8c73146b9d066a283"
+      },
+      "cy/cy_GB/gwryw_gogleddol/medium/MODEL_CARD": {
+        "size_bytes": 337,
+        "md5_digest": "39bd3ade08289afe1cb3f867aef957fa"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "da_DK-talesyntese-medium": {
+    "key": "da_DK-talesyntese-medium",
+    "name": "talesyntese",
+    "language": {
+      "code": "da_DK",
+      "family": "da",
+      "region": "DK",
+      "name_native": "Dansk",
+      "name_english": "Danish",
+      "country_english": "Denmark"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "9c05494a3e0c1136337581e01222395d"
+      },
+      "da/da_DK/talesyntese/medium/da_DK-talesyntese-medium.onnx.json": {
+        "size_bytes": 4878,
+        "md5_digest": "8a56843f52992e490f062e68c14fa193"
+      },
+      "da/da_DK/talesyntese/medium/MODEL_CARD": {
+        "size_bytes": 308,
+        "md5_digest": "628cc03fca8f5d2c454824d6252955ad"
+      }
+    },
+    "aliases": [
+      "da-nst_talesyntese-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "de_DE-eva_k-x_low": {
+    "key": "de_DE-eva_k-x_low",
+    "name": "eva_k",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/eva_k/x_low/de_DE-eva_k-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "51bfc52a58282c2e4fc01ae66567a708"
+      },
+      "de/de_DE/eva_k/x_low/de_DE-eva_k-x_low.onnx.json": {
+        "size_bytes": 4158,
+        "md5_digest": "2034ba7a991ac47d911c98ee4844fc90"
+      },
+      "de/de_DE/eva_k/x_low/MODEL_CARD": {
+        "size_bytes": 246,
+        "md5_digest": "02b01f3d47b2798ece347b2c7e94c9e9"
+      }
+    },
+    "aliases": [
+      "de-eva_k-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-karlsson-low": {
+    "key": "de_DE-karlsson-low",
+    "name": "karlsson",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/karlsson/low/de_DE-karlsson-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "c94b5b8e8c7147b4b2c4a19ca5a3c41b"
+      },
+      "de/de_DE/karlsson/low/de_DE-karlsson-low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "34efeb531752d0a71ef52eb46600d7bd"
+      },
+      "de/de_DE/karlsson/low/MODEL_CARD": {
+        "size_bytes": 289,
+        "md5_digest": "6e2f3eec10cf7fceb0b68b67eccd06a4"
+      }
+    },
+    "aliases": [
+      "de-karlsson-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-kerstin-low": {
+    "key": "de_DE-kerstin-low",
+    "name": "kerstin",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/kerstin/low/de_DE-kerstin-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "1d5e5788cfddb04cbb34418f2841931e"
+      },
+      "de/de_DE/kerstin/low/de_DE-kerstin-low.onnx.json": {
+        "size_bytes": 4158,
+        "md5_digest": "a96995af6c1c5b37ed3d62b5107e1d9a"
+      },
+      "de/de_DE/kerstin/low/MODEL_CARD": {
+        "size_bytes": 272,
+        "md5_digest": "69ec1bc99fc7e19c9ddcdf712920a6c7"
+      }
+    },
+    "aliases": [
+      "de-kerstin-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-mls-medium": {
+    "key": "de_DE-mls-medium",
+    "name": "mls",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "medium",
+    "num_speakers": 236,
+    "speaker_id_map": {
+      "2422": 0,
+      "4536": 1,
+      "2037": 2,
+      "9565": 3,
+      "10148": 4,
+      "6507": 5,
+      "5055": 6,
+      "3503": 7,
+      "252": 8,
+      "9132": 9,
+      "3990": 10,
+      "5753": 11,
+      "5424": 12,
+      "2602": 13,
+      "4174": 14,
+      "3885": 15,
+      "12415": 16,
+      "8470": 17,
+      "11927": 18,
+      "9639": 19,
+      "3494": 20,
+      "2946": 21,
+      "5283": 22,
+      "4533": 23,
+      "2497": 24,
+      "12275": 25,
+      "1649": 26,
+      "146": 27,
+      "8337": 28,
+      "4542": 29,
+      "589": 30,
+      "1998": 31,
+      "3797": 32,
+      "5244": 33,
+      "7328": 34,
+      "7998": 35,
+      "10179": 36,
+      "9610": 37,
+      "20": 38,
+      "253": 39,
+      "12899": 40,
+      "7194": 41,
+      "3759": 42,
+      "2677": 43,
+      "6719": 44,
+      "1897": 45,
+      "11990": 46,
+      "6880": 47,
+      "19": 48,
+      "9515": 49,
+      "327": 50,
+      "3244": 51,
+      "5324": 52,
+      "2234": 53,
+      "3124": 54,
+      "2043": 55,
+      "143": 56,
+      "8139": 57,
+      "9646": 58,
+      "8659": 59,
+      "9538": 60,
+      "989": 61,
+      "5405": 62,
+      "10087": 63,
+      "8294": 64,
+      "4396": 65,
+      "1474": 66,
+      "139": 67,
+      "136": 68,
+      "10791": 69,
+      "7242": 70,
+      "3631": 71,
+      "9908": 72,
+      "7906": 73,
+      "1171": 74,
+      "7479": 75,
+      "5632": 76,
+      "3731": 77,
+      "4650": 78,
+      "135": 79,
+      "145": 80,
+      "137": 81,
+      "1757": 82,
+      "91": 83,
+      "9514": 84,
+      "13494": 85,
+      "1946": 86,
+      "3277": 87,
+      "5595": 88,
+      "278": 89,
+      "7120": 90,
+      "7406": 91,
+      "11695": 92,
+      "1593": 93,
+      "3862": 94,
+      "138": 95,
+      "141": 96,
+      "9948": 97,
+      "1163": 98,
+      "1054": 99,
+      "1844": 100,
+      "4911": 101,
+      "7261": 102,
+      "8223": 103,
+      "7624": 104,
+      "144": 105,
+      "13871": 106,
+      "2974": 107,
+      "5934": 108,
+      "7002": 109,
+      "8769": 110,
+      "3363": 111,
+      "3040": 112,
+      "6067": 113,
+      "9494": 114,
+      "8743": 115,
+      "13255": 116,
+      "1660": 117,
+      "3588": 118,
+      "4748": 119,
+      "8450": 120,
+      "5295": 121,
+      "4705": 122,
+      "8125": 123,
+      "7272": 124,
+      "7320": 125,
+      "1874": 126,
+      "1262": 127,
+      "10870": 128,
+      "12379": 129,
+      "4463": 130,
+      "10349": 131,
+      "2252": 132,
+      "8325": 133,
+      "3052": 134,
+      "4001": 135,
+      "7456": 136,
+      "140": 137,
+      "4739": 138,
+      "11299": 139,
+      "4730": 140,
+      "6659": 141,
+      "2034": 142,
+      "2732": 143,
+      "2158": 144,
+      "3698": 145,
+      "5675": 146,
+      "6315": 147,
+      "10904": 148,
+      "7202": 149,
+      "11480": 150,
+      "10625": 151,
+      "11546": 152,
+      "4576": 153,
+      "4512": 154,
+      "8634": 155,
+      "13626": 156,
+      "1613": 157,
+      "287": 158,
+      "9207": 159,
+      "6982": 160,
+      "1724": 161,
+      "10191": 162,
+      "1091": 163,
+      "2909": 164,
+      "1965": 165,
+      "2506": 166,
+      "4414": 167,
+      "5764": 168,
+      "12776": 169,
+      "1033": 170,
+      "13726": 171,
+      "2314": 172,
+      "6826": 173,
+      "9706": 174,
+      "8427": 175,
+      "9168": 176,
+      "9287": 177,
+      "6905": 178,
+      "4153": 179,
+      "3330": 180,
+      "2859": 181,
+      "5406": 182,
+      "2840": 183,
+      "1920": 184,
+      "9241": 185,
+      "10163": 186,
+      "8305": 187,
+      "12461": 188,
+      "3276": 189,
+      "11413": 190,
+      "10536": 191,
+      "10614": 192,
+      "7579": 193,
+      "8675": 194,
+      "7483": 195,
+      "7270": 196,
+      "8704": 197,
+      "4468": 198,
+      "6611": 199,
+      "11497": 200,
+      "11772": 201,
+      "2792": 202,
+      "11481": 203,
+      "10162": 204,
+      "10819": 205,
+      "8732": 206,
+      "11328": 207,
+      "11920": 208,
+      "6646": 209,
+      "7486": 210,
+      "11870": 211,
+      "12417": 212,
+      "10364": 213,
+      "6117": 214,
+      "6448": 215,
+      "10433": 216,
+      "7515": 217,
+      "5823": 218,
+      "8567": 219,
+      "10947": 220,
+      "11869": 221,
+      "12335": 222,
+      "12500": 223,
+      "13755": 224,
+      "7006": 225,
+      "3685": 226,
+      "5819": 227,
+      "9353": 228,
+      "11355": 229,
+      "12174": 230,
+      "7150": 231,
+      "6952": 232,
+      "11987": 233,
+      "3995": 234,
+      "7449": 235
+    },
+    "files": {
+      "de/de_DE/mls/medium/de_DE-mls-medium.onnx": {
+        "size_bytes": 76961079,
+        "md5_digest": "bb543a8e82b95993cdd2199a0049623b"
+      },
+      "de/de_DE/mls/medium/de_DE-mls-medium.onnx.json": {
+        "size_bytes": 8948,
+        "md5_digest": "3fb96c627820ac38cff6e8c3ac0e4aa0"
+      },
+      "de/de_DE/mls/medium/MODEL_CARD": {
+        "size_bytes": 223,
+        "md5_digest": "e32e1746dddda1336c1b6725afa6251d"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "de_DE-pavoque-low": {
+    "key": "de_DE-pavoque-low",
+    "name": "pavoque",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/pavoque/low/de_DE-pavoque-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "bc37dccbad87fd65c8501c412c0c31ca"
+      },
+      "de/de_DE/pavoque/low/de_DE-pavoque-low.onnx.json": {
+        "size_bytes": 4158,
+        "md5_digest": "424d4f2132ea6d9b7c92f8a19e752ca3"
+      },
+      "de/de_DE/pavoque/low/MODEL_CARD": {
+        "size_bytes": 309,
+        "md5_digest": "e0aacaf7b834938c4e3ad1fb3f68ef87"
+      }
+    },
+    "aliases": [
+      "de-pavoque-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-ramona-low": {
+    "key": "de_DE-ramona-low",
+    "name": "ramona",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/ramona/low/de_DE-ramona-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "b4aaf3673170a0d96519cdc992c23fda"
+      },
+      "de/de_DE/ramona/low/de_DE-ramona-low.onnx.json": {
+        "size_bytes": 4157,
+        "md5_digest": "d61011961f01f349331b1a1b1b0ca58a"
+      },
+      "de/de_DE/ramona/low/MODEL_CARD": {
+        "size_bytes": 255,
+        "md5_digest": "c970992423b5fc7a26340a9363e15952"
+      }
+    },
+    "aliases": [
+      "de-ramona-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-thorsten-high": {
+    "key": "de_DE-thorsten-high",
+    "name": "thorsten",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/thorsten/high/de_DE-thorsten-high.onnx": {
+        "size_bytes": 113895201,
+        "md5_digest": "256505fe58fb8b9d6ed78b83f6b8a9d2"
+      },
+      "de/de_DE/thorsten/high/de_DE-thorsten-high.onnx.json": {
+        "size_bytes": 4875,
+        "md5_digest": "e81686e00a9d825e2488ead660bec6fd"
+      },
+      "de/de_DE/thorsten/high/MODEL_CARD": {
+        "size_bytes": 281,
+        "md5_digest": "582a051328d56a564e8a38c9029ae630"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "de_DE-thorsten-low": {
+    "key": "de_DE-thorsten-low",
+    "name": "thorsten",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/thorsten/low/de_DE-thorsten-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "c06eb96aceb61895fcb09ffc30eef60b"
+      },
+      "de/de_DE/thorsten/low/de_DE-thorsten-low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "c4a38327b98f25524128def8190e8ca0"
+      },
+      "de/de_DE/thorsten/low/MODEL_CARD": {
+        "size_bytes": 274,
+        "md5_digest": "203f58b93f0372564e745f1e05ea47bb"
+      }
+    },
+    "aliases": [
+      "de-thorsten-low"
+    ],
+    "has_rt_variant": false
+  },
+  "de_DE-thorsten-medium": {
+    "key": "de_DE-thorsten-medium",
+    "name": "thorsten",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "a129b00fb3078df43c96bab6c94535c0"
+      },
+      "de/de_DE/thorsten/medium/de_DE-thorsten-medium.onnx.json": {
+        "size_bytes": 4819,
+        "md5_digest": "843a7bd7272724f750534dd5a26d1aad"
+      },
+      "de/de_DE/thorsten/medium/MODEL_CARD": {
+        "size_bytes": 285,
+        "md5_digest": "e84cf8b09957fccceb068a3c1664d0f3"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "de_DE-thorsten_emotional-medium": {
+    "key": "de_DE-thorsten_emotional-medium",
+    "name": "thorsten_emotional",
+    "language": {
+      "code": "de_DE",
+      "family": "de",
+      "region": "DE",
+      "name_native": "Deutsch",
+      "name_english": "German",
+      "country_english": "Germany"
+    },
+    "quality": "medium",
+    "num_speakers": 8,
+    "speaker_id_map": {
+      "amused": 0,
+      "angry": 1,
+      "disgusted": 2,
+      "drunk": 3,
+      "neutral": 4,
+      "sleepy": 5,
+      "surprised": 6,
+      "whisper": 7
+    },
+    "files": {
+      "de/de_DE/thorsten_emotional/medium/de_DE-thorsten_emotional-medium.onnx": {
+        "size_bytes": 76745905,
+        "md5_digest": "7cc67d24d9d0b34d7a4f6224d16236b9"
+      },
+      "de/de_DE/thorsten_emotional/medium/de_DE-thorsten_emotional-medium.onnx.json": {
+        "size_bytes": 5031,
+        "md5_digest": "1abac7e46522f774217c170da222f2a6"
+      },
+      "de/de_DE/thorsten_emotional/medium/MODEL_CARD": {
+        "size_bytes": 302,
+        "md5_digest": "91874c31e5b2e497ecda2ea8e6fda4a7"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "el_GR-rapunzelina-low": {
+    "key": "el_GR-rapunzelina-low",
+    "name": "rapunzelina",
+    "language": {
+      "code": "el_GR",
+      "family": "el",
+      "region": "GR",
+      "name_native": "Ελληνικά",
+      "name_english": "Greek",
+      "country_english": "Greece"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "el/el_GR/rapunzelina/low/el_GR-rapunzelina-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "04e0151b653bb64540b1cde027054140"
+      },
+      "el/el_GR/rapunzelina/low/el_GR-rapunzelina-low.onnx.json": {
+        "size_bytes": 4198,
+        "md5_digest": "8d6cd8a576008116be5281b13e1c7b45"
+      },
+      "el/el_GR/rapunzelina/low/MODEL_CARD": {
+        "size_bytes": 303,
+        "md5_digest": "c75270b41e7bf60dacd351753a483574"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_GB-alan-low": {
+    "key": "en_GB-alan-low",
+    "name": "alan",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/alan/low/en_GB-alan-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "2acae8c79395ab109a7572f0afa61fff"
+      },
+      "en/en_GB/alan/low/en_GB-alan-low.onnx.json": {
+        "size_bytes": 4170,
+        "md5_digest": "4c0fa2c6763bf49b343cbb4f655a147b"
+      },
+      "en/en_GB/alan/low/MODEL_CARD": {
+        "size_bytes": 309,
+        "md5_digest": "b116c3cbdebac99ade9af03807cb9301"
+      }
+    },
+    "aliases": [
+      "en-gb-alan-low"
+    ],
+    "has_rt_variant": false
+  },
+  "en_GB-alan-medium": {
+    "key": "en_GB-alan-medium",
+    "name": "alan",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/alan/medium/en_GB-alan-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "8f6b35eeb8ef6269021c6cb6d2414c9b"
+      },
+      "en/en_GB/alan/medium/en_GB-alan-medium.onnx.json": {
+        "size_bytes": 4888,
+        "md5_digest": "b11d9afd0a8f5372c42a52fbd6e021d4"
+      },
+      "en/en_GB/alan/medium/MODEL_CARD": {
+        "size_bytes": 320,
+        "md5_digest": "24a2232470ca1be071debf53c984666e"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-alba-medium": {
+    "key": "en_GB-alba-medium",
+    "name": "alba",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/alba/medium/en_GB-alba-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "c07f313752bb3aba8061041666251654"
+      },
+      "en/en_GB/alba/medium/en_GB-alba-medium.onnx.json": {
+        "size_bytes": 4888,
+        "md5_digest": "dbb6f2ede31082710665221417906e13"
+      },
+      "en/en_GB/alba/medium/MODEL_CARD": {
+        "size_bytes": 324,
+        "md5_digest": "d5a8716acb311b20e0f28710d0fcc982"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-aru-medium": {
+    "key": "en_GB-aru-medium",
+    "name": "aru",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 12,
+    "speaker_id_map": {
+      "03": 0,
+      "06": 1,
+      "10": 2,
+      "01": 3,
+      "09": 4,
+      "08": 5,
+      "11": 6,
+      "05": 7,
+      "12": 8,
+      "02": 9,
+      "07": 10,
+      "04": 11
+    },
+    "files": {
+      "en/en_GB/aru/medium/en_GB-aru-medium.onnx": {
+        "size_bytes": 76754097,
+        "md5_digest": "7862d75539b8ef867e7c04e772d323ea"
+      },
+      "en/en_GB/aru/medium/en_GB-aru-medium.onnx.json": {
+        "size_bytes": 5048,
+        "md5_digest": "903a8ec4cdfea0123a004ab4a87e547c"
+      },
+      "en/en_GB/aru/medium/MODEL_CARD": {
+        "size_bytes": 368,
+        "md5_digest": "09496f38078e0eefe220a497b7b70631"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-cori-high": {
+    "key": "en_GB-cori-high",
+    "name": "cori",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/cori/high/en_GB-cori-high.onnx": {
+        "size_bytes": 114219352,
+        "md5_digest": "3474a80133d9a03e6870d2ac42c18806"
+      },
+      "en/en_GB/cori/high/en_GB-cori-high.onnx.json": {
+        "size_bytes": 4963,
+        "md5_digest": "0f7d42e77a99193006aa34a34442f5e0"
+      },
+      "en/en_GB/cori/high/MODEL_CARD": {
+        "size_bytes": 468,
+        "md5_digest": "12db31ecedf1d6458a215d3012339a20"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-cori-medium": {
+    "key": "en_GB-cori-medium",
+    "name": "cori",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/cori/medium/en_GB-cori-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "f143307611eccea9d976235d0895f57c"
+      },
+      "en/en_GB/cori/medium/en_GB-cori-medium.onnx.json": {
+        "size_bytes": 4966,
+        "md5_digest": "12b1dc45d8919f3475cf296d5f16a4c6"
+      },
+      "en/en_GB/cori/medium/MODEL_CARD": {
+        "size_bytes": 474,
+        "md5_digest": "43861aa2d2c143356702fd966b7812c4"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_GB-jenny_dioco-medium": {
+    "key": "en_GB-jenny_dioco-medium",
+    "name": "jenny_dioco",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/jenny_dioco/medium/en_GB-jenny_dioco-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "d08f2f7edf0c858275a7eca74ff2a9e4"
+      },
+      "en/en_GB/jenny_dioco/medium/en_GB-jenny_dioco-medium.onnx.json": {
+        "size_bytes": 4895,
+        "md5_digest": "e999a9c0aa535fb42e43b04cebcd65d2"
+      },
+      "en/en_GB/jenny_dioco/medium/MODEL_CARD": {
+        "size_bytes": 298,
+        "md5_digest": "ff351d05502764d5b4a074e0648e9434"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-northern_english_male-medium": {
+    "key": "en_GB-northern_english_male-medium",
+    "name": "northern_english_male",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/northern_english_male/medium/en_GB-northern_english_male-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "4c9a9735bfb76ad67c8b31b23d6840a0"
+      },
+      "en/en_GB/northern_english_male/medium/en_GB-northern_english_male-medium.onnx.json": {
+        "size_bytes": 4847,
+        "md5_digest": "0ce3f61a9604616ed475c921fdeedb1a"
+      },
+      "en/en_GB/northern_english_male/medium/MODEL_CARD": {
+        "size_bytes": 305,
+        "md5_digest": "8d1b725154c658ead4f068389c319c82"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-semaine-medium": {
+    "key": "en_GB-semaine-medium",
+    "name": "semaine",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 4,
+    "speaker_id_map": {
+      "prudence": 0,
+      "spike": 1,
+      "obadiah": 2,
+      "poppy": 3
+    },
+    "files": {
+      "en/en_GB/semaine/medium/en_GB-semaine-medium.onnx": {
+        "size_bytes": 76737711,
+        "md5_digest": "3634c3b388165d3b698ea07ba3cac7d2"
+      },
+      "en/en_GB/semaine/medium/en_GB-semaine-medium.onnx.json": {
+        "size_bytes": 5076,
+        "md5_digest": "c30f92604f6ce3f378e7211440f13c8f"
+      },
+      "en/en_GB/semaine/medium/MODEL_CARD": {
+        "size_bytes": 332,
+        "md5_digest": "340045a0ec470eaf3bec271ea746f946"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_GB-southern_english_female-low": {
+    "key": "en_GB-southern_english_female-low",
+    "name": "southern_english_female",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_GB/southern_english_female/low/en_GB-southern_english_female-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "596c7ed4d8488cf64e027765dce2dad1"
+      },
+      "en/en_GB/southern_english_female/low/en_GB-southern_english_female-low.onnx.json": {
+        "size_bytes": 4189,
+        "md5_digest": "7548456e9f2bc4c16bf818be26618ea1"
+      },
+      "en/en_GB/southern_english_female/low/MODEL_CARD": {
+        "size_bytes": 296,
+        "md5_digest": "77ac998c8b37842ef98594567f141629"
+      }
+    },
+    "aliases": [
+      "en-gb-southern_english_female-low"
+    ],
+    "has_rt_variant": false
+  },
+  "en_GB-vctk-medium": {
+    "key": "en_GB-vctk-medium",
+    "name": "vctk",
+    "language": {
+      "code": "en_GB",
+      "family": "en",
+      "region": "GB",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "Great Britain"
+    },
+    "quality": "medium",
+    "num_speakers": 109,
+    "speaker_id_map": {
+      "p239": 0,
+      "p236": 1,
+      "p264": 2,
+      "p250": 3,
+      "p259": 4,
+      "p247": 5,
+      "p261": 6,
+      "p263": 7,
+      "p283": 8,
+      "p286": 9,
+      "p274": 10,
+      "p276": 11,
+      "p270": 12,
+      "p281": 13,
+      "p277": 14,
+      "p231": 15,
+      "p271": 16,
+      "p238": 17,
+      "p257": 18,
+      "p273": 19,
+      "p284": 20,
+      "p329": 21,
+      "p361": 22,
+      "p287": 23,
+      "p360": 24,
+      "p374": 25,
+      "p376": 26,
+      "p310": 27,
+      "p304": 28,
+      "p334": 29,
+      "p340": 30,
+      "p323": 31,
+      "p347": 32,
+      "p330": 33,
+      "p308": 34,
+      "p314": 35,
+      "p317": 36,
+      "p339": 37,
+      "p311": 38,
+      "p294": 39,
+      "p305": 40,
+      "p266": 41,
+      "p335": 42,
+      "p318": 43,
+      "p351": 44,
+      "p333": 45,
+      "p313": 46,
+      "p316": 47,
+      "p244": 48,
+      "p307": 49,
+      "p363": 50,
+      "p336": 51,
+      "p297": 52,
+      "p312": 53,
+      "p267": 54,
+      "p275": 55,
+      "p295": 56,
+      "p258": 57,
+      "p288": 58,
+      "p301": 59,
+      "p232": 60,
+      "p292": 61,
+      "p272": 62,
+      "p280": 63,
+      "p278": 64,
+      "p341": 65,
+      "p268": 66,
+      "p298": 67,
+      "p299": 68,
+      "p279": 69,
+      "p285": 70,
+      "p326": 71,
+      "p300": 72,
+      "s5": 73,
+      "p230": 74,
+      "p345": 75,
+      "p254": 76,
+      "p269": 77,
+      "p293": 78,
+      "p252": 79,
+      "p262": 80,
+      "p243": 81,
+      "p227": 82,
+      "p343": 83,
+      "p255": 84,
+      "p229": 85,
+      "p240": 86,
+      "p248": 87,
+      "p253": 88,
+      "p233": 89,
+      "p228": 90,
+      "p282": 91,
+      "p251": 92,
+      "p246": 93,
+      "p234": 94,
+      "p226": 95,
+      "p260": 96,
+      "p245": 97,
+      "p241": 98,
+      "p303": 99,
+      "p265": 100,
+      "p306": 101,
+      "p237": 102,
+      "p249": 103,
+      "p256": 104,
+      "p302": 105,
+      "p364": 106,
+      "p225": 107,
+      "p362": 108
+    },
+    "files": {
+      "en/en_GB/vctk/medium/en_GB-vctk-medium.onnx": {
+        "size_bytes": 76952753,
+        "md5_digest": "573025290fdc68812543b7438ace0c29"
+      },
+      "en/en_GB/vctk/medium/en_GB-vctk-medium.onnx.json": {
+        "size_bytes": 6637,
+        "md5_digest": "68e82dee4c9a723e804f9fc0b14f1802"
+      },
+      "en/en_GB/vctk/medium/MODEL_CARD": {
+        "size_bytes": 326,
+        "md5_digest": "b88a963e3bee27bc4fff84563f1be388"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-amy-low": {
+    "key": "en_US-amy-low",
+    "name": "amy",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/amy/low/en_US-amy-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "3c3f6a6ec605f3a59763256d3b2db012"
+      },
+      "en/en_US/amy/low/en_US-amy-low.onnx.json": {
+        "size_bytes": 4164,
+        "md5_digest": "85a339b51379b13bbbb0784382ca75bc"
+      },
+      "en/en_US/amy/low/MODEL_CARD": {
+        "size_bytes": 273,
+        "md5_digest": "e1cdd84aa7493b8fbe1e6471f6f93cea"
+      }
+    },
+    "aliases": [
+      "en-us-amy-low"
+    ],
+    "has_rt_variant": false
+  },
+  "en_US-amy-medium": {
+    "key": "en_US-amy-medium",
+    "name": "amy",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/amy/medium/en_US-amy-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "778d28aeb95fcdf8a882344d9df142fc"
+      },
+      "en/en_US/amy/medium/en_US-amy-medium.onnx.json": {
+        "size_bytes": 4882,
+        "md5_digest": "7f37dadb26340c90ebc8088e0b252310"
+      },
+      "en/en_US/amy/medium/MODEL_CARD": {
+        "size_bytes": 281,
+        "md5_digest": "6fca05ee5bfe8b28211b88b86b47e822"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-arctic-medium": {
+    "key": "en_US-arctic-medium",
+    "name": "arctic",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 18,
+    "speaker_id_map": {
+      "awb": 0,
+      "rms": 1,
+      "slt": 2,
+      "ksp": 3,
+      "clb": 4,
+      "lnh": 5,
+      "aew": 6,
+      "bdl": 7,
+      "jmk": 8,
+      "rxr": 9,
+      "fem": 10,
+      "ljm": 11,
+      "slp": 12,
+      "aup": 13,
+      "ahw": 14,
+      "axb": 15,
+      "eey": 16,
+      "gka": 17
+    },
+    "files": {
+      "en/en_US/arctic/medium/en_US-arctic-medium.onnx": {
+        "size_bytes": 76766385,
+        "md5_digest": "497c47037c2e279faf467e0a06f965d2"
+      },
+      "en/en_US/arctic/medium/en_US-arctic-medium.onnx.json": {
+        "size_bytes": 5148,
+        "md5_digest": "b7ed018d74f0d5ba7cd49051de43a461"
+      },
+      "en/en_US/arctic/medium/MODEL_CARD": {
+        "size_bytes": 289,
+        "md5_digest": "efe5b89e46cf8e0efa254203da8c7baf"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-bryce-medium": {
+    "key": "en_US-bryce-medium",
+    "name": "bryce",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/bryce/medium/en_US-bryce-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "a8482817c3bdc3d20121a0e31bfa9809"
+      },
+      "en/en_US/bryce/medium/en_US-bryce-medium.onnx.json": {
+        "size_bytes": 4966,
+        "md5_digest": "a548d1d4ce8579f5a16926bdec77c7bf"
+      },
+      "en/en_US/bryce/medium/MODEL_CARD": {
+        "size_bytes": 405,
+        "md5_digest": "79f21fcb165d0fcc4680222164bbb569"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_US-danny-low": {
+    "key": "en_US-danny-low",
+    "name": "danny",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/danny/low/en_US-danny-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "73cc296e178ab3d2a5698179b629cd12"
+      },
+      "en/en_US/danny/low/en_US-danny-low.onnx.json": {
+        "size_bytes": 4166,
+        "md5_digest": "c0aa454db4e5a6581e45799c79aa99c6"
+      },
+      "en/en_US/danny/low/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "62d30d0cccea265949980cb48212ebee"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_US-hfc_female-medium": {
+    "key": "en_US-hfc_female-medium",
+    "name": "hfc_female",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/hfc_female/medium/en_US-hfc_female-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "7abec91f1d6e19e913fbc4a333f62787"
+      },
+      "en/en_US/hfc_female/medium/en_US-hfc_female-medium.onnx.json": {
+        "size_bytes": 5033,
+        "md5_digest": "c3d00f54dac3b4068f2576c15c5da3bc"
+      },
+      "en/en_US/hfc_female/medium/MODEL_CARD": {
+        "size_bytes": 354,
+        "md5_digest": "a4a7b5da65e03e6972e44e9555a59aef"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-hfc_male-medium": {
+    "key": "en_US-hfc_male-medium",
+    "name": "hfc_male",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/hfc_male/medium/en_US-hfc_male-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "cd2fda1933f0653d3ddc85e5f30ebdd2"
+      },
+      "en/en_US/hfc_male/medium/en_US-hfc_male-medium.onnx.json": {
+        "size_bytes": 5033,
+        "md5_digest": "9b4849dbc1e72f35de7391528dea60d9"
+      },
+      "en/en_US/hfc_male/medium/MODEL_CARD": {
+        "size_bytes": 352,
+        "md5_digest": "0bc174f6fe7a6d795a790110e8bf9096"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-joe-medium": {
+    "key": "en_US-joe-medium",
+    "name": "joe",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/joe/medium/en_US-joe-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "74fd6a4dc39e0aa9dce145d7f5acd4f6"
+      },
+      "en/en_US/joe/medium/en_US-joe-medium.onnx.json": {
+        "size_bytes": 4794,
+        "md5_digest": "811036b9c1451545f9495fdc1baa0754"
+      },
+      "en/en_US/joe/medium/MODEL_CARD": {
+        "size_bytes": 280,
+        "md5_digest": "7d25cb111aa9699518764a1cb3943af1"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-john-medium": {
+    "key": "en_US-john-medium",
+    "name": "john",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/john/medium/en_US-john-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "70480857f21f2560f3a232722023b36d"
+      },
+      "en/en_US/john/medium/en_US-john-medium.onnx.json": {
+        "size_bytes": 4965,
+        "md5_digest": "f2d04611b498e14d394385d1ec8a2d2d"
+      },
+      "en/en_US/john/medium/MODEL_CARD": {
+        "size_bytes": 498,
+        "md5_digest": "4ef938585cf2cc8da4ada9b6d2c579ec"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_US-kathleen-low": {
+    "key": "en_US-kathleen-low",
+    "name": "kathleen",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/kathleen/low/en_US-kathleen-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "dd1ab131724b1cff76fe388252bec47b"
+      },
+      "en/en_US/kathleen/low/en_US-kathleen-low.onnx.json": {
+        "size_bytes": 4169,
+        "md5_digest": "d970eebfe8e9f8515e405659da658f9b"
+      },
+      "en/en_US/kathleen/low/MODEL_CARD": {
+        "size_bytes": 281,
+        "md5_digest": "0585e0a798d093c9ee090b99d9c8f68e"
+      }
+    },
+    "aliases": [
+      "en-us-kathleen-low"
+    ],
+    "has_rt_variant": false
+  },
+  "en_US-kristin-medium": {
+    "key": "en_US-kristin-medium",
+    "name": "kristin",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/kristin/medium/en_US-kristin-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "5fed42d2296baca042e2bf74785db725"
+      },
+      "en/en_US/kristin/medium/en_US-kristin-medium.onnx.json": {
+        "size_bytes": 4968,
+        "md5_digest": "70bc97d350c796c64ea5e4d08241afac"
+      },
+      "en/en_US/kristin/medium/MODEL_CARD": {
+        "size_bytes": 479,
+        "md5_digest": "9bfb8192299b34cddf76455f04cb8cd2"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-kusal-medium": {
+    "key": "en_US-kusal-medium",
+    "name": "kusal",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/kusal/medium/en_US-kusal-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "95334de7385a03c5c9de25b920c33492"
+      },
+      "en/en_US/kusal/medium/en_US-kusal-medium.onnx.json": {
+        "size_bytes": 4884,
+        "md5_digest": "722e434f8e1a768dd6b6fab5b4cfde4d"
+      },
+      "en/en_US/kusal/medium/MODEL_CARD": {
+        "size_bytes": 279,
+        "md5_digest": "b627e950e8e10a1ec7b30e5f9b312a05"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-l2arctic-medium": {
+    "key": "en_US-l2arctic-medium",
+    "name": "l2arctic",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 24,
+    "speaker_id_map": {
+      "TXHC": 0,
+      "THV": 1,
+      "SVBI": 2,
+      "ZHAA": 3,
+      "PNV": 4,
+      "TLV": 5,
+      "ERMS": 6,
+      "MBMPS": 7,
+      "HQTV": 8,
+      "TNI": 9,
+      "ASI": 10,
+      "HJK": 11,
+      "LXC": 12,
+      "NCC": 13,
+      "YKWK": 14,
+      "YDCK": 15,
+      "HKK": 16,
+      "NJS": 17,
+      "YBAA": 18,
+      "RRBI": 19,
+      "BWC": 20,
+      "ABA": 21,
+      "EBVS": 22,
+      "SKA": 23
+    },
+    "files": {
+      "en/en_US/l2arctic/medium/en_US-l2arctic-medium.onnx": {
+        "size_bytes": 76778673,
+        "md5_digest": "a71d8acf9b01676931cd548f739382cd"
+      },
+      "en/en_US/l2arctic/medium/en_US-l2arctic-medium.onnx.json": {
+        "size_bytes": 5252,
+        "md5_digest": "a0f29a10628f08dccd757aca57ccb163"
+      },
+      "en/en_US/l2arctic/medium/MODEL_CARD": {
+        "size_bytes": 365,
+        "md5_digest": "8d5e9dc31cba2a9b7ee68a2a70e084f2"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-lessac-high": {
+    "key": "en_US-lessac-high",
+    "name": "lessac",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/lessac/high/en_US-lessac-high.onnx": {
+        "size_bytes": 113895201,
+        "md5_digest": "99d1f6181a7f5ccbe3f117ba8ce63c93"
+      },
+      "en/en_US/lessac/high/en_US-lessac-high.onnx.json": {
+        "size_bytes": 4883,
+        "md5_digest": "02e8e364c86b5d3b75e81704b0369856"
+      },
+      "en/en_US/lessac/high/MODEL_CARD": {
+        "size_bytes": 347,
+        "md5_digest": "2ff564555f6d6cde3c19dcc8f3815428"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-lessac-low": {
+    "key": "en_US-lessac-low",
+    "name": "lessac",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/lessac/low/en_US-lessac-low.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "31883a7506589feadf3c3474fd8ef658"
+      },
+      "en/en_US/lessac/low/en_US-lessac-low.onnx.json": {
+        "size_bytes": 4882,
+        "md5_digest": "64876daa19dd042b368cd64fa379a75f"
+      },
+      "en/en_US/lessac/low/MODEL_CARD": {
+        "size_bytes": 345,
+        "md5_digest": "999cbf2c337d8fb2f21b0fa2c95e9e85"
+      }
+    },
+    "aliases": [
+      "en-us-lessac-low"
+    ],
+    "has_rt_variant": true
+  },
+  "en_US-lessac-medium": {
+    "key": "en_US-lessac-medium",
+    "name": "lessac",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/lessac/medium/en_US-lessac-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "2fc642b535197b6305c7c8f92dc8b24f"
+      },
+      "en/en_US/lessac/medium/en_US-lessac-medium.onnx.json": {
+        "size_bytes": 4885,
+        "md5_digest": "c1f2b7bddefe113f3255ff9ef234cfd3"
+      },
+      "en/en_US/lessac/medium/MODEL_CARD": {
+        "size_bytes": 351,
+        "md5_digest": "42f2dd4a98149e12fc70b301d9579dfd"
+      }
+    },
+    "aliases": [
+      "en-us-lessac-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "en_US-libritts-high": {
+    "key": "en_US-libritts-high",
+    "name": "libritts",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "high",
+    "num_speakers": 904,
+    "speaker_id_map": {
+      "p3922": 0,
+      "p8699": 1,
+      "p4535": 2,
+      "p6701": 3,
+      "p3638": 4,
+      "p922": 5,
+      "p2531": 6,
+      "p1638": 7,
+      "p8848": 8,
+      "p6544": 9,
+      "p3615": 10,
+      "p318": 11,
+      "p6104": 12,
+      "p1382": 13,
+      "p5400": 14,
+      "p5712": 15,
+      "p2769": 16,
+      "p2573": 17,
+      "p1463": 18,
+      "p6458": 19,
+      "p3274": 20,
+      "p4356": 21,
+      "p8498": 22,
+      "p5570": 23,
+      "p176": 24,
+      "p339": 25,
+      "p28": 26,
+      "p5909": 27,
+      "p3869": 28,
+      "p4899": 29,
+      "p64": 30,
+      "p3368": 31,
+      "p3307": 32,
+      "p5618": 33,
+      "p3370": 34,
+      "p7704": 35,
+      "p8506": 36,
+      "p8410": 37,
+      "p6904": 38,
+      "p5655": 39,
+      "p2204": 40,
+      "p501": 41,
+      "p7314": 42,
+      "p1027": 43,
+      "p5054": 44,
+      "p534": 45,
+      "p2853": 46,
+      "p5935": 47,
+      "p2404": 48,
+      "p7874": 49,
+      "p816": 50,
+      "p2053": 51,
+      "p8066": 52,
+      "p16": 53,
+      "p4586": 54,
+      "p1923": 55,
+      "p2592": 56,
+      "p1265": 57,
+      "p6189": 58,
+      "p100": 59,
+      "p6371": 60,
+      "p4957": 61,
+      "p4116": 62,
+      "p3003": 63,
+      "p7739": 64,
+      "p1752": 65,
+      "p5717": 66,
+      "p5012": 67,
+      "p5062": 68,
+      "p7481": 69,
+      "p4595": 70,
+      "p2299": 71,
+      "p7188": 72,
+      "p93": 73,
+      "p4145": 74,
+      "p8684": 75,
+      "p7594": 76,
+      "p2598": 77,
+      "p3540": 78,
+      "p7717": 79,
+      "p6426": 80,
+      "p4148": 81,
+      "p335": 82,
+      "p1379": 83,
+      "p2512": 84,
+      "p242": 85,
+      "p8855": 86,
+      "p8118": 87,
+      "p369": 88,
+      "p6575": 89,
+      "p6694": 90,
+      "p8080": 91,
+      "p1283": 92,
+      "p7434": 93,
+      "p5290": 94,
+      "p1731": 95,
+      "p2401": 96,
+      "p459": 97,
+      "p192": 98,
+      "p7910": 99,
+      "p114": 100,
+      "p5660": 101,
+      "p1313": 102,
+      "p203": 103,
+      "p7460": 104,
+      "p207": 105,
+      "p6497": 106,
+      "p6696": 107,
+      "p7766": 108,
+      "p6233": 109,
+      "p3185": 110,
+      "p2010": 111,
+      "p2056": 112,
+      "p3717": 113,
+      "p5802": 114,
+      "p5622": 115,
+      "p2156": 116,
+      "p4243": 117,
+      "p1422": 118,
+      "p5039": 119,
+      "p4110": 120,
+      "p1093": 121,
+      "p1776": 122,
+      "p7995": 123,
+      "p6877": 124,
+      "p5635": 125,
+      "p54": 126,
+      "p288": 127,
+      "p4592": 128,
+      "p7276": 129,
+      "p688": 130,
+      "p8388": 131,
+      "p8152": 132,
+      "p8194": 133,
+      "p7000": 134,
+      "p8527": 135,
+      "p5126": 136,
+      "p3923": 137,
+      "p1054": 138,
+      "p3927": 139,
+      "p5029": 140,
+      "p4098": 141,
+      "p1789": 142,
+      "p56": 143,
+      "p7240": 144,
+      "p5538": 145,
+      "p1903": 146,
+      "p6538": 147,
+      "p3380": 148,
+      "p6643": 149,
+      "p7495": 150,
+      "p8718": 151,
+      "p8050": 152,
+      "p126": 153,
+      "p7245": 154,
+      "p2517": 155,
+      "p4438": 156,
+      "p4945": 157,
+      "p7145": 158,
+      "p724": 159,
+      "p9022": 160,
+      "p6637": 161,
+      "p6927": 162,
+      "p6937": 163,
+      "p8113": 164,
+      "p5724": 165,
+      "p6006": 166,
+      "p3584": 167,
+      "p2971": 168,
+      "p2230": 169,
+      "p7982": 170,
+      "p1649": 171,
+      "p3994": 172,
+      "p7720": 173,
+      "p6981": 174,
+      "p781": 175,
+      "p4973": 176,
+      "p6206": 177,
+      "p2481": 178,
+      "p3157": 179,
+      "p1509": 180,
+      "p510": 181,
+      "p7540": 182,
+      "p8887": 183,
+      "p7120": 184,
+      "p2882": 185,
+      "p7128": 186,
+      "p8142": 187,
+      "p7229": 188,
+      "p2787": 189,
+      "p8820": 190,
+      "p2368": 191,
+      "p4331": 192,
+      "p4967": 193,
+      "p4427": 194,
+      "p6054": 195,
+      "p3728": 196,
+      "p274": 197,
+      "p7134": 198,
+      "p1603": 199,
+      "p1383": 200,
+      "p1165": 201,
+      "p4363": 202,
+      "p512": 203,
+      "p5985": 204,
+      "p7967": 205,
+      "p2060": 206,
+      "p7752": 207,
+      "p7484": 208,
+      "p8643": 209,
+      "p3549": 210,
+      "p5731": 211,
+      "p7881": 212,
+      "p667": 213,
+      "p6828": 214,
+      "p5740": 215,
+      "p3483": 216,
+      "p718": 217,
+      "p6341": 218,
+      "p1913": 219,
+      "p3228": 220,
+      "p7247": 221,
+      "p7705": 222,
+      "p1018": 223,
+      "p8193": 224,
+      "p6098": 225,
+      "p3989": 226,
+      "p7828": 227,
+      "p5876": 228,
+      "p7754": 229,
+      "p4719": 230,
+      "p8011": 231,
+      "p7939": 232,
+      "p5975": 233,
+      "p2004": 234,
+      "p6139": 235,
+      "p8183": 236,
+      "p3482": 237,
+      "p3361": 238,
+      "p4289": 239,
+      "p231": 240,
+      "p7789": 241,
+      "p4598": 242,
+      "p5239": 243,
+      "p2638": 244,
+      "p6300": 245,
+      "p8474": 246,
+      "p2194": 247,
+      "p7832": 248,
+      "p1079": 249,
+      "p1335": 250,
+      "p188": 251,
+      "p1195": 252,
+      "p5914": 253,
+      "p1401": 254,
+      "p7318": 255,
+      "p5448": 256,
+      "p1392": 257,
+      "p3703": 258,
+      "p2113": 259,
+      "p7783": 260,
+      "p8176": 261,
+      "p6519": 262,
+      "p7933": 263,
+      "p7938": 264,
+      "p7802": 265,
+      "p6120": 266,
+      "p224": 267,
+      "p209": 268,
+      "p5656": 269,
+      "p3032": 270,
+      "p6965": 271,
+      "p258": 272,
+      "p4837": 273,
+      "p5489": 274,
+      "p272": 275,
+      "p3851": 276,
+      "p7140": 277,
+      "p2562": 278,
+      "p1472": 279,
+      "p79": 280,
+      "p2775": 281,
+      "p3046": 282,
+      "p2532": 283,
+      "p8266": 284,
+      "p6099": 285,
+      "p4425": 286,
+      "p5293": 287,
+      "p7981": 288,
+      "p2045": 289,
+      "p920": 290,
+      "p511": 291,
+      "p7416": 292,
+      "p835": 293,
+      "p1289": 294,
+      "p8195": 295,
+      "p7833": 296,
+      "p8772": 297,
+      "p968": 298,
+      "p1641": 299,
+      "p7117": 300,
+      "p1678": 301,
+      "p5809": 302,
+      "p8028": 303,
+      "p500": 304,
+      "p6505": 305,
+      "p7868": 306,
+      "p14": 307,
+      "p2238": 308,
+      "p4744": 309,
+      "p3733": 310,
+      "p7515": 311,
+      "p699": 312,
+      "p5093": 313,
+      "p6388": 314,
+      "p7959": 315,
+      "p98": 316,
+      "p3914": 317,
+      "p5246": 318,
+      "p2570": 319,
+      "p8396": 320,
+      "p3513": 321,
+      "p882": 322,
+      "p7994": 323,
+      "p5968": 324,
+      "p8591": 325,
+      "p806": 326,
+      "p5261": 327,
+      "p1271": 328,
+      "p899": 329,
+      "p3945": 330,
+      "p8404": 331,
+      "p249": 332,
+      "p3008": 333,
+      "p7139": 334,
+      "p6395": 335,
+      "p6215": 336,
+      "p6080": 337,
+      "p4054": 338,
+      "p7825": 339,
+      "p6683": 340,
+      "p8725": 341,
+      "p3230": 342,
+      "p4138": 343,
+      "p6160": 344,
+      "p666": 345,
+      "p6510": 346,
+      "p3551": 347,
+      "p8075": 348,
+      "p225": 349,
+      "p7169": 350,
+      "p1851": 351,
+      "p5984": 352,
+      "p2960": 353,
+      "p8329": 354,
+      "p175": 355,
+      "p6378": 356,
+      "p480": 357,
+      "p7538": 358,
+      "p479": 359,
+      "p5519": 360,
+      "p8534": 361,
+      "p4856": 362,
+      "p101": 363,
+      "p3521": 364,
+      "p2256": 365,
+      "p3083": 366,
+      "p4278": 367,
+      "p8713": 368,
+      "p1226": 369,
+      "p4222": 370,
+      "p8494": 371,
+      "p8776": 372,
+      "p731": 373,
+      "p6574": 374,
+      "p5319": 375,
+      "p8605": 376,
+      "p5583": 377,
+      "p6406": 378,
+      "p4064": 379,
+      "p4806": 380,
+      "p3972": 381,
+      "p7383": 382,
+      "p5133": 383,
+      "p597": 384,
+      "p1025": 385,
+      "p7313": 386,
+      "p5304": 387,
+      "p8758": 388,
+      "p1050": 389,
+      "p6499": 390,
+      "p6956": 391,
+      "p770": 392,
+      "p4108": 393,
+      "p2774": 394,
+      "p3864": 395,
+      "p4490": 396,
+      "p4848": 397,
+      "p1826": 398,
+      "p6294": 399,
+      "p7949": 400,
+      "p1446": 401,
+      "p7867": 402,
+      "p8163": 403,
+      "p953": 404,
+      "p8138": 405,
+      "p353": 406,
+      "p7553": 407,
+      "p8825": 408,
+      "p5189": 409,
+      "p2012": 410,
+      "p948": 411,
+      "p205": 412,
+      "p1535": 413,
+      "p8008": 414,
+      "p1112": 415,
+      "p7926": 416,
+      "p4039": 417,
+      "p716": 418,
+      "p3967": 419,
+      "p7932": 420,
+      "p7525": 421,
+      "p7316": 422,
+      "p3448": 423,
+      "p2393": 424,
+      "p6788": 425,
+      "p6550": 426,
+      "p7011": 427,
+      "p8791": 428,
+      "p8119": 429,
+      "p1777": 430,
+      "p6014": 431,
+      "p1046": 432,
+      "p6269": 433,
+      "p6188": 434,
+      "p5266": 435,
+      "p3490": 436,
+      "p8786": 437,
+      "p8824": 438,
+      "p589": 439,
+      "p576": 440,
+      "p1121": 441,
+      "p1806": 442,
+      "p7294": 443,
+      "p3119": 444,
+      "p2688": 445,
+      "p1012": 446,
+      "p4807": 447,
+      "p7498": 448,
+      "p3905": 449,
+      "p7384": 450,
+      "p2992": 451,
+      "p30": 452,
+      "p497": 453,
+      "p227": 454,
+      "p4226": 455,
+      "p5007": 456,
+      "p1066": 457,
+      "p8222": 458,
+      "p7688": 459,
+      "p6865": 460,
+      "p6286": 461,
+      "p8225": 462,
+      "p3224": 463,
+      "p8635": 464,
+      "p1348": 465,
+      "p3645": 466,
+      "p1961": 467,
+      "p8190": 468,
+      "p6032": 469,
+      "p7286": 470,
+      "p5389": 471,
+      "p3105": 472,
+      "p1028": 473,
+      "p6038": 474,
+      "p764": 475,
+      "p7437": 476,
+      "p6555": 477,
+      "p8875": 478,
+      "p2074": 479,
+      "p7809": 480,
+      "p2240": 481,
+      "p2827": 482,
+      "p5386": 483,
+      "p6763": 484,
+      "p3009": 485,
+      "p6339": 486,
+      "p1825": 487,
+      "p7569": 488,
+      "p359": 489,
+      "p7956": 490,
+      "p2137": 491,
+      "p8677": 492,
+      "p4434": 493,
+      "p329": 494,
+      "p3289": 495,
+      "p4290": 496,
+      "p2999": 497,
+      "p2427": 498,
+      "p637": 499,
+      "p2229": 500,
+      "p1874": 501,
+      "p3446": 502,
+      "p9023": 503,
+      "p3114": 504,
+      "p6235": 505,
+      "p4860": 506,
+      "p4519": 507,
+      "p561": 508,
+      "p70": 509,
+      "p4800": 510,
+      "p2294": 511,
+      "p6115": 512,
+      "p2582": 513,
+      "p8464": 514,
+      "p5139": 515,
+      "p6918": 516,
+      "p337": 517,
+      "p5810": 518,
+      "p8401": 519,
+      "p303": 520,
+      "p5206": 521,
+      "p2589": 522,
+      "p7061": 523,
+      "p2269": 524,
+      "p2758": 525,
+      "p3389": 526,
+      "p4629": 527,
+      "p707": 528,
+      "p5606": 529,
+      "p1513": 530,
+      "p2473": 531,
+      "p664": 532,
+      "p5092": 533,
+      "p5154": 534,
+      "p6288": 535,
+      "p6308": 536,
+      "p4731": 537,
+      "p3328": 538,
+      "p7816": 539,
+      "p3221": 540,
+      "p8687": 541,
+      "p7030": 542,
+      "p476": 543,
+      "p4257": 544,
+      "p5918": 545,
+      "p6317": 546,
+      "p204": 547,
+      "p8006": 548,
+      "p6895": 549,
+      "p1264": 550,
+      "p2494": 551,
+      "p112": 552,
+      "p1859": 553,
+      "p398": 554,
+      "p1052": 555,
+      "p3294": 556,
+      "p1460": 557,
+      "p8573": 558,
+      "p5684": 559,
+      "p8421": 560,
+      "p5883": 561,
+      "p7297": 562,
+      "p246": 563,
+      "p8057": 564,
+      "p3835": 565,
+      "p1748": 566,
+      "p3816": 567,
+      "p3357": 568,
+      "p1053": 569,
+      "p409": 570,
+      "p868": 571,
+      "p3118": 572,
+      "p7520": 573,
+      "p6686": 574,
+      "p1241": 575,
+      "p5190": 576,
+      "p166": 577,
+      "p1482": 578,
+      "p5604": 579,
+      "p1212": 580,
+      "p2741": 581,
+      "p1259": 582,
+      "p984": 583,
+      "p6492": 584,
+      "p6167": 585,
+      "p296": 586,
+      "p6567": 587,
+      "p6924": 588,
+      "p2272": 589,
+      "p7085": 590,
+      "p345": 591,
+      "p2388": 592,
+      "p1705": 593,
+      "p1343": 594,
+      "p7241": 595,
+      "p451": 596,
+      "p5401": 597,
+      "p6446": 598,
+      "p612": 599,
+      "p594": 600,
+      "p7555": 601,
+      "p7069": 602,
+      "p2577": 603,
+      "p5333": 604,
+      "p8742": 605,
+      "p6727": 606,
+      "p1571": 607,
+      "p4734": 608,
+      "p7258": 609,
+      "p3977": 610,
+      "p373": 611,
+      "p5723": 612,
+      "p1365": 613,
+      "p7285": 614,
+      "p580": 615,
+      "p836": 616,
+      "p6782": 617,
+      "p3654": 618,
+      "p1974": 619,
+      "p6258": 620,
+      "p925": 621,
+      "p949": 622,
+      "p2790": 623,
+      "p698": 624,
+      "p6373": 625,
+      "p2785": 626,
+      "p1222": 627,
+      "p2751": 628,
+      "p3825": 629,
+      "p5115": 630,
+      "p1827": 631,
+      "p3171": 632,
+      "p119": 633,
+      "p850": 634,
+      "p3258": 635,
+      "p7909": 636,
+      "p1322": 637,
+      "p8097": 638,
+      "p22": 639,
+      "p7478": 640,
+      "p1349": 641,
+      "p4854": 642,
+      "p2929": 643,
+      "p7335": 644,
+      "p5868": 645,
+      "p454": 646,
+      "p7945": 647,
+      "p2654": 648,
+      "p3493": 649,
+      "p1060": 650,
+      "p8545": 651,
+      "p6509": 652,
+      "p5002": 653,
+      "p7732": 654,
+      "p3082": 655,
+      "p1779": 656,
+      "p2709": 657,
+      "p7398": 658,
+      "p8879": 659,
+      "p639": 660,
+      "p598": 661,
+      "p5672": 662,
+      "p6553": 663,
+      "p4111": 664,
+      "p1417": 665,
+      "p7991": 666,
+      "p380": 667,
+      "p8459": 668,
+      "p8347": 669,
+      "p1769": 670,
+      "p2673": 671,
+      "p3330": 672,
+      "p7051": 673,
+      "p1337": 674,
+      "p4057": 675,
+      "p4839": 676,
+      "p6060": 677,
+      "p7095": 678,
+      "p278": 679,
+      "p1445": 680,
+      "p6518": 681,
+      "p2364": 682,
+      "p1958": 683,
+      "p548": 684,
+      "p4010": 685,
+      "p3072": 686,
+      "p6993": 687,
+      "p8575": 688,
+      "p2149": 689,
+      "p240": 690,
+      "p2920": 691,
+      "p5588": 692,
+      "p1885": 693,
+      "p6082": 694,
+      "p9026": 695,
+      "p340": 696,
+      "p159": 697,
+      "p7730": 698,
+      "p7962": 699,
+      "p1987": 700,
+      "p3876": 701,
+      "p8771": 702,
+      "p5123": 703,
+      "p3866": 704,
+      "p3546": 705,
+      "p7777": 706,
+      "p115": 707,
+      "p5337": 708,
+      "p475": 709,
+      "p1724": 710,
+      "p6359": 711,
+      "p4260": 712,
+      "p2110": 713,
+      "p1845": 714,
+      "p4335": 715,
+      "p4133": 716,
+      "p783": 717,
+      "p8479": 718,
+      "p1448": 719,
+      "p1160": 720,
+      "p7647": 721,
+      "p2618": 722,
+      "p3630": 723,
+      "p4013": 724,
+      "p5242": 725,
+      "p7957": 726,
+      "p3852": 727,
+      "p3889": 728,
+      "p1387": 729,
+      "p439": 730,
+      "p1425": 731,
+      "p2061": 732,
+      "p7395": 733,
+      "p7837": 734,
+      "p5147": 735,
+      "p2319": 736,
+      "p3781": 737,
+      "p1311": 738,
+      "p4733": 739,
+      "p8705": 740,
+      "p3094": 741,
+      "p2823": 742,
+      "p1914": 743,
+      "p954": 744,
+      "p4381": 745,
+      "p4044": 746,
+      "p593": 747,
+      "p8300": 748,
+      "p7558": 749,
+      "p6494": 750,
+      "p6330": 751,
+      "p5940": 752,
+      "p7126": 753,
+      "p1061": 754,
+      "p6352": 755,
+      "p5186": 756,
+      "p1944": 757,
+      "p2285": 758,
+      "p6673": 759,
+      "p5746": 760,
+      "p208": 761,
+      "p492": 762,
+      "p216": 763,
+      "p979": 764,
+      "p1668": 765,
+      "p6620": 766,
+      "p711": 767,
+      "p7733": 768,
+      "p8619": 769,
+      "p5157": 770,
+      "p829": 771,
+      "p3180": 772,
+      "p3979": 773,
+      "p1556": 774,
+      "p3379": 775,
+      "p5727": 776,
+      "p596": 777,
+      "p2127": 778,
+      "p581": 779,
+      "p2652": 780,
+      "p2628": 781,
+      "p1849": 782,
+      "p4238": 783,
+      "p606": 784,
+      "p1224": 785,
+      "p1629": 786,
+      "p1413": 787,
+      "p957": 788,
+      "p8592": 789,
+      "p2254": 790,
+      "p1323": 791,
+      "p122": 792,
+      "p2093": 793,
+      "p1100": 794,
+      "p81": 795,
+      "p323": 796,
+      "p815": 797,
+      "p2581": 798,
+      "p543": 799,
+      "p6037": 800,
+      "p2397": 801,
+      "p5513": 802,
+      "p4495": 803,
+      "p5776": 804,
+      "p17": 805,
+      "p4590": 806,
+      "p8228": 807,
+      "p708": 808,
+      "p3792": 809,
+      "p3790": 810,
+      "p7090": 811,
+      "p1943": 812,
+      "p4246": 813,
+      "p559": 814,
+      "p3738": 815,
+      "p2167": 816,
+      "p1933": 817,
+      "p2162": 818,
+      "p549": 819,
+      "p3025": 820,
+      "p1182": 821,
+      "p4358": 822,
+      "p636": 823,
+      "p986": 824,
+      "p8490": 825,
+      "p3340": 826,
+      "p90": 827,
+      "p1487": 828,
+      "p1639": 829,
+      "p1547": 830,
+      "p4152": 831,
+      "p1498": 832,
+      "p1740": 833,
+      "p6157": 834,
+      "p217": 835,
+      "p2201": 836,
+      "p362": 837,
+      "p2146": 838,
+      "p1801": 839,
+      "p5063": 840,
+      "p7339": 841,
+      "p663": 842,
+      "p38": 843,
+      "p1336": 844,
+      "p3215": 845,
+      "p210": 846,
+      "p6075": 847,
+      "p55": 848,
+      "p2411": 849,
+      "p7445": 850,
+      "p5767": 851,
+      "p2812": 852,
+      "p472": 853,
+      "p803": 854,
+      "p4236": 855,
+      "p7665": 856,
+      "p1607": 857,
+      "p1316": 858,
+      "p7475": 859,
+      "p3001": 860,
+      "p1473": 861,
+      "p3537": 862,
+      "p3070": 863,
+      "p1390": 864,
+      "p1290": 865,
+      "p2499": 866,
+      "p154": 867,
+      "p7518": 868,
+      "p408": 869,
+      "p1811": 870,
+      "p1734": 871,
+      "p7342": 872,
+      "p8722": 873,
+      "p1754": 874,
+      "p7657": 875,
+      "p583": 876,
+      "p830": 877,
+      "p6690": 878,
+      "p1552": 879,
+      "p2498": 880,
+      "p1296": 881,
+      "p3686": 882,
+      "p157": 883,
+      "p487": 884,
+      "p6119": 885,
+      "p4926": 886,
+      "p4846": 887,
+      "p1536": 888,
+      "p2674": 889,
+      "p1645": 890,
+      "p3187": 891,
+      "p1058": 892,
+      "p2039": 893,
+      "p4071": 894,
+      "p4433": 895,
+      "p1175": 896,
+      "p434": 897,
+      "p1001": 898,
+      "p2816": 899,
+      "p820": 900,
+      "p2696": 901,
+      "p4681": 902,
+      "p2085": 903
+    },
+    "files": {
+      "en/en_US/libritts/high/en_US-libritts-high.onnx": {
+        "size_bytes": 136673811,
+        "md5_digest": "61d7845257f8abdc27476f606151ef8d"
+      },
+      "en/en_US/libritts/high/en_US-libritts-high.onnx.json": {
+        "size_bytes": 20163,
+        "md5_digest": "cb1564bb779f3b1f87e2de778adeb669"
+      },
+      "en/en_US/libritts/high/MODEL_CARD": {
+        "size_bytes": 255,
+        "md5_digest": "cdeac934f1154489924a071470b22365"
+      }
+    },
+    "aliases": [
+      "en-us-libritts-high"
+    ],
+    "has_rt_variant": false
+  },
+  "en_US-libritts_r-medium": {
+    "key": "en_US-libritts_r-medium",
+    "name": "libritts_r",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 904,
+    "speaker_id_map": {
+      "3922": 0,
+      "8699": 1,
+      "4535": 2,
+      "6701": 3,
+      "3638": 4,
+      "922": 5,
+      "2531": 6,
+      "1638": 7,
+      "8848": 8,
+      "6544": 9,
+      "3615": 10,
+      "318": 11,
+      "6104": 12,
+      "5400": 13,
+      "5712": 14,
+      "1382": 15,
+      "2769": 16,
+      "2573": 17,
+      "1463": 18,
+      "6458": 19,
+      "4356": 20,
+      "3274": 21,
+      "8498": 22,
+      "5570": 23,
+      "176": 24,
+      "339": 25,
+      "28": 26,
+      "5909": 27,
+      "3869": 28,
+      "4899": 29,
+      "64": 30,
+      "3368": 31,
+      "3307": 32,
+      "5618": 33,
+      "3370": 34,
+      "4595": 35,
+      "7704": 36,
+      "8506": 37,
+      "8410": 38,
+      "6904": 39,
+      "5655": 40,
+      "2204": 41,
+      "501": 42,
+      "7314": 43,
+      "1027": 44,
+      "5054": 45,
+      "534": 46,
+      "2853": 47,
+      "5935": 48,
+      "2404": 49,
+      "7874": 50,
+      "816": 51,
+      "2053": 52,
+      "8066": 53,
+      "16": 54,
+      "4586": 55,
+      "1923": 56,
+      "2592": 57,
+      "1265": 58,
+      "6189": 59,
+      "100": 60,
+      "6371": 61,
+      "4957": 62,
+      "4116": 63,
+      "3003": 64,
+      "7739": 65,
+      "1752": 66,
+      "5717": 67,
+      "5012": 68,
+      "5062": 69,
+      "7481": 70,
+      "2299": 71,
+      "7188": 72,
+      "93": 73,
+      "4145": 74,
+      "8684": 75,
+      "7594": 76,
+      "2598": 77,
+      "3540": 78,
+      "7717": 79,
+      "6426": 80,
+      "4148": 81,
+      "1379": 82,
+      "2512": 83,
+      "335": 84,
+      "242": 85,
+      "8855": 86,
+      "8118": 87,
+      "369": 88,
+      "6575": 89,
+      "6694": 90,
+      "8080": 91,
+      "1283": 92,
+      "7434": 93,
+      "5290": 94,
+      "1731": 95,
+      "2401": 96,
+      "459": 97,
+      "192": 98,
+      "7910": 99,
+      "114": 100,
+      "5660": 101,
+      "1313": 102,
+      "203": 103,
+      "7460": 104,
+      "207": 105,
+      "6497": 106,
+      "6696": 107,
+      "7766": 108,
+      "6233": 109,
+      "3185": 110,
+      "2010": 111,
+      "2056": 112,
+      "3717": 113,
+      "5802": 114,
+      "5622": 115,
+      "2156": 116,
+      "4243": 117,
+      "5039": 118,
+      "4110": 119,
+      "1093": 120,
+      "1776": 121,
+      "7995": 122,
+      "6877": 123,
+      "5635": 124,
+      "54": 125,
+      "288": 126,
+      "4592": 127,
+      "7276": 128,
+      "688": 129,
+      "8388": 130,
+      "1422": 131,
+      "8152": 132,
+      "8194": 133,
+      "7000": 134,
+      "8527": 135,
+      "5126": 136,
+      "3923": 137,
+      "1054": 138,
+      "3927": 139,
+      "5029": 140,
+      "4098": 141,
+      "56": 142,
+      "7240": 143,
+      "5538": 144,
+      "1903": 145,
+      "6538": 146,
+      "3380": 147,
+      "6643": 148,
+      "7495": 149,
+      "8718": 150,
+      "8050": 151,
+      "1789": 152,
+      "126": 153,
+      "7245": 154,
+      "2517": 155,
+      "4438": 156,
+      "7145": 157,
+      "724": 158,
+      "4945": 159,
+      "9022": 160,
+      "6637": 161,
+      "6927": 162,
+      "6937": 163,
+      "8113": 164,
+      "5724": 165,
+      "6006": 166,
+      "3584": 167,
+      "2971": 168,
+      "2230": 169,
+      "7982": 170,
+      "1649": 171,
+      "3994": 172,
+      "7720": 173,
+      "6981": 174,
+      "781": 175,
+      "4973": 176,
+      "6206": 177,
+      "2481": 178,
+      "3157": 179,
+      "1509": 180,
+      "510": 181,
+      "7540": 182,
+      "8887": 183,
+      "7120": 184,
+      "2882": 185,
+      "7128": 186,
+      "8142": 187,
+      "7229": 188,
+      "2787": 189,
+      "8820": 190,
+      "2368": 191,
+      "4331": 192,
+      "4967": 193,
+      "4427": 194,
+      "6054": 195,
+      "3728": 196,
+      "274": 197,
+      "7134": 198,
+      "1603": 199,
+      "1383": 200,
+      "1165": 201,
+      "4363": 202,
+      "512": 203,
+      "5985": 204,
+      "7967": 205,
+      "2060": 206,
+      "7752": 207,
+      "7484": 208,
+      "8643": 209,
+      "3549": 210,
+      "5731": 211,
+      "7881": 212,
+      "667": 213,
+      "6828": 214,
+      "5740": 215,
+      "3483": 216,
+      "718": 217,
+      "6341": 218,
+      "1913": 219,
+      "3228": 220,
+      "7247": 221,
+      "7705": 222,
+      "1018": 223,
+      "8193": 224,
+      "6098": 225,
+      "3989": 226,
+      "7828": 227,
+      "5876": 228,
+      "7754": 229,
+      "4719": 230,
+      "8011": 231,
+      "7939": 232,
+      "5975": 233,
+      "2004": 234,
+      "6139": 235,
+      "8183": 236,
+      "3482": 237,
+      "3361": 238,
+      "4289": 239,
+      "231": 240,
+      "7789": 241,
+      "4598": 242,
+      "5239": 243,
+      "2638": 244,
+      "6300": 245,
+      "8474": 246,
+      "2194": 247,
+      "7832": 248,
+      "1079": 249,
+      "1335": 250,
+      "188": 251,
+      "1195": 252,
+      "5914": 253,
+      "1401": 254,
+      "7318": 255,
+      "5448": 256,
+      "1392": 257,
+      "3703": 258,
+      "2113": 259,
+      "7783": 260,
+      "8176": 261,
+      "6519": 262,
+      "7933": 263,
+      "7938": 264,
+      "7802": 265,
+      "6120": 266,
+      "224": 267,
+      "209": 268,
+      "5656": 269,
+      "3032": 270,
+      "6965": 271,
+      "258": 272,
+      "4837": 273,
+      "5489": 274,
+      "272": 275,
+      "3851": 276,
+      "7140": 277,
+      "2562": 278,
+      "1472": 279,
+      "79": 280,
+      "2775": 281,
+      "3046": 282,
+      "2532": 283,
+      "8266": 284,
+      "6099": 285,
+      "4425": 286,
+      "5293": 287,
+      "7981": 288,
+      "2045": 289,
+      "920": 290,
+      "511": 291,
+      "7416": 292,
+      "835": 293,
+      "1289": 294,
+      "8195": 295,
+      "7833": 296,
+      "8772": 297,
+      "968": 298,
+      "1641": 299,
+      "7117": 300,
+      "1678": 301,
+      "5809": 302,
+      "8028": 303,
+      "500": 304,
+      "6505": 305,
+      "7868": 306,
+      "14": 307,
+      "2238": 308,
+      "4744": 309,
+      "3733": 310,
+      "7515": 311,
+      "699": 312,
+      "5093": 313,
+      "6388": 314,
+      "7959": 315,
+      "98": 316,
+      "3914": 317,
+      "5246": 318,
+      "2570": 319,
+      "8396": 320,
+      "3513": 321,
+      "882": 322,
+      "7994": 323,
+      "5968": 324,
+      "8591": 325,
+      "806": 326,
+      "5261": 327,
+      "1271": 328,
+      "899": 329,
+      "3945": 330,
+      "8404": 331,
+      "249": 332,
+      "3008": 333,
+      "7139": 334,
+      "6395": 335,
+      "6215": 336,
+      "6080": 337,
+      "4054": 338,
+      "7825": 339,
+      "6683": 340,
+      "8725": 341,
+      "3230": 342,
+      "4138": 343,
+      "6160": 344,
+      "666": 345,
+      "6510": 346,
+      "3551": 347,
+      "8075": 348,
+      "225": 349,
+      "7169": 350,
+      "1851": 351,
+      "5984": 352,
+      "2960": 353,
+      "8329": 354,
+      "175": 355,
+      "6378": 356,
+      "480": 357,
+      "7538": 358,
+      "479": 359,
+      "5519": 360,
+      "8534": 361,
+      "4856": 362,
+      "101": 363,
+      "3521": 364,
+      "2256": 365,
+      "3083": 366,
+      "4278": 367,
+      "8713": 368,
+      "1226": 369,
+      "4222": 370,
+      "8494": 371,
+      "8776": 372,
+      "731": 373,
+      "6574": 374,
+      "5319": 375,
+      "8605": 376,
+      "5583": 377,
+      "6406": 378,
+      "4064": 379,
+      "4806": 380,
+      "3972": 381,
+      "7383": 382,
+      "5133": 383,
+      "597": 384,
+      "1025": 385,
+      "7313": 386,
+      "5304": 387,
+      "8758": 388,
+      "1050": 389,
+      "6499": 390,
+      "6956": 391,
+      "770": 392,
+      "4108": 393,
+      "2774": 394,
+      "3864": 395,
+      "4490": 396,
+      "4848": 397,
+      "1826": 398,
+      "6294": 399,
+      "7949": 400,
+      "1446": 401,
+      "7867": 402,
+      "8163": 403,
+      "953": 404,
+      "8138": 405,
+      "353": 406,
+      "7553": 407,
+      "8825": 408,
+      "5189": 409,
+      "2012": 410,
+      "948": 411,
+      "205": 412,
+      "1535": 413,
+      "8008": 414,
+      "1112": 415,
+      "7926": 416,
+      "4039": 417,
+      "716": 418,
+      "3967": 419,
+      "7932": 420,
+      "7525": 421,
+      "7316": 422,
+      "2393": 423,
+      "6788": 424,
+      "6550": 425,
+      "7011": 426,
+      "8791": 427,
+      "8119": 428,
+      "1777": 429,
+      "6014": 430,
+      "1046": 431,
+      "6269": 432,
+      "6188": 433,
+      "5266": 434,
+      "3490": 435,
+      "8786": 436,
+      "8824": 437,
+      "3448": 438,
+      "589": 439,
+      "576": 440,
+      "1121": 441,
+      "1806": 442,
+      "7294": 443,
+      "3119": 444,
+      "2688": 445,
+      "3446": 446,
+      "1012": 447,
+      "4807": 448,
+      "7498": 449,
+      "3905": 450,
+      "7384": 451,
+      "2992": 452,
+      "30": 453,
+      "497": 454,
+      "227": 455,
+      "4226": 456,
+      "5007": 457,
+      "1066": 458,
+      "8222": 459,
+      "7688": 460,
+      "6865": 461,
+      "6286": 462,
+      "8225": 463,
+      "3224": 464,
+      "8635": 465,
+      "1348": 466,
+      "3645": 467,
+      "1961": 468,
+      "8190": 469,
+      "6032": 470,
+      "7286": 471,
+      "5389": 472,
+      "3105": 473,
+      "1028": 474,
+      "6038": 475,
+      "764": 476,
+      "7437": 477,
+      "6555": 478,
+      "8875": 479,
+      "2074": 480,
+      "7809": 481,
+      "2240": 482,
+      "2827": 483,
+      "5386": 484,
+      "6763": 485,
+      "3009": 486,
+      "6339": 487,
+      "1825": 488,
+      "7569": 489,
+      "359": 490,
+      "7956": 491,
+      "2137": 492,
+      "8677": 493,
+      "4434": 494,
+      "329": 495,
+      "3289": 496,
+      "4290": 497,
+      "2999": 498,
+      "2427": 499,
+      "637": 500,
+      "2229": 501,
+      "1874": 502,
+      "9023": 503,
+      "3114": 504,
+      "6235": 505,
+      "4860": 506,
+      "4519": 507,
+      "561": 508,
+      "70": 509,
+      "4800": 510,
+      "2294": 511,
+      "6115": 512,
+      "2582": 513,
+      "8464": 514,
+      "5139": 515,
+      "6918": 516,
+      "337": 517,
+      "5810": 518,
+      "8401": 519,
+      "303": 520,
+      "5206": 521,
+      "2589": 522,
+      "7061": 523,
+      "2269": 524,
+      "2758": 525,
+      "3389": 526,
+      "4629": 527,
+      "707": 528,
+      "5606": 529,
+      "1513": 530,
+      "2473": 531,
+      "664": 532,
+      "5092": 533,
+      "5154": 534,
+      "6288": 535,
+      "6308": 536,
+      "4731": 537,
+      "3328": 538,
+      "7816": 539,
+      "3221": 540,
+      "8687": 541,
+      "7030": 542,
+      "476": 543,
+      "5918": 544,
+      "6317": 545,
+      "204": 546,
+      "8006": 547,
+      "6895": 548,
+      "1264": 549,
+      "112": 550,
+      "1859": 551,
+      "398": 552,
+      "1052": 553,
+      "3294": 554,
+      "1460": 555,
+      "8573": 556,
+      "5684": 557,
+      "8421": 558,
+      "5883": 559,
+      "7297": 560,
+      "246": 561,
+      "8057": 562,
+      "3835": 563,
+      "1748": 564,
+      "3816": 565,
+      "3357": 566,
+      "1053": 567,
+      "409": 568,
+      "868": 569,
+      "3118": 570,
+      "7520": 571,
+      "2494": 572,
+      "6686": 573,
+      "1241": 574,
+      "5190": 575,
+      "166": 576,
+      "4257": 577,
+      "1482": 578,
+      "5604": 579,
+      "1212": 580,
+      "2741": 581,
+      "1259": 582,
+      "984": 583,
+      "6492": 584,
+      "6167": 585,
+      "296": 586,
+      "6567": 587,
+      "6924": 588,
+      "2272": 589,
+      "7085": 590,
+      "2388": 591,
+      "1705": 592,
+      "1343": 593,
+      "7241": 594,
+      "451": 595,
+      "345": 596,
+      "5401": 597,
+      "6446": 598,
+      "612": 599,
+      "594": 600,
+      "7555": 601,
+      "7069": 602,
+      "2577": 603,
+      "5333": 604,
+      "8742": 605,
+      "6727": 606,
+      "1571": 607,
+      "4734": 608,
+      "7258": 609,
+      "3977": 610,
+      "373": 611,
+      "5723": 612,
+      "1365": 613,
+      "7285": 614,
+      "580": 615,
+      "836": 616,
+      "6782": 617,
+      "3654": 618,
+      "1974": 619,
+      "6258": 620,
+      "925": 621,
+      "949": 622,
+      "2790": 623,
+      "698": 624,
+      "6373": 625,
+      "2785": 626,
+      "1222": 627,
+      "2751": 628,
+      "3825": 629,
+      "5115": 630,
+      "1827": 631,
+      "3171": 632,
+      "119": 633,
+      "850": 634,
+      "3258": 635,
+      "7909": 636,
+      "1322": 637,
+      "8097": 638,
+      "22": 639,
+      "7478": 640,
+      "1349": 641,
+      "4854": 642,
+      "2929": 643,
+      "7335": 644,
+      "5868": 645,
+      "454": 646,
+      "7945": 647,
+      "2654": 648,
+      "3493": 649,
+      "1060": 650,
+      "8545": 651,
+      "6509": 652,
+      "5002": 653,
+      "7732": 654,
+      "3082": 655,
+      "1779": 656,
+      "2709": 657,
+      "7398": 658,
+      "8879": 659,
+      "639": 660,
+      "598": 661,
+      "5672": 662,
+      "6553": 663,
+      "4111": 664,
+      "1417": 665,
+      "7991": 666,
+      "380": 667,
+      "8459": 668,
+      "8347": 669,
+      "1769": 670,
+      "2673": 671,
+      "3330": 672,
+      "7051": 673,
+      "1337": 674,
+      "4057": 675,
+      "4839": 676,
+      "6060": 677,
+      "7095": 678,
+      "278": 679,
+      "1445": 680,
+      "6518": 681,
+      "2364": 682,
+      "1958": 683,
+      "548": 684,
+      "4010": 685,
+      "3072": 686,
+      "6993": 687,
+      "8575": 688,
+      "2149": 689,
+      "240": 690,
+      "2920": 691,
+      "5588": 692,
+      "1885": 693,
+      "6082": 694,
+      "9026": 695,
+      "340": 696,
+      "159": 697,
+      "7730": 698,
+      "7962": 699,
+      "1987": 700,
+      "3876": 701,
+      "8771": 702,
+      "5123": 703,
+      "3866": 704,
+      "3546": 705,
+      "7777": 706,
+      "115": 707,
+      "5337": 708,
+      "475": 709,
+      "1724": 710,
+      "6359": 711,
+      "4260": 712,
+      "2110": 713,
+      "1845": 714,
+      "4335": 715,
+      "4133": 716,
+      "783": 717,
+      "8479": 718,
+      "1448": 719,
+      "1160": 720,
+      "7647": 721,
+      "2618": 722,
+      "3630": 723,
+      "4013": 724,
+      "5242": 725,
+      "7957": 726,
+      "3852": 727,
+      "3889": 728,
+      "1387": 729,
+      "439": 730,
+      "1425": 731,
+      "2061": 732,
+      "7395": 733,
+      "7837": 734,
+      "5147": 735,
+      "2319": 736,
+      "3781": 737,
+      "1311": 738,
+      "4733": 739,
+      "8705": 740,
+      "3094": 741,
+      "2823": 742,
+      "1914": 743,
+      "954": 744,
+      "4381": 745,
+      "4044": 746,
+      "593": 747,
+      "8300": 748,
+      "7558": 749,
+      "6494": 750,
+      "6330": 751,
+      "5940": 752,
+      "7126": 753,
+      "1061": 754,
+      "6352": 755,
+      "5186": 756,
+      "1944": 757,
+      "2285": 758,
+      "6673": 759,
+      "5746": 760,
+      "208": 761,
+      "492": 762,
+      "216": 763,
+      "979": 764,
+      "1668": 765,
+      "6620": 766,
+      "711": 767,
+      "7733": 768,
+      "8619": 769,
+      "5157": 770,
+      "829": 771,
+      "3180": 772,
+      "3979": 773,
+      "1556": 774,
+      "3379": 775,
+      "5727": 776,
+      "596": 777,
+      "2127": 778,
+      "581": 779,
+      "2652": 780,
+      "2628": 781,
+      "1849": 782,
+      "4238": 783,
+      "606": 784,
+      "1224": 785,
+      "1629": 786,
+      "1413": 787,
+      "957": 788,
+      "8592": 789,
+      "2254": 790,
+      "1323": 791,
+      "122": 792,
+      "2093": 793,
+      "1100": 794,
+      "81": 795,
+      "323": 796,
+      "815": 797,
+      "2581": 798,
+      "543": 799,
+      "6037": 800,
+      "2397": 801,
+      "5513": 802,
+      "4495": 803,
+      "5776": 804,
+      "17": 805,
+      "4590": 806,
+      "8228": 807,
+      "708": 808,
+      "3792": 809,
+      "3790": 810,
+      "7090": 811,
+      "1943": 812,
+      "4246": 813,
+      "559": 814,
+      "3738": 815,
+      "2167": 816,
+      "1933": 817,
+      "2162": 818,
+      "549": 819,
+      "3025": 820,
+      "1182": 821,
+      "4358": 822,
+      "636": 823,
+      "986": 824,
+      "8490": 825,
+      "3340": 826,
+      "90": 827,
+      "1487": 828,
+      "1639": 829,
+      "1547": 830,
+      "4152": 831,
+      "1498": 832,
+      "1740": 833,
+      "6157": 834,
+      "217": 835,
+      "2201": 836,
+      "362": 837,
+      "2146": 838,
+      "1801": 839,
+      "5063": 840,
+      "7339": 841,
+      "663": 842,
+      "38": 843,
+      "1336": 844,
+      "3215": 845,
+      "210": 846,
+      "6075": 847,
+      "55": 848,
+      "2411": 849,
+      "7445": 850,
+      "5767": 851,
+      "2812": 852,
+      "472": 853,
+      "803": 854,
+      "4236": 855,
+      "7665": 856,
+      "1607": 857,
+      "1316": 858,
+      "7475": 859,
+      "3001": 860,
+      "1473": 861,
+      "3537": 862,
+      "3070": 863,
+      "1390": 864,
+      "1290": 865,
+      "2499": 866,
+      "154": 867,
+      "7518": 868,
+      "408": 869,
+      "1811": 870,
+      "1734": 871,
+      "7342": 872,
+      "8722": 873,
+      "1754": 874,
+      "7657": 875,
+      "583": 876,
+      "830": 877,
+      "6690": 878,
+      "1552": 879,
+      "2498": 880,
+      "1296": 881,
+      "3686": 882,
+      "157": 883,
+      "487": 884,
+      "6119": 885,
+      "4926": 886,
+      "4846": 887,
+      "1536": 888,
+      "2674": 889,
+      "1645": 890,
+      "3187": 891,
+      "1058": 892,
+      "2039": 893,
+      "4071": 894,
+      "4433": 895,
+      "1175": 896,
+      "434": 897,
+      "1001": 898,
+      "2816": 899,
+      "820": 900,
+      "2696": 901,
+      "4681": 902,
+      "2085": 903
+    },
+    "files": {
+      "en/en_US/libritts_r/medium/en_US-libritts_r-medium.onnx": {
+        "size_bytes": 78580914,
+        "md5_digest": "bb2c2776cffbfd736c7c497f620c0ca6"
+      },
+      "en/en_US/libritts_r/medium/en_US-libritts_r-medium.onnx.json": {
+        "size_bytes": 20123,
+        "md5_digest": "c740db18a0dab11b13ce0292ea1196c6"
+      },
+      "en/en_US/libritts_r/medium/MODEL_CARD": {
+        "size_bytes": 279,
+        "md5_digest": "ae42a6ca5f3fdc81690d4fe191b6fdee"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-ljspeech-high": {
+    "key": "en_US-ljspeech-high",
+    "name": "ljspeech",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/ljspeech/high/en_US-ljspeech-high.onnx": {
+        "size_bytes": 114199011,
+        "md5_digest": "dad093b5d2cff6a5fda99883ceda09d1"
+      },
+      "en/en_US/ljspeech/high/en_US-ljspeech-high.onnx.json": {
+        "size_bytes": 4970,
+        "md5_digest": "de98fc398ddead60fb82d93bfafb3ad1"
+      },
+      "en/en_US/ljspeech/high/MODEL_CARD": {
+        "size_bytes": 515,
+        "md5_digest": "59322a9a8d2c0e556f0be1171cd54ea7"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-ljspeech-medium": {
+    "key": "en_US-ljspeech-medium",
+    "name": "ljspeech",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/ljspeech/medium/en_US-ljspeech-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "109d552e9dd78d92d1169a7edd6de38d"
+      },
+      "en/en_US/ljspeech/medium/en_US-ljspeech-medium.onnx.json": {
+        "size_bytes": 4972,
+        "md5_digest": "0668112b8b3ac5bb4b12c2b1a366776a"
+      },
+      "en/en_US/ljspeech/medium/MODEL_CARD": {
+        "size_bytes": 517,
+        "md5_digest": "5ad31d314786587d4f97effb0b716d61"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "en_US-norman-medium": {
+    "key": "en_US-norman-medium",
+    "name": "norman",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/norman/medium/en_US-norman-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "829cea515dc724d694b83b71e8083f9f"
+      },
+      "en/en_US/norman/medium/en_US-norman-medium.onnx.json": {
+        "size_bytes": 4968,
+        "md5_digest": "975830d6f230f6eccf657d265de99eba"
+      },
+      "en/en_US/norman/medium/MODEL_CARD": {
+        "size_bytes": 528,
+        "md5_digest": "c34f20bbc4918681ad7a070a8321f2fa"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_US-reza_ibrahim-medium": {
+    "key": "en_US-reza_ibrahim-medium",
+    "name": "reza_ibrahim",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/reza_ibrahim/medium/en_US-reza_ibrahim-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "b9d4059c794df8336060fb7f36264a43"
+      },
+      "en/en_US/reza_ibrahim/medium/en_US-reza_ibrahim-medium.onnx.json": {
+        "size_bytes": 4976,
+        "md5_digest": "94aa2ac1bcb4c64f3c4c561d5d5f5676"
+      },
+      "en/en_US/reza_ibrahim/medium/MODEL_CARD": {
+        "size_bytes": 635,
+        "md5_digest": "941fdcc93ba4b03298ac2218c7e350fc"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "en_US-ryan-high": {
+    "key": "en_US-ryan-high",
+    "name": "ryan",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/ryan/high/en_US-ryan-high.onnx": {
+        "size_bytes": 120786792,
+        "md5_digest": "5d879a17bddf5007f76655b445ba78b4"
+      },
+      "en/en_US/ryan/high/en_US-ryan-high.onnx.json": {
+        "size_bytes": 4166,
+        "md5_digest": "444ff9d6c17218a0eb1d12a20559d869"
+      },
+      "en/en_US/ryan/high/MODEL_CARD": {
+        "size_bytes": 265,
+        "md5_digest": "9c966517ed0bfbffbfdb218e99dbeadd"
+      }
+    },
+    "aliases": [
+      "en-us-ryan-high"
+    ],
+    "has_rt_variant": false
+  },
+  "en_US-ryan-low": {
+    "key": "en_US-ryan-low",
+    "name": "ryan",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/ryan/low/en_US-ryan-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "32f6a995d6d561cd040b20a76f4edb1e"
+      },
+      "en/en_US/ryan/low/en_US-ryan-low.onnx.json": {
+        "size_bytes": 4165,
+        "md5_digest": "38eb0602e1f8bf627a0d9a747723cbf6"
+      },
+      "en/en_US/ryan/low/MODEL_CARD": {
+        "size_bytes": 263,
+        "md5_digest": "030252d21b0bd1048c37a9eb7f94eb17"
+      }
+    },
+    "aliases": [
+      "en-us-ryan-low"
+    ],
+    "has_rt_variant": false
+  },
+  "en_US-ryan-medium": {
+    "key": "en_US-ryan-medium",
+    "name": "ryan",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/ryan/medium/en_US-ryan-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "8f06d3aff8ded5a7f13f907e6bec32ac"
+      },
+      "en/en_US/ryan/medium/en_US-ryan-medium.onnx.json": {
+        "size_bytes": 4883,
+        "md5_digest": "f173a2b5202b3e4128ccc3ed8195306c"
+      },
+      "en/en_US/ryan/medium/MODEL_CARD": {
+        "size_bytes": 306,
+        "md5_digest": "79d9200481a9dcabfa1803cb9e31c28a"
+      }
+    },
+    "aliases": [
+      "en-us-ryan-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "en_US-sam-medium": {
+    "key": "en_US-sam-medium",
+    "name": "sam",
+    "language": {
+      "code": "en_US",
+      "family": "en",
+      "region": "US",
+      "name_native": "English",
+      "name_english": "English",
+      "country_english": "United States"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "en/en_US/sam/medium/en_US-sam-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "57efcb38a3d0510051f9f55c517ccb76"
+      },
+      "en/en_US/sam/medium/en_US-sam-medium.onnx.json": {
+        "size_bytes": 5040,
+        "md5_digest": "a124497d09ce818f9800d16f24e1a8d1"
+      },
+      "en/en_US/sam/medium/MODEL_CARD": {
+        "size_bytes": 354,
+        "md5_digest": "6d703b6f41e53c4a6fb6512e91780dc0"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "es_AR-daniela-high": {
+    "key": "es_AR-daniela-high",
+    "name": "daniela",
+    "language": {
+      "code": "es_AR",
+      "family": "es",
+      "region": "AR",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Argentina"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_AR/daniela/high/es_AR-daniela-high.onnx": {
+        "size_bytes": 114199011,
+        "md5_digest": "e373fb657c93877dbc438badeadff4cb"
+      },
+      "es/es_AR/daniela/high/es_AR-daniela-high.onnx.json": {
+        "size_bytes": 7248,
+        "md5_digest": "b68d699a1779d98ee94c0cd9a08ba95b"
+      },
+      "es/es_AR/daniela/high/MODEL_CARD": {
+        "size_bytes": 353,
+        "md5_digest": "d940f7c6667a11ea165ff83ef7a86669"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "es_ES-carlfm-x_low": {
+    "key": "es_ES-carlfm-x_low",
+    "name": "carlfm",
+    "language": {
+      "code": "es_ES",
+      "family": "es",
+      "region": "ES",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Spain"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_ES/carlfm/x_low/es_ES-carlfm-x_low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "4137b5aee01ea6241080fc4dbe59a8ee"
+      },
+      "es/es_ES/carlfm/x_low/es_ES-carlfm-x_low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "f4ab058cc8b5d024f1b123d06049df22"
+      },
+      "es/es_ES/carlfm/x_low/MODEL_CARD": {
+        "size_bytes": 250,
+        "md5_digest": "19cb47bbe9e07e8d7937cfd39027d3a9"
+      }
+    },
+    "aliases": [
+      "es-carlfm-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "es_ES-davefx-medium": {
+    "key": "es_ES-davefx-medium",
+    "name": "davefx",
+    "language": {
+      "code": "es_ES",
+      "family": "es",
+      "region": "ES",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Spain"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_ES/davefx/medium/es_ES-davefx-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "dc515cd4ecc5f6f72fe14a941188fc9c"
+      },
+      "es/es_ES/davefx/medium/es_ES-davefx-medium.onnx.json": {
+        "size_bytes": 4817,
+        "md5_digest": "dd157b5eaf6930bf949cf416d9a9307a"
+      },
+      "es/es_ES/davefx/medium/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "5569c0fb20448308466216428b52f392"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "es_ES-mls_10246-low": {
+    "key": "es_ES-mls_10246-low",
+    "name": "mls_10246",
+    "language": {
+      "code": "es_ES",
+      "family": "es",
+      "region": "ES",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Spain"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_ES/mls_10246/low/es_ES-mls_10246-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "ab8e93c9d2714fd4481fbca4e2a38891"
+      },
+      "es/es_ES/mls_10246/low/es_ES-mls_10246-low.onnx.json": {
+        "size_bytes": 4160,
+        "md5_digest": "8948a322c81cae2bc5fb1b9bbbc4961e"
+      },
+      "es/es_ES/mls_10246/low/MODEL_CARD": {
+        "size_bytes": 257,
+        "md5_digest": "a345cefedda92347f53ea9a84d1b3983"
+      }
+    },
+    "aliases": [
+      "es-mls_10246-low"
+    ],
+    "has_rt_variant": false
+  },
+  "es_ES-mls_9972-low": {
+    "key": "es_ES-mls_9972-low",
+    "name": "mls_9972",
+    "language": {
+      "code": "es_ES",
+      "family": "es",
+      "region": "ES",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Spain"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_ES/mls_9972/low/es_ES-mls_9972-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "587f2fc38dc3f582e771c3748465e2a2"
+      },
+      "es/es_ES/mls_9972/low/es_ES-mls_9972-low.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "97195bce39639d77af82c9c9c2110620"
+      },
+      "es/es_ES/mls_9972/low/MODEL_CARD": {
+        "size_bytes": 256,
+        "md5_digest": "4ba8c18ce72a202a49312ee1914ca6b0"
+      }
+    },
+    "aliases": [
+      "es-mls_9972-low"
+    ],
+    "has_rt_variant": false
+  },
+  "es_ES-sharvard-medium": {
+    "key": "es_ES-sharvard-medium",
+    "name": "sharvard",
+    "language": {
+      "code": "es_ES",
+      "family": "es",
+      "region": "ES",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Spain"
+    },
+    "quality": "medium",
+    "num_speakers": 2,
+    "speaker_id_map": {
+      "M": 0,
+      "F": 1
+    },
+    "files": {
+      "es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx": {
+        "size_bytes": 76733615,
+        "md5_digest": "77e6f9c26e92799fb04bb90b46bf1834"
+      },
+      "es/es_ES/sharvard/medium/es_ES-sharvard-medium.onnx.json": {
+        "size_bytes": 4903,
+        "md5_digest": "e49cab310ce362145f7d94b347c291ff"
+      },
+      "es/es_ES/sharvard/medium/MODEL_CARD": {
+        "size_bytes": 392,
+        "md5_digest": "b600a21381af84fa21b29f519a3a829a"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "es_MX-ald-medium": {
+    "key": "es_MX-ald-medium",
+    "name": "ald",
+    "language": {
+      "code": "es_MX",
+      "family": "es",
+      "region": "MX",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Mexico"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_MX/ald/medium/es_MX-ald-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "86374058e59b41ac3b7fe4181e1daad6"
+      },
+      "es/es_MX/ald/medium/es_MX-ald-medium.onnx.json": {
+        "size_bytes": 4889,
+        "md5_digest": "31c5463bf001d6e69bf57fc5916c0908"
+      },
+      "es/es_MX/ald/medium/MODEL_CARD": {
+        "size_bytes": 320,
+        "md5_digest": "a858af3698e0c7cda6c9ad5d0d11b651"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "es_MX-claude-high": {
+    "key": "es_MX-claude-high",
+    "name": "claude",
+    "language": {
+      "code": "es_MX",
+      "family": "es",
+      "region": "MX",
+      "name_native": "Español",
+      "name_english": "Spanish",
+      "country_english": "Mexico"
+    },
+    "quality": "high",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "es/es_MX/claude/high/es_MX-claude-high.onnx": {
+        "size_bytes": 63122309,
+        "md5_digest": "cb1966e0ff20ca3aa010f6c9a0ce296a"
+      },
+      "es/es_MX/claude/high/es_MX-claude-high.onnx.json": {
+        "size_bytes": 4963,
+        "md5_digest": "36882201922fabb409f18d284af3eddd"
+      },
+      "es/es_MX/claude/high/MODEL_CARD": {
+        "size_bytes": 247,
+        "md5_digest": "bca99dc9b9a6c8f2f8563d73d52c4a3b"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fa_IR-amir-medium": {
+    "key": "fa_IR-amir-medium",
+    "name": "amir",
+    "language": {
+      "code": "fa_IR",
+      "family": "fa",
+      "region": "IR",
+      "name_native": "فارسی",
+      "name_english": "Farsi",
+      "country_english": "Iran"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fa/fa_IR/amir/medium/fa_IR-amir-medium.onnx": {
+        "size_bytes": 63531379,
+        "md5_digest": "7c0598c9726427869e1e86447b333539"
+      },
+      "fa/fa_IR/amir/medium/fa_IR-amir-medium.onnx.json": {
+        "size_bytes": 4958,
+        "md5_digest": "48c5e81f5aa4e1c5eba3dda0be403b58"
+      },
+      "fa/fa_IR/amir/medium/MODEL_CARD": {
+        "size_bytes": 264,
+        "md5_digest": "0728165259eb968913a680077607cd5c"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fa_IR-ganji-medium": {
+    "key": "fa_IR-ganji-medium",
+    "name": "ganji",
+    "language": {
+      "code": "fa_IR",
+      "family": "fa",
+      "region": "IR",
+      "name_native": "فارسی",
+      "name_english": "Farsi",
+      "country_english": "Iran"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fa/fa_IR/ganji/medium/fa_IR-ganji-medium.onnx": {
+        "size_bytes": 63516050,
+        "md5_digest": "b50577af60b986135b37edaeaabb01b9"
+      },
+      "fa/fa_IR/ganji/medium/fa_IR-ganji-medium.onnx.json": {
+        "size_bytes": 4958,
+        "md5_digest": "717462455e6abf8a4b8ea2365faaa41c"
+      },
+      "fa/fa_IR/ganji/medium/MODEL_CARD": {
+        "size_bytes": 247,
+        "md5_digest": "30c45ec6a69cbca1f65af2f67fce870d"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fa_IR-ganji_adabi-medium": {
+    "key": "fa_IR-ganji_adabi-medium",
+    "name": "ganji_adabi",
+    "language": {
+      "code": "fa_IR",
+      "family": "fa",
+      "region": "IR",
+      "name_native": "فارسی",
+      "name_english": "Farsi",
+      "country_english": "Iran"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fa/fa_IR/ganji_adabi/medium/fa_IR-ganji_adabi-medium.onnx": {
+        "size_bytes": 63516050,
+        "md5_digest": "596844694672ac3d007c544301874553"
+      },
+      "fa/fa_IR/ganji_adabi/medium/fa_IR-ganji_adabi-medium.onnx.json": {
+        "size_bytes": 4964,
+        "md5_digest": "4ddbb3131d8bbf33cdc4d441062db6f4"
+      },
+      "fa/fa_IR/ganji_adabi/medium/MODEL_CARD": {
+        "size_bytes": 253,
+        "md5_digest": "0cdd82f4e66bde5ac302a6cfe6e68337"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fa_IR-gyro-medium": {
+    "key": "fa_IR-gyro-medium",
+    "name": "gyro",
+    "language": {
+      "code": "fa_IR",
+      "family": "fa",
+      "region": "IR",
+      "name_native": "فارسی",
+      "name_english": "Farsi",
+      "country_english": "Iran"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fa/fa_IR/gyro/medium/fa_IR-gyro-medium.onnx": {
+        "size_bytes": 63122309,
+        "md5_digest": "e8ce094894c8ec2a77bfd0397b45d112"
+      },
+      "fa/fa_IR/gyro/medium/fa_IR-gyro-medium.onnx.json": {
+        "size_bytes": 7210,
+        "md5_digest": "15bcedc4117870524b30b0e07bdee27f"
+      },
+      "fa/fa_IR/gyro/medium/MODEL_CARD": {
+        "size_bytes": 262,
+        "md5_digest": "b30a1713c6e67946e3f1ed33eac06039"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fa_IR-reza_ibrahim-medium": {
+    "key": "fa_IR-reza_ibrahim-medium",
+    "name": "reza_ibrahim",
+    "language": {
+      "code": "fa_IR",
+      "family": "fa",
+      "region": "IR",
+      "name_native": "فارسی",
+      "name_english": "Farsi",
+      "country_english": "Iran"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fa/fa_IR/reza_ibrahim/medium/fa_IR-reza_ibrahim-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "b9d4059c794df8336060fb7f36264a43"
+      },
+      "fa/fa_IR/reza_ibrahim/medium/fa_IR-reza_ibrahim-medium.onnx.json": {
+        "size_bytes": 4967,
+        "md5_digest": "2b6d6de83d6ea01f161e992b6a1edc8e"
+      },
+      "fa/fa_IR/reza_ibrahim/medium/MODEL_CARD": {
+        "size_bytes": 635,
+        "md5_digest": "941fdcc93ba4b03298ac2218c7e350fc"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fi_FI-harri-low": {
+    "key": "fi_FI-harri-low",
+    "name": "harri",
+    "language": {
+      "code": "fi_FI",
+      "family": "fi",
+      "region": "FI",
+      "name_native": "Suomi",
+      "name_english": "Finnish",
+      "country_english": "Finland"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fi/fi_FI/harri/low/fi_FI-harri-low.onnx": {
+        "size_bytes": 69795191,
+        "md5_digest": "f44b67203de7fd488eabc4692d30b598"
+      },
+      "fi/fi_FI/harri/low/fi_FI-harri-low.onnx.json": {
+        "size_bytes": 4155,
+        "md5_digest": "76822a028ed11d02d9d7c25a49223a10"
+      },
+      "fi/fi_FI/harri/low/MODEL_CARD": {
+        "size_bytes": 284,
+        "md5_digest": "93ccf398abae82b7d7a3d420658e26f1"
+      }
+    },
+    "aliases": [
+      "fi-harri-low"
+    ],
+    "has_rt_variant": false
+  },
+  "fi_FI-harri-medium": {
+    "key": "fi_FI-harri-medium",
+    "name": "harri",
+    "language": {
+      "code": "fi_FI",
+      "family": "fi",
+      "region": "FI",
+      "name_native": "Suomi",
+      "name_english": "Finnish",
+      "country_english": "Finland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fi/fi_FI/harri/medium/fi_FI-harri-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "8e96b9e765f8db3e910943520aa0f475"
+      },
+      "fi/fi_FI/harri/medium/fi_FI-harri-medium.onnx.json": {
+        "size_bytes": 4873,
+        "md5_digest": "d944b7607e545ee3a0d06887c3e4ccc4"
+      },
+      "fi/fi_FI/harri/medium/MODEL_CARD": {
+        "size_bytes": 304,
+        "md5_digest": "95d5aff86d27b69c8ee7deed6c056aff"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "fr_FR-gilles-low": {
+    "key": "fr_FR-gilles-low",
+    "name": "gilles",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "f984386d1f0927597f09a3ec10b11b5d"
+      },
+      "fr/fr_FR/gilles/low/fr_FR-gilles-low.onnx.json": {
+        "size_bytes": 4158,
+        "md5_digest": "38b1775fef8b9de50f15f63c5d8b8643"
+      },
+      "fr/fr_FR/gilles/low/MODEL_CARD": {
+        "size_bytes": 300,
+        "md5_digest": "9317af9efdb0d9986d42357b180f06e2"
+      }
+    },
+    "aliases": [
+      "fr-gilles-low"
+    ],
+    "has_rt_variant": false
+  },
+  "fr_FR-mls-medium": {
+    "key": "fr_FR-mls-medium",
+    "name": "mls",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "medium",
+    "num_speakers": 125,
+    "speaker_id_map": {
+      "1840": 0,
+      "3698": 1,
+      "123": 2,
+      "1474": 3,
+      "12709": 4,
+      "7423": 5,
+      "9242": 6,
+      "8778": 7,
+      "3060": 8,
+      "4512": 9,
+      "6249": 10,
+      "12541": 11,
+      "13634": 12,
+      "10065": 13,
+      "6128": 14,
+      "5232": 15,
+      "5764": 16,
+      "12713": 17,
+      "12823": 18,
+      "6070": 19,
+      "12501": 20,
+      "9121": 21,
+      "1649": 22,
+      "2776": 23,
+      "11772": 24,
+      "5612": 25,
+      "11822": 26,
+      "1590": 27,
+      "5525": 28,
+      "10827": 29,
+      "1243": 30,
+      "13142": 31,
+      "62": 32,
+      "13177": 33,
+      "10620": 34,
+      "8102": 35,
+      "8582": 36,
+      "11875": 37,
+      "7239": 38,
+      "9854": 39,
+      "7377": 40,
+      "10082": 41,
+      "12512": 42,
+      "1329": 43,
+      "2506": 44,
+      "6856": 45,
+      "10058": 46,
+      "103": 47,
+      "14": 48,
+      "6381": 49,
+      "1664": 50,
+      "11954": 51,
+      "66": 52,
+      "1127": 53,
+      "3270": 54,
+      "13611": 55,
+      "13658": 56,
+      "12968": 57,
+      "1989": 58,
+      "12981": 59,
+      "7193": 60,
+      "6348": 61,
+      "7679": 62,
+      "2284": 63,
+      "3182": 64,
+      "3503": 65,
+      "2033": 66,
+      "2771": 67,
+      "7614": 68,
+      "125": 69,
+      "3204": 70,
+      "5595": 71,
+      "5553": 72,
+      "694": 73,
+      "1624": 74,
+      "1887": 75,
+      "2926": 76,
+      "7150": 77,
+      "3190": 78,
+      "3344": 79,
+      "4699": 80,
+      "1798": 81,
+      "1745": 82,
+      "5077": 83,
+      "753": 84,
+      "52": 85,
+      "4174": 86,
+      "4018": 87,
+      "12899": 88,
+      "1844": 89,
+      "4396": 90,
+      "1817": 91,
+      "2155": 92,
+      "2946": 93,
+      "4336": 94,
+      "4609": 95,
+      "1977": 96,
+      "10957": 97,
+      "204": 98,
+      "4650": 99,
+      "5295": 100,
+      "5968": 101,
+      "4744": 102,
+      "2825": 103,
+      "9804": 104,
+      "707": 105,
+      "30": 106,
+      "115": 107,
+      "5840": 108,
+      "2587": 109,
+      "2607": 110,
+      "2544": 111,
+      "28": 112,
+      "27": 113,
+      "177": 114,
+      "112": 115,
+      "94": 116,
+      "2596": 117,
+      "3595": 118,
+      "7032": 119,
+      "7848": 120,
+      "11247": 121,
+      "7439": 122,
+      "2904": 123,
+      "6362": 124
+    },
+    "files": {
+      "fr/fr_FR/mls/medium/fr_FR-mls-medium.onnx": {
+        "size_bytes": 76733750,
+        "md5_digest": "87831389d3ae92347d91e38b0c57add9"
+      },
+      "fr/fr_FR/mls/medium/fr_FR-mls-medium.onnx.json": {
+        "size_bytes": 7036,
+        "md5_digest": "be41a30aab03788f5e5c4fe51620ccbe"
+      },
+      "fr/fr_FR/mls/medium/MODEL_CARD": {
+        "size_bytes": 222,
+        "md5_digest": "88d84c1c548aa27c1d119d2964f8fcf0"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "fr_FR-mls_1840-low": {
+    "key": "fr_FR-mls_1840-low",
+    "name": "mls_1840",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fr/fr_FR/mls_1840/low/fr_FR-mls_1840-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "1873b5d95cb0aad9909d32d1747ae72b"
+      },
+      "fr/fr_FR/mls_1840/low/fr_FR-mls_1840-low.onnx.json": {
+        "size_bytes": 4160,
+        "md5_digest": "eb0a76447f47f9114f832b1a0da9a8b3"
+      },
+      "fr/fr_FR/mls_1840/low/MODEL_CARD": {
+        "size_bytes": 257,
+        "md5_digest": "35d860ab0a8497966c73da525728e711"
+      }
+    },
+    "aliases": [
+      "fr-mls_1840-low"
+    ],
+    "has_rt_variant": false
+  },
+  "fr_FR-siwis-low": {
+    "key": "fr_FR-siwis-low",
+    "name": "siwis",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fr/fr_FR/siwis/low/fr_FR-siwis-low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "fcb614122005d70f27e4e61e58b4bb56"
+      },
+      "fr/fr_FR/siwis/low/fr_FR-siwis-low.onnx.json": {
+        "size_bytes": 4157,
+        "md5_digest": "5222111c6eaa632c7ea01a5a8938e5e1"
+      },
+      "fr/fr_FR/siwis/low/MODEL_CARD": {
+        "size_bytes": 274,
+        "md5_digest": "5d4a6b6e8d4a476e9b415ec0c1f030da"
+      }
+    },
+    "aliases": [
+      "fr-siwis-low"
+    ],
+    "has_rt_variant": false
+  },
+  "fr_FR-siwis-medium": {
+    "key": "fr_FR-siwis-medium",
+    "name": "siwis",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fr/fr_FR/siwis/medium/fr_FR-siwis-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "20e876e8c839e9b11a26085858f2300c"
+      },
+      "fr/fr_FR/siwis/medium/fr_FR-siwis-medium.onnx.json": {
+        "size_bytes": 4875,
+        "md5_digest": "a407e7e6901feb79c2ea2a5466076cce"
+      },
+      "fr/fr_FR/siwis/medium/MODEL_CARD": {
+        "size_bytes": 284,
+        "md5_digest": "2b9ea48b15e9e1fd25f95b415caaf66f"
+      }
+    },
+    "aliases": [
+      "fr-siwis-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "fr_FR-tom-medium": {
+    "key": "fr_FR-tom-medium",
+    "name": "tom",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "fr/fr_FR/tom/medium/fr_FR-tom-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "5b460c2394a871e675f5c798af149412"
+      },
+      "fr/fr_FR/tom/medium/fr_FR-tom-medium.onnx.json": {
+        "size_bytes": 4959,
+        "md5_digest": "964d58602df7adf76c2401b070f68ea2"
+      },
+      "fr/fr_FR/tom/medium/MODEL_CARD": {
+        "size_bytes": 233,
+        "md5_digest": "d82342c0c27cfbe9342814c7da46cb83"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "fr_FR-upmc-medium": {
+    "key": "fr_FR-upmc-medium",
+    "name": "upmc",
+    "language": {
+      "code": "fr_FR",
+      "family": "fr",
+      "region": "FR",
+      "name_native": "Français",
+      "name_english": "French",
+      "country_english": "France"
+    },
+    "quality": "medium",
+    "num_speakers": 2,
+    "speaker_id_map": {
+      "jessica": 0,
+      "pierre": 1
+    },
+    "files": {
+      "fr/fr_FR/upmc/medium/fr_FR-upmc-medium.onnx": {
+        "size_bytes": 76733615,
+        "md5_digest": "6837ede9408c7e1b39fa4a126af9e865"
+      },
+      "fr/fr_FR/upmc/medium/fr_FR-upmc-medium.onnx.json": {
+        "size_bytes": 4996,
+        "md5_digest": "574571ae93aba72dbd159582981037da"
+      },
+      "fr/fr_FR/upmc/medium/MODEL_CARD": {
+        "size_bytes": 316,
+        "md5_digest": "9a49df5c79d89290ac626ebe08f05830"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "hi_IN-pratham-medium": {
+    "key": "hi_IN-pratham-medium",
+    "name": "pratham",
+    "language": {
+      "code": "hi_IN",
+      "family": "hi",
+      "region": "IN",
+      "name_native": "हिन्दी",
+      "name_english": "Hindi",
+      "country_english": "India"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "hi/hi_IN/pratham/medium/hi_IN-pratham-medium.onnx": {
+        "size_bytes": 63516050,
+        "md5_digest": "f1e5a629a9e533a7155910530109eb86"
+      },
+      "hi/hi_IN/pratham/medium/hi_IN-pratham-medium.onnx.json": {
+        "size_bytes": 4970,
+        "md5_digest": "ab655cdad90f1939f00d1b3aaf440e99"
+      },
+      "hi/hi_IN/pratham/medium/MODEL_CARD": {
+        "size_bytes": 304,
+        "md5_digest": "eccc77c3d857a883e85c52cb17653c1f"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "hi_IN-priyamvada-medium": {
+    "key": "hi_IN-priyamvada-medium",
+    "name": "priyamvada",
+    "language": {
+      "code": "hi_IN",
+      "family": "hi",
+      "region": "IN",
+      "name_native": "हिन्दी",
+      "name_english": "Hindi",
+      "country_english": "India"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "hi/hi_IN/priyamvada/medium/hi_IN-priyamvada-medium.onnx": {
+        "size_bytes": 63516050,
+        "md5_digest": "7d5e20c2d1e72de8ed772f222e679626"
+      },
+      "hi/hi_IN/priyamvada/medium/hi_IN-priyamvada-medium.onnx.json": {
+        "size_bytes": 4973,
+        "md5_digest": "599ca4dc5d421a9c66692433f618e080"
+      },
+      "hi/hi_IN/priyamvada/medium/MODEL_CARD": {
+        "size_bytes": 307,
+        "md5_digest": "e2b745cf97087be0a97c7f10215bfa70"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "hu_HU-anna-medium": {
+    "key": "hu_HU-anna-medium",
+    "name": "anna",
+    "language": {
+      "code": "hu_HU",
+      "family": "hu",
+      "region": "HU",
+      "name_native": "Magyar",
+      "name_english": "Hungarian",
+      "country_english": "Hungary"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "hu/hu_HU/anna/medium/hu_HU-anna-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "3796f9fa28bd8d390d17828e2e2e952d"
+      },
+      "hu/hu_HU/anna/medium/hu_HU-anna-medium.onnx.json": {
+        "size_bytes": 5018,
+        "md5_digest": "ae63867e2c2cb6695555a17bdee8b751"
+      },
+      "hu/hu_HU/anna/medium/MODEL_CARD": {
+        "size_bytes": 277,
+        "md5_digest": "1a1332b041bc211d4d14fbd93eff03e9"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "hu_HU-berta-medium": {
+    "key": "hu_HU-berta-medium",
+    "name": "berta",
+    "language": {
+      "code": "hu_HU",
+      "family": "hu",
+      "region": "HU",
+      "name_native": "Magyar",
+      "name_english": "Hungarian",
+      "country_english": "Hungary"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "hu/hu_HU/berta/medium/hu_HU-berta-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "a94cc2562ba892f462cb502f9d3c3ca3"
+      },
+      "hu/hu_HU/berta/medium/hu_HU-berta-medium.onnx.json": {
+        "size_bytes": 4961,
+        "md5_digest": "1f722cc72f330e3ba0222c6a94a527fa"
+      },
+      "hu/hu_HU/berta/medium/MODEL_CARD": {
+        "size_bytes": 278,
+        "md5_digest": "009624d3fa8f0f1e73c22a6277798c95"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "hu_HU-imre-medium": {
+    "key": "hu_HU-imre-medium",
+    "name": "imre",
+    "language": {
+      "code": "hu_HU",
+      "family": "hu",
+      "region": "HU",
+      "name_native": "Magyar",
+      "name_english": "Hungarian",
+      "country_english": "Hungary"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "hu/hu_HU/imre/medium/hu_HU-imre-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "aa0b1d1fdd539881c64ed249097e75ff"
+      },
+      "hu/hu_HU/imre/medium/hu_HU-imre-medium.onnx.json": {
+        "size_bytes": 5019,
+        "md5_digest": "9b6974c685cd8289619660f5e078de06"
+      },
+      "hu/hu_HU/imre/medium/MODEL_CARD": {
+        "size_bytes": 277,
+        "md5_digest": "3efe4f497211542985d2d52d403eecad"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "is_IS-bui-medium": {
+    "key": "is_IS-bui-medium",
+    "name": "bui",
+    "language": {
+      "code": "is_IS",
+      "family": "is",
+      "region": "IS",
+      "name_native": "íslenska",
+      "name_english": "Icelandic",
+      "country_english": "Iceland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "is/is_IS/bui/medium/is_IS-bui-medium.onnx": {
+        "size_bytes": 76495465,
+        "md5_digest": "08332bb41a67b52a3361bd1e8e36fb10"
+      },
+      "is/is_IS/bui/medium/is_IS-bui-medium.onnx.json": {
+        "size_bytes": 4162,
+        "md5_digest": "dae8bd862a11dd826a01d262d8fe62cf"
+      },
+      "is/is_IS/bui/medium/MODEL_CARD": {
+        "size_bytes": 246,
+        "md5_digest": "a055aad199d8cc58e52913ff2af461d8"
+      }
+    },
+    "aliases": [
+      "is-bui-medium"
+    ],
+    "has_rt_variant": false
+  },
+  "is_IS-salka-medium": {
+    "key": "is_IS-salka-medium",
+    "name": "salka",
+    "language": {
+      "code": "is_IS",
+      "family": "is",
+      "region": "IS",
+      "name_native": "íslenska",
+      "name_english": "Icelandic",
+      "country_english": "Iceland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "is/is_IS/salka/medium/is_IS-salka-medium.onnx": {
+        "size_bytes": 76495465,
+        "md5_digest": "5967c9456b931d6123687d7b78fd81a7"
+      },
+      "is/is_IS/salka/medium/is_IS-salka-medium.onnx.json": {
+        "size_bytes": 4164,
+        "md5_digest": "ce262d355da30218152cbc256b0f2b69"
+      },
+      "is/is_IS/salka/medium/MODEL_CARD": {
+        "size_bytes": 241,
+        "md5_digest": "0f3d286069e4c7bead9b40ece3bbefe6"
+      }
+    },
+    "aliases": [
+      "is-salka-medium"
+    ],
+    "has_rt_variant": false
+  },
+  "is_IS-steinn-medium": {
+    "key": "is_IS-steinn-medium",
+    "name": "steinn",
+    "language": {
+      "code": "is_IS",
+      "family": "is",
+      "region": "IS",
+      "name_native": "íslenska",
+      "name_english": "Icelandic",
+      "country_english": "Iceland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "is/is_IS/steinn/medium/is_IS-steinn-medium.onnx": {
+        "size_bytes": 76495465,
+        "md5_digest": "fd8189eb0a72e78d525e70a71aaa792c"
+      },
+      "is/is_IS/steinn/medium/is_IS-steinn-medium.onnx.json": {
+        "size_bytes": 4165,
+        "md5_digest": "9d4ac17e0cd1f83cd940e2563c04b8a1"
+      },
+      "is/is_IS/steinn/medium/MODEL_CARD": {
+        "size_bytes": 242,
+        "md5_digest": "45ab46f37e5a6bdf739d58496752e6a0"
+      }
+    },
+    "aliases": [
+      "is-steinn-medium"
+    ],
+    "has_rt_variant": false
+  },
+  "is_IS-ugla-medium": {
+    "key": "is_IS-ugla-medium",
+    "name": "ugla",
+    "language": {
+      "code": "is_IS",
+      "family": "is",
+      "region": "IS",
+      "name_native": "íslenska",
+      "name_english": "Icelandic",
+      "country_english": "Iceland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "is/is_IS/ugla/medium/is_IS-ugla-medium.onnx": {
+        "size_bytes": 76495465,
+        "md5_digest": "722fcea3546f0113ad6664290aa97cab"
+      },
+      "is/is_IS/ugla/medium/is_IS-ugla-medium.onnx.json": {
+        "size_bytes": 4163,
+        "md5_digest": "c8c1aebf00bdc7ae6541ce68e3b83f31"
+      },
+      "is/is_IS/ugla/medium/MODEL_CARD": {
+        "size_bytes": 240,
+        "md5_digest": "a3ba0a35bc26d440ee3b0872e435fcd5"
+      }
+    },
+    "aliases": [
+      "is-ugla-medium"
+    ],
+    "has_rt_variant": false
+  },
+  "it_IT-paola-medium": {
+    "key": "it_IT-paola-medium",
+    "name": "paola",
+    "language": {
+      "code": "it_IT",
+      "family": "it",
+      "region": "IT",
+      "name_native": "Italiano",
+      "name_english": "Italian",
+      "country_english": "Italy"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "it/it_IT/paola/medium/it_IT-paola-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "3a44e73b12ca5d0c21a72e388b5847c8"
+      },
+      "it/it_IT/paola/medium/it_IT-paola-medium.onnx.json": {
+        "size_bytes": 7099,
+        "md5_digest": "cd471a3757c88a7a4baee6207248b5d5"
+      },
+      "it/it_IT/paola/medium/MODEL_CARD": {
+        "size_bytes": 303,
+        "md5_digest": "436971e8acb0a92dd8dbc42542e59d03"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "it_IT-riccardo-x_low": {
+    "key": "it_IT-riccardo-x_low",
+    "name": "riccardo",
+    "language": {
+      "code": "it_IT",
+      "family": "it",
+      "region": "IT",
+      "name_native": "Italiano",
+      "name_english": "Italian",
+      "country_english": "Italy"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "2c564b67f6bfaf3ad02d28ab528929b8"
+      },
+      "it/it_IT/riccardo/x_low/it_IT-riccardo-x_low.onnx.json": {
+        "size_bytes": 4161,
+        "md5_digest": "ed24cd550b79acbdc337e519849e9636"
+      },
+      "it/it_IT/riccardo/x_low/MODEL_CARD": {
+        "size_bytes": 260,
+        "md5_digest": "3e70f29ab998ac0380edc0cec7395e80"
+      }
+    },
+    "aliases": [
+      "it-riccardo_fasol-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "ka_GE-natia-medium": {
+    "key": "ka_GE-natia-medium",
+    "name": "natia",
+    "language": {
+      "code": "ka_GE",
+      "family": "ka",
+      "region": "GE",
+      "name_native": "ქართული ენა",
+      "name_english": "Georgian",
+      "country_english": "Georgia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ka/ka_GE/natia/medium/ka_GE-natia-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "83bd40f8d176a83d3d8d605fada2a5e7"
+      },
+      "ka/ka_GE/natia/medium/ka_GE-natia-medium.onnx.json": {
+        "size_bytes": 4842,
+        "md5_digest": "f992d9a6887cce43e707119e66c0db55"
+      },
+      "ka/ka_GE/natia/medium/MODEL_CARD": {
+        "size_bytes": 288,
+        "md5_digest": "81ac71dd5b3dac89bf7762bf7b738c95"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "kk_KZ-iseke-x_low": {
+    "key": "kk_KZ-iseke-x_low",
+    "name": "iseke",
+    "language": {
+      "code": "kk_KZ",
+      "family": "kk",
+      "region": "KZ",
+      "name_native": "қазақша",
+      "name_english": "Kazakh",
+      "country_english": "Kazakhstan"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "kk/kk_KZ/iseke/x_low/kk_KZ-iseke-x_low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "1674f3f4ce48981d77e500741afa4ff9"
+      },
+      "kk/kk_KZ/iseke/x_low/kk_KZ-iseke-x_low.onnx.json": {
+        "size_bytes": 4168,
+        "md5_digest": "bc9832bc17f9d64367ee3bfb64f7f944"
+      },
+      "kk/kk_KZ/iseke/x_low/MODEL_CARD": {
+        "size_bytes": 239,
+        "md5_digest": "fce637093c4437a1f929280913a86aa5"
+      }
+    },
+    "aliases": [
+      "kk-iseke-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "kk_KZ-issai-high": {
+    "key": "kk_KZ-issai-high",
+    "name": "issai",
+    "language": {
+      "code": "kk_KZ",
+      "family": "kk",
+      "region": "KZ",
+      "name_native": "қазақша",
+      "name_english": "Kazakh",
+      "country_english": "Kazakhstan"
+    },
+    "quality": "high",
+    "num_speakers": 6,
+    "speaker_id_map": {
+      "ISSAI_KazakhTTS2_M2": 0,
+      "ISSAI_KazakhTTS_M1_Iseke": 1,
+      "ISSAI_KazakhTTS2_F3": 2,
+      "ISSAI_KazakhTTS_F1_Raya": 3,
+      "ISSAI_KazakhTTS2_F1": 4,
+      "ISSAI_KazakhTTS2_F2": 5
+    },
+    "files": {
+      "kk/kk_KZ/issai/high/kk_KZ-issai-high.onnx": {
+        "size_bytes": 127864258,
+        "md5_digest": "d5a97c25feb0949c187ae5f8e72753e3"
+      },
+      "kk/kk_KZ/issai/high/kk_KZ-issai-high.onnx.json": {
+        "size_bytes": 4358,
+        "md5_digest": "cfef5328137c8a1e4d1e5d3dac0c7056"
+      },
+      "kk/kk_KZ/issai/high/MODEL_CARD": {
+        "size_bytes": 237,
+        "md5_digest": "30487d1011336ed15feabd156424cbd9"
+      }
+    },
+    "aliases": [
+      "kk-issai-high"
+    ],
+    "has_rt_variant": false
+  },
+  "kk_KZ-raya-x_low": {
+    "key": "kk_KZ-raya-x_low",
+    "name": "raya",
+    "language": {
+      "code": "kk_KZ",
+      "family": "kk",
+      "region": "KZ",
+      "name_native": "қазақша",
+      "name_english": "Kazakh",
+      "country_english": "Kazakhstan"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "kk/kk_KZ/raya/x_low/kk_KZ-raya-x_low.onnx": {
+        "size_bytes": 28130791,
+        "md5_digest": "476ecc32e07cad26572a50f26d0ebe28"
+      },
+      "kk/kk_KZ/raya/x_low/kk_KZ-raya-x_low.onnx.json": {
+        "size_bytes": 4167,
+        "md5_digest": "cc696dbf95d53a280b6805d81b4eac64"
+      },
+      "kk/kk_KZ/raya/x_low/MODEL_CARD": {
+        "size_bytes": 238,
+        "md5_digest": "fb34d2e65fac42f4d6e003d3d30c897e"
+      }
+    },
+    "aliases": [
+      "kk-raya-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "lb_LU-marylux-medium": {
+    "key": "lb_LU-marylux-medium",
+    "name": "marylux",
+    "language": {
+      "code": "lb_LU",
+      "family": "lb",
+      "region": "LU",
+      "name_native": "Lëtzebuergesch",
+      "name_english": "Luxembourgish",
+      "country_english": "Luxembourg"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "lb/lb_LU/marylux/medium/lb_LU-marylux-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "966856e665a46cee45cb0cd2c475f8d5"
+      },
+      "lb/lb_LU/marylux/medium/lb_LU-marylux-medium.onnx.json": {
+        "size_bytes": 4979,
+        "md5_digest": "aea98b0e4fecaa0b3b7adc2048561095"
+      },
+      "lb/lb_LU/marylux/medium/MODEL_CARD": {
+        "size_bytes": 330,
+        "md5_digest": "1eeb3d600789cdd8b3f23866023d8543"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "lv_LV-aivars-medium": {
+    "key": "lv_LV-aivars-medium",
+    "name": "aivars",
+    "language": {
+      "code": "lv_LV",
+      "family": "lv",
+      "region": "LV",
+      "name_native": "Latviešu",
+      "name_english": "Latvian",
+      "country_english": "Latvia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "lv/lv_LV/aivars/medium/lv_LV-aivars-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "5b48c6f958aea5b7e9ff34f6a10882dd"
+      },
+      "lv/lv_LV/aivars/medium/lv_LV-aivars-medium.onnx.json": {
+        "size_bytes": 7242,
+        "md5_digest": "7264f291326a66e8055e3a48fdd0bf55"
+      },
+      "lv/lv_LV/aivars/medium/MODEL_CARD": {
+        "size_bytes": 257,
+        "md5_digest": "171ee8dd94c40ee2faf96837086bd2a7"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "ml_IN-arjun-medium": {
+    "key": "ml_IN-arjun-medium",
+    "name": "arjun",
+    "language": {
+      "code": "ml_IN",
+      "family": "ml",
+      "region": "IN",
+      "name_native": "മലയാളം",
+      "name_english": "Malayalam",
+      "country_english": "India"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ml/ml_IN/arjun/medium/ml_IN-arjun-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "4f20109c108aa80f46df85ab9cda5daa"
+      },
+      "ml/ml_IN/arjun/medium/ml_IN-arjun-medium.onnx.json": {
+        "size_bytes": 5044,
+        "md5_digest": "18454efcad5bb889ee4cb1cb035993f5"
+      },
+      "ml/ml_IN/arjun/medium/MODEL_CARD": {
+        "size_bytes": 308,
+        "md5_digest": "eb0037396b93f38ffbc093dba42cf8be"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "ml_IN-meera-medium": {
+    "key": "ml_IN-meera-medium",
+    "name": "meera",
+    "language": {
+      "code": "ml_IN",
+      "family": "ml",
+      "region": "IN",
+      "name_native": "മലയാളം",
+      "name_english": "Malayalam",
+      "country_english": "India"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ml/ml_IN/meera/medium/ml_IN-meera-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "3eb7b05d25c1551f7a7cec1e1c153b1f"
+      },
+      "ml/ml_IN/meera/medium/ml_IN-meera-medium.onnx.json": {
+        "size_bytes": 5045,
+        "md5_digest": "64c2eee28c62e3a072ccc2ea3d812748"
+      },
+      "ml/ml_IN/meera/medium/MODEL_CARD": {
+        "size_bytes": 308,
+        "md5_digest": "626a0c1d744d0ce6ffca95665c526939"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "ne_NP-chitwan-medium": {
+    "key": "ne_NP-chitwan-medium",
+    "name": "chitwan",
+    "language": {
+      "code": "ne_NP",
+      "family": "ne",
+      "region": "NP",
+      "name_native": "नेपाली",
+      "name_english": "Nepali",
+      "country_english": "Nepal"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ne/ne_NP/chitwan/medium/ne_NP-chitwan-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "74cdb5b32816c366af74b55ed7494e25"
+      },
+      "ne/ne_NP/chitwan/medium/ne_NP-chitwan-medium.onnx.json": {
+        "size_bytes": 5043,
+        "md5_digest": "7ddc520e24a862016f6d22cde4b70ac1"
+      },
+      "ne/ne_NP/chitwan/medium/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "dcd35df097f84ace498d7afeb5b1a29c"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "ne_NP-google-medium": {
+    "key": "ne_NP-google-medium",
+    "name": "google",
+    "language": {
+      "code": "ne_NP",
+      "family": "ne",
+      "region": "NP",
+      "name_native": "नेपाली",
+      "name_english": "Nepali",
+      "country_english": "Nepal"
+    },
+    "quality": "medium",
+    "num_speakers": 18,
+    "speaker_id_map": {
+      "0546": 0,
+      "3614": 1,
+      "2099": 2,
+      "3960": 3,
+      "6834": 4,
+      "7957": 5,
+      "6329": 6,
+      "9407": 7,
+      "6587": 8,
+      "0258": 9,
+      "2139": 10,
+      "5687": 11,
+      "0283": 12,
+      "3997": 13,
+      "3154": 14,
+      "0883": 15,
+      "2027": 16,
+      "0649": 17
+    },
+    "files": {
+      "ne/ne_NP/google/medium/ne_NP-google-medium.onnx": {
+        "size_bytes": 76766385,
+        "md5_digest": "2c24ccfe18eca2f14bccd0a188516109"
+      },
+      "ne/ne_NP/google/medium/ne_NP-google-medium.onnx.json": {
+        "size_bytes": 5165,
+        "md5_digest": "28ebbba4fbbbaa5f7ed302e5e7c7105f"
+      },
+      "ne/ne_NP/google/medium/MODEL_CARD": {
+        "size_bytes": 283,
+        "md5_digest": "afe022ba061870d0c9fe085fe9a9f31f"
+      }
+    },
+    "aliases": [
+      "ne-google-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "ne_NP-google-x_low": {
+    "key": "ne_NP-google-x_low",
+    "name": "google",
+    "language": {
+      "code": "ne_NP",
+      "family": "ne",
+      "region": "NP",
+      "name_native": "नेपाली",
+      "name_english": "Nepali",
+      "country_english": "Nepal"
+    },
+    "quality": "x_low",
+    "num_speakers": 18,
+    "speaker_id_map": {
+      "0546": 0,
+      "3614": 1,
+      "2099": 2,
+      "3960": 3,
+      "6834": 4,
+      "7957": 5,
+      "6329": 6,
+      "9407": 7,
+      "6587": 8,
+      "0258": 9,
+      "2139": 10,
+      "5687": 11,
+      "0283": 12,
+      "3997": 13,
+      "3154": 14,
+      "0883": 15,
+      "2027": 16,
+      "0649": 17
+    },
+    "files": {
+      "ne/ne_NP/google/x_low/ne_NP-google-x_low.onnx": {
+        "size_bytes": 27693157,
+        "md5_digest": "b11030daccc781a7db64c9413197ca8a"
+      },
+      "ne/ne_NP/google/x_low/ne_NP-google-x_low.onnx.json": {
+        "size_bytes": 4449,
+        "md5_digest": "c6856d6ad593dc459bd50204e9b29b1c"
+      },
+      "ne/ne_NP/google/x_low/MODEL_CARD": {
+        "size_bytes": 244,
+        "md5_digest": "5ea405c002a69df5961c8d43cadbb844"
+      }
+    },
+    "aliases": [
+      "ne-google-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_BE-nathalie-medium": {
+    "key": "nl_BE-nathalie-medium",
+    "name": "nathalie",
+    "language": {
+      "code": "nl_BE",
+      "family": "nl",
+      "region": "BE",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Belgium"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_BE/nathalie/medium/nl_BE-nathalie-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "ab0c38b5f66764b59ad9e3e98b1c2172"
+      },
+      "nl/nl_BE/nathalie/medium/nl_BE-nathalie-medium.onnx.json": {
+        "size_bytes": 4879,
+        "md5_digest": "13c6e6c9511447e1906c25748a93f0bd"
+      },
+      "nl/nl_BE/nathalie/medium/MODEL_CARD": {
+        "size_bytes": 284,
+        "md5_digest": "ff335f87ca41a3f89180781498e02635"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "nl_BE-nathalie-x_low": {
+    "key": "nl_BE-nathalie-x_low",
+    "name": "nathalie",
+    "language": {
+      "code": "nl_BE",
+      "family": "nl",
+      "region": "BE",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Belgium"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_BE/nathalie/x_low/nl_BE-nathalie-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "4a00803b60caecad30ea612bcd9f9344"
+      },
+      "nl/nl_BE/nathalie/x_low/nl_BE-nathalie-x_low.onnx.json": {
+        "size_bytes": 4163,
+        "md5_digest": "5307e9c8398ab02060611bb9c2e0f137"
+      },
+      "nl/nl_BE/nathalie/x_low/MODEL_CARD": {
+        "size_bytes": 246,
+        "md5_digest": "5df62094bde427374223f91f44476392"
+      }
+    },
+    "aliases": [
+      "nl-nathalie-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_BE-rdh-medium": {
+    "key": "nl_BE-rdh-medium",
+    "name": "rdh",
+    "language": {
+      "code": "nl_BE",
+      "family": "nl",
+      "region": "BE",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Belgium"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_BE/rdh/medium/nl_BE-rdh-medium.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "33d3469d745677ec4d7e96eb4145b09e"
+      },
+      "nl/nl_BE/rdh/medium/nl_BE-rdh-medium.onnx.json": {
+        "size_bytes": 4159,
+        "md5_digest": "4a7629a2d00a62e72b8692f7a19135f1"
+      },
+      "nl/nl_BE/rdh/medium/MODEL_CARD": {
+        "size_bytes": 244,
+        "md5_digest": "dc4487b06fcef6ff270c852ce12947b9"
+      }
+    },
+    "aliases": [
+      "nl-rdh-medium"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_BE-rdh-x_low": {
+    "key": "nl_BE-rdh-x_low",
+    "name": "rdh",
+    "language": {
+      "code": "nl_BE",
+      "family": "nl",
+      "region": "BE",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Belgium"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_BE/rdh/x_low/nl_BE-rdh-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "7d60d0de9ad9ec11a1d293665743afda"
+      },
+      "nl/nl_BE/rdh/x_low/nl_BE-rdh-x_low.onnx.json": {
+        "size_bytes": 4158,
+        "md5_digest": "d222d7fa8654d49e3b35c640cc28891f"
+      },
+      "nl/nl_BE/rdh/x_low/MODEL_CARD": {
+        "size_bytes": 242,
+        "md5_digest": "6d0157bcd5ff281717e663d56dab980e"
+      }
+    },
+    "aliases": [
+      "nl-rdh-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_NL-mls-medium": {
+    "key": "nl_NL-mls-medium",
+    "name": "mls",
+    "language": {
+      "code": "nl_NL",
+      "family": "nl",
+      "region": "NL",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Netherlands"
+    },
+    "quality": "medium",
+    "num_speakers": 52,
+    "speaker_id_map": {
+      "2450": 0,
+      "1724": 1,
+      "1666": 2,
+      "5809": 3,
+      "496": 4,
+      "2506": 5,
+      "7432": 6,
+      "3619": 7,
+      "4429": 8,
+      "3798": 9,
+      "12500": 10,
+      "10587": 11,
+      "2951": 12,
+      "1775": 13,
+      "9861": 14,
+      "880": 15,
+      "3034": 16,
+      "2825": 17,
+      "5438": 18,
+      "3245": 19,
+      "4396": 20,
+      "11290": 21,
+      "11936": 22,
+      "6916": 23,
+      "10294": 24,
+      "10079": 25,
+      "7588": 26,
+      "7579": 27,
+      "123": 28,
+      "3024": 29,
+      "960": 30,
+      "10984": 31,
+      "2792": 32,
+      "7723": 33,
+      "4174": 34,
+      "2981": 35,
+      "5764": 36,
+      "6513": 37,
+      "7884": 38,
+      "6697": 39,
+      "12749": 40,
+      "11157": 41,
+      "2239": 42,
+      "10879": 43,
+      "1085": 44,
+      "8480": 45,
+      "8331": 46,
+      "6282": 47,
+      "10632": 48,
+      "2602": 49,
+      "5367": 50,
+      "11472": 51
+    },
+    "files": {
+      "nl/nl_NL/mls/medium/nl_NL-mls-medium.onnx": {
+        "size_bytes": 76584246,
+        "md5_digest": "f1d4b1452ccfdac24be72085b2b6b55c"
+      },
+      "nl/nl_NL/mls/medium/nl_NL-mls-medium.onnx.json": {
+        "size_bytes": 5856,
+        "md5_digest": "1915807d7cb85274ba957846370fff39"
+      },
+      "nl/nl_NL/mls/medium/MODEL_CARD": {
+        "size_bytes": 225,
+        "md5_digest": "6e5d961780907a4d7746eada893b8eca"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "nl_NL-mls_5809-low": {
+    "key": "nl_NL-mls_5809-low",
+    "name": "mls_5809",
+    "language": {
+      "code": "nl_NL",
+      "family": "nl",
+      "region": "NL",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Netherlands"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_NL/mls_5809/low/nl_NL-mls_5809-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "e69130a776b04c9962a1fefb4878d7d9"
+      },
+      "nl/nl_NL/mls_5809/low/nl_NL-mls_5809-low.onnx.json": {
+        "size_bytes": 4165,
+        "md5_digest": "b927009215c55c28654ddbc7b86674c2"
+      },
+      "nl/nl_NL/mls_5809/low/MODEL_CARD": {
+        "size_bytes": 261,
+        "md5_digest": "ac4b35e581cea8418909947a29a671bb"
+      }
+    },
+    "aliases": [
+      "nl-mls_5809-low"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_NL-mls_7432-low": {
+    "key": "nl_NL-mls_7432-low",
+    "name": "mls_7432",
+    "language": {
+      "code": "nl_NL",
+      "family": "nl",
+      "region": "NL",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Netherlands"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_NL/mls_7432/low/nl_NL-mls_7432-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "044b69d583e191203997761434607273"
+      },
+      "nl/nl_NL/mls_7432/low/nl_NL-mls_7432-low.onnx.json": {
+        "size_bytes": 4165,
+        "md5_digest": "4d6ecdff8b7cd39e8f7137983140cf1c"
+      },
+      "nl/nl_NL/mls_7432/low/MODEL_CARD": {
+        "size_bytes": 260,
+        "md5_digest": "5d8ee8e955f077fc99cac61191d00892"
+      }
+    },
+    "aliases": [
+      "nl-mls_7432-low"
+    ],
+    "has_rt_variant": false
+  },
+  "nl_NL-pim-medium": {
+    "key": "nl_NL-pim-medium",
+    "name": "pim",
+    "language": {
+      "code": "nl_NL",
+      "family": "nl",
+      "region": "NL",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Netherlands"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_NL/pim/medium/nl_NL-pim-medium.onnx": {
+        "size_bytes": 63516050,
+        "md5_digest": "190b3e6463a931d3c583d2fa7cd0e4a0"
+      },
+      "nl/nl_NL/pim/medium/nl_NL-pim-medium.onnx.json": {
+        "size_bytes": 5037,
+        "md5_digest": "c4d22097fefa2afe275b9bb6ff4db865"
+      },
+      "nl/nl_NL/pim/medium/MODEL_CARD": {
+        "size_bytes": 276,
+        "md5_digest": "2d28b81a9acf714216f8d334581e8439"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "nl_NL-ronnie-medium": {
+    "key": "nl_NL-ronnie-medium",
+    "name": "ronnie",
+    "language": {
+      "code": "nl_NL",
+      "family": "nl",
+      "region": "NL",
+      "name_native": "Nederlands",
+      "name_english": "Dutch",
+      "country_english": "Netherlands"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "f74c8e7779cb05f935367d661de5b380"
+      },
+      "nl/nl_NL/ronnie/medium/nl_NL-ronnie-medium.onnx.json": {
+        "size_bytes": 5040,
+        "md5_digest": "6bd4d32724d8c68926ce7b5012370e61"
+      },
+      "nl/nl_NL/ronnie/medium/MODEL_CARD": {
+        "size_bytes": 279,
+        "md5_digest": "97acf736be1e3fdd8d9ed576dceffb29"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "no_NO-talesyntese-medium": {
+    "key": "no_NO-talesyntese-medium",
+    "name": "talesyntese",
+    "language": {
+      "code": "no_NO",
+      "family": "no",
+      "region": "NO",
+      "name_native": "Norsk",
+      "name_english": "Norwegian",
+      "country_english": "Norway"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "no/no_NO/talesyntese/medium/no_NO-talesyntese-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "9fc876e7edc6593086b4f2f34889f44b"
+      },
+      "no/no_NO/talesyntese/medium/no_NO-talesyntese-medium.onnx.json": {
+        "size_bytes": 4880,
+        "md5_digest": "94b938e1bd319e6a084dc8380fb53619"
+      },
+      "no/no_NO/talesyntese/medium/MODEL_CARD": {
+        "size_bytes": 312,
+        "md5_digest": "5fe51d2a4a0e05e85c88a80373000ae1"
+      }
+    },
+    "aliases": [
+      "no-talesyntese-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "pl_PL-darkman-medium": {
+    "key": "pl_PL-darkman-medium",
+    "name": "darkman",
+    "language": {
+      "code": "pl_PL",
+      "family": "pl",
+      "region": "PL",
+      "name_native": "Polski",
+      "name_english": "Polish",
+      "country_english": "Poland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pl/pl_PL/darkman/medium/pl_PL-darkman-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "27bf2d71e934b112657544fd0b100a7a"
+      },
+      "pl/pl_PL/darkman/medium/pl_PL-darkman-medium.onnx.json": {
+        "size_bytes": 4816,
+        "md5_digest": "1c13180312cca98cb75ca39b31972056"
+      },
+      "pl/pl_PL/darkman/medium/MODEL_CARD": {
+        "size_bytes": 276,
+        "md5_digest": "952772905864f6f6375df54a675895b7"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "pl_PL-gosia-medium": {
+    "key": "pl_PL-gosia-medium",
+    "name": "gosia",
+    "language": {
+      "code": "pl_PL",
+      "family": "pl",
+      "region": "PL",
+      "name_native": "Polski",
+      "name_english": "Polish",
+      "country_english": "Poland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pl/pl_PL/gosia/medium/pl_PL-gosia-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "ecf817530e575025166e454adde1f382"
+      },
+      "pl/pl_PL/gosia/medium/pl_PL-gosia-medium.onnx.json": {
+        "size_bytes": 4814,
+        "md5_digest": "e57055b9eec14e570617af2b716bd5c3"
+      },
+      "pl/pl_PL/gosia/medium/MODEL_CARD": {
+        "size_bytes": 274,
+        "md5_digest": "e1355330fe5fab166e6f2e20af7e91e9"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "pl_PL-mc_speech-medium": {
+    "key": "pl_PL-mc_speech-medium",
+    "name": "mc_speech",
+    "language": {
+      "code": "pl_PL",
+      "family": "pl",
+      "region": "PL",
+      "name_native": "Polski",
+      "name_english": "Polish",
+      "country_english": "Poland"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pl/pl_PL/mc_speech/medium/pl_PL-mc_speech-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "a927e2f2c882bb40cbc2e5f3356ce19b"
+      },
+      "pl/pl_PL/mc_speech/medium/pl_PL-mc_speech-medium.onnx.json": {
+        "size_bytes": 4961,
+        "md5_digest": "3f506e68bb9531b11e94e5f5dda5dd21"
+      },
+      "pl/pl_PL/mc_speech/medium/MODEL_CARD": {
+        "size_bytes": 296,
+        "md5_digest": "affe6073af7777237f73d0768103547e"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "pl_PL-mls_6892-low": {
+    "key": "pl_PL-mls_6892-low",
+    "name": "mls_6892",
+    "language": {
+      "code": "pl_PL",
+      "family": "pl",
+      "region": "PL",
+      "name_native": "Polski",
+      "name_english": "Polish",
+      "country_english": "Poland"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pl/pl_PL/mls_6892/low/pl_PL-mls_6892-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "8590d8e979292ca35d20e6e123bfa612"
+      },
+      "pl/pl_PL/mls_6892/low/pl_PL-mls_6892-low.onnx.json": {
+        "size_bytes": 4157,
+        "md5_digest": "7da3504b7726d6a7143a9265d9295fa1"
+      },
+      "pl/pl_PL/mls_6892/low/MODEL_CARD": {
+        "size_bytes": 257,
+        "md5_digest": "74ebc618d120896113449ad2f957b7a4"
+      }
+    },
+    "aliases": [
+      "pl-mls_6892-low"
+    ],
+    "has_rt_variant": false
+  },
+  "pt_BR-cadu-medium": {
+    "key": "pt_BR-cadu-medium",
+    "name": "cadu",
+    "language": {
+      "code": "pt_BR",
+      "family": "pt",
+      "region": "BR",
+      "name_native": "Português",
+      "name_english": "Portuguese",
+      "country_english": "Brazil"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pt/pt_BR/cadu/medium/pt_BR-cadu-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "6f3a6e23694c9088e3696a15191af2cc"
+      },
+      "pt/pt_BR/cadu/medium/pt_BR-cadu-medium.onnx.json": {
+        "size_bytes": 5040,
+        "md5_digest": "3d35f13df6a2f7dc9b7b7924befbe7bb"
+      },
+      "pt/pt_BR/cadu/medium/MODEL_CARD": {
+        "size_bytes": 277,
+        "md5_digest": "4f69a194136ecb54aee5ae98273debc4"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "pt_BR-edresson-low": {
+    "key": "pt_BR-edresson-low",
+    "name": "edresson",
+    "language": {
+      "code": "pt_BR",
+      "family": "pt",
+      "region": "BR",
+      "name_native": "Português",
+      "name_english": "Portuguese",
+      "country_english": "Brazil"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pt/pt_BR/edresson/low/pt_BR-edresson-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "53e365c040dd07890fe1855b64c7cc58"
+      },
+      "pt/pt_BR/edresson/low/pt_BR-edresson-low.onnx.json": {
+        "size_bytes": 4168,
+        "md5_digest": "806966b457e27c01d9b8eed2bc76a185"
+      },
+      "pt/pt_BR/edresson/low/MODEL_CARD": {
+        "size_bytes": 283,
+        "md5_digest": "62cde47b9a3214109e601f90eeadea11"
+      }
+    },
+    "aliases": [
+      "pt-br-edresson-low"
+    ],
+    "has_rt_variant": false
+  },
+  "pt_BR-faber-medium": {
+    "key": "pt_BR-faber-medium",
+    "name": "faber",
+    "language": {
+      "code": "pt_BR",
+      "family": "pt",
+      "region": "BR",
+      "name_native": "Português",
+      "name_english": "Portuguese",
+      "country_english": "Brazil"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pt/pt_BR/faber/medium/pt_BR-faber-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "e0724a2f07965f6523d2a1e96b488a4c"
+      },
+      "pt/pt_BR/faber/medium/pt_BR-faber-medium.onnx.json": {
+        "size_bytes": 4855,
+        "md5_digest": "a1258e1e113c47d9a1486a9bef1daab4"
+      },
+      "pt/pt_BR/faber/medium/MODEL_CARD": {
+        "size_bytes": 278,
+        "md5_digest": "a81a3840b1749cf34b0e31de1577ef47"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "pt_BR-jeff-medium": {
+    "key": "pt_BR-jeff-medium",
+    "name": "jeff",
+    "language": {
+      "code": "pt_BR",
+      "family": "pt",
+      "region": "BR",
+      "name_native": "Português",
+      "name_english": "Portuguese",
+      "country_english": "Brazil"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pt/pt_BR/jeff/medium/pt_BR-jeff-medium.onnx": {
+        "size_bytes": 62950044,
+        "md5_digest": "dfb93e9da48638f9efa6b63fdb0b7030"
+      },
+      "pt/pt_BR/jeff/medium/pt_BR-jeff-medium.onnx.json": {
+        "size_bytes": 5041,
+        "md5_digest": "e7d673d946db4d9e9d8644babf347ea9"
+      },
+      "pt/pt_BR/jeff/medium/MODEL_CARD": {
+        "size_bytes": 277,
+        "md5_digest": "e6ec017f5195c56575aab61900e16110"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "pt_PT-tugão-medium": {
+    "key": "pt_PT-tugão-medium",
+    "name": "tugão",
+    "language": {
+      "code": "pt_PT",
+      "family": "pt",
+      "region": "PT",
+      "name_native": "Português",
+      "name_english": "Portuguese",
+      "country_english": "Portugal"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "0642048511ffe36c3b519520614b53f4"
+      },
+      "pt/pt_PT/tugão/medium/pt_PT-tugão-medium.onnx.json": {
+        "size_bytes": 5026,
+        "md5_digest": "c4113a1da477aa6db28420454c142ebd"
+      },
+      "pt/pt_PT/tugão/medium/MODEL_CARD": {
+        "size_bytes": 281,
+        "md5_digest": "fcaafaf8d265f5a5b8e83df547f49bfd"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ro_RO-mihai-medium": {
+    "key": "ro_RO-mihai-medium",
+    "name": "mihai",
+    "language": {
+      "code": "ro_RO",
+      "family": "ro",
+      "region": "RO",
+      "name_native": "Română",
+      "name_english": "Romanian",
+      "country_english": "Romania"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ro/ro_RO/mihai/medium/ro_RO-mihai-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "45f4253916c93d3d05ad3fe1b07ea4f3"
+      },
+      "ro/ro_RO/mihai/medium/ro_RO-mihai-medium.onnx.json": {
+        "size_bytes": 4877,
+        "md5_digest": "f820f8ba65a8646c68792be581b85144"
+      },
+      "ro/ro_RO/mihai/medium/MODEL_CARD": {
+        "size_bytes": 277,
+        "md5_digest": "4075864685b207c9a98bf1af237a1502"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ru_RU-denis-medium": {
+    "key": "ru_RU-denis-medium",
+    "name": "denis",
+    "language": {
+      "code": "ru_RU",
+      "family": "ru",
+      "region": "RU",
+      "name_native": "Русский",
+      "name_english": "Russian",
+      "country_english": "Russia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "76c2f14e521fef3ed574f97ad492728e"
+      },
+      "ru/ru_RU/denis/medium/ru_RU-denis-medium.onnx.json": {
+        "size_bytes": 4823,
+        "md5_digest": "e3df5957c07647cab05cf9910ef3ede0"
+      },
+      "ru/ru_RU/denis/medium/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "6fe09e0e097e4538809cc420653974e4"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ru_RU-dmitri-medium": {
+    "key": "ru_RU-dmitri-medium",
+    "name": "dmitri",
+    "language": {
+      "code": "ru_RU",
+      "family": "ru",
+      "region": "RU",
+      "name_native": "Русский",
+      "name_english": "Russian",
+      "country_english": "Russia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "589ccc91745a1e2353508ff62c5941b7"
+      },
+      "ru/ru_RU/dmitri/medium/ru_RU-dmitri-medium.onnx.json": {
+        "size_bytes": 4824,
+        "md5_digest": "4eaf0d090190ecb8d958d40c76fd85e8"
+      },
+      "ru/ru_RU/dmitri/medium/MODEL_CARD": {
+        "size_bytes": 276,
+        "md5_digest": "c19f9eff768d0c0e1f476a4c6ca1ff1e"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "ru_RU-irina-medium": {
+    "key": "ru_RU-irina-medium",
+    "name": "irina",
+    "language": {
+      "code": "ru_RU",
+      "family": "ru",
+      "region": "RU",
+      "name_native": "Русский",
+      "name_english": "Russian",
+      "country_english": "Russia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "21fbe77fdc68bdc35d7adb6bf4f52199"
+      },
+      "ru/ru_RU/irina/medium/ru_RU-irina-medium.onnx.json": {
+        "size_bytes": 4765,
+        "md5_digest": "e239bb7f22d5de4a44ec6b1cb6c06bb5"
+      },
+      "ru/ru_RU/irina/medium/MODEL_CARD": {
+        "size_bytes": 271,
+        "md5_digest": "397e67453b4ea5a95642673d0debb5ba"
+      }
+    },
+    "aliases": [
+      "ru-irinia-medium"
+    ],
+    "has_rt_variant": true
+  },
+  "ru_RU-ruslan-medium": {
+    "key": "ru_RU-ruslan-medium",
+    "name": "ruslan",
+    "language": {
+      "code": "ru_RU",
+      "family": "ru",
+      "region": "RU",
+      "name_native": "Русский",
+      "name_english": "Russian",
+      "country_english": "Russia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "731eb188e63b4c57320e38047ba2d850"
+      },
+      "ru/ru_RU/ruslan/medium/ru_RU-ruslan-medium.onnx.json": {
+        "size_bytes": 4882,
+        "md5_digest": "ae6e273bd38d6ecb05c2d1969b24db0c"
+      },
+      "ru/ru_RU/ruslan/medium/MODEL_CARD": {
+        "size_bytes": 313,
+        "md5_digest": "7b50a255192cc1c44358d7cb20ddbb5c"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "sk_SK-lili-medium": {
+    "key": "sk_SK-lili-medium",
+    "name": "lili",
+    "language": {
+      "code": "sk_SK",
+      "family": "sk",
+      "region": "SK",
+      "name_native": "Slovenčina",
+      "name_english": "Slovak",
+      "country_english": "Slovakia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "sk/sk_SK/lili/medium/sk_SK-lili-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "836e078518042448bda8416a8ea52984"
+      },
+      "sk/sk_SK/lili/medium/sk_SK-lili-medium.onnx.json": {
+        "size_bytes": 4963,
+        "md5_digest": "e49cbd13cb5ce5b8f7e1c1479ec2cc91"
+      },
+      "sk/sk_SK/lili/medium/MODEL_CARD": {
+        "size_bytes": 275,
+        "md5_digest": "101dc437bf775a45dd6eedb14d9cfb4e"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "sl_SI-artur-medium": {
+    "key": "sl_SI-artur-medium",
+    "name": "artur",
+    "language": {
+      "code": "sl_SI",
+      "family": "sl",
+      "region": "SI",
+      "name_native": "Slovenščina",
+      "name_english": "Slovenian",
+      "country_english": "Slovenia"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "sl/sl_SI/artur/medium/sl_SI-artur-medium.onnx": {
+        "size_bytes": 63200492,
+        "md5_digest": "ca0aac61139e446bebf98561e8cf9407"
+      },
+      "sl/sl_SI/artur/medium/sl_SI-artur-medium.onnx.json": {
+        "size_bytes": 4970,
+        "md5_digest": "8683796803bce4e9131eec00a93251ad"
+      },
+      "sl/sl_SI/artur/medium/MODEL_CARD": {
+        "size_bytes": 329,
+        "md5_digest": "c7547b0d2c97f38dcbb231c5e77c75c9"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "sr_RS-serbski_institut-medium": {
+    "key": "sr_RS-serbski_institut-medium",
+    "name": "serbski_institut",
+    "language": {
+      "code": "sr_RS",
+      "family": "sr",
+      "region": "RS",
+      "name_native": "srpski",
+      "name_english": "Serbian",
+      "country_english": "Serbia"
+    },
+    "quality": "medium",
+    "num_speakers": 2,
+    "speaker_id_map": {
+      "dsb": 0,
+      "hsb": 1
+    },
+    "files": {
+      "sr/sr_RS/serbski_institut/medium/sr_RS-serbski_institut-medium.onnx": {
+        "size_bytes": 76733615,
+        "md5_digest": "02c6e27ac7b4dfa84272df89edca9feb"
+      },
+      "sr/sr_RS/serbski_institut/medium/sr_RS-serbski_institut-medium.onnx.json": {
+        "size_bytes": 4999,
+        "md5_digest": "dacee7595352af9b4d78bb42237bd759"
+      },
+      "sr/sr_RS/serbski_institut/medium/MODEL_CARD": {
+        "size_bytes": 343,
+        "md5_digest": "407a5b8ebef4877405de2e89eb806633"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "sv_SE-lisa-medium": {
+    "key": "sv_SE-lisa-medium",
+    "name": "lisa",
+    "language": {
+      "code": "sv_SE",
+      "family": "sv",
+      "region": "SE",
+      "name_native": "Svenska",
+      "name_english": "Swedish",
+      "country_english": "Sweden"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "sv/sv_SE/lisa/medium/sv_SE-lisa-medium.onnx": {
+        "size_bytes": 63511038,
+        "md5_digest": "46398d70bbb12d033e15e601a92cd711"
+      },
+      "sv/sv_SE/lisa/medium/sv_SE-lisa-medium.onnx.json": {
+        "size_bytes": 7239,
+        "md5_digest": "1a768f208277aa835e203a969df71345"
+      },
+      "sv/sv_SE/lisa/medium/MODEL_CARD": {
+        "size_bytes": 198,
+        "md5_digest": "730544963a31316127b188dd2a4f462b"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "sv_SE-nst-medium": {
+    "key": "sv_SE-nst-medium",
+    "name": "nst",
+    "language": {
+      "code": "sv_SE",
+      "family": "sv",
+      "region": "SE",
+      "name_native": "Svenska",
+      "name_english": "Swedish",
+      "country_english": "Sweden"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "sv/sv_SE/nst/medium/sv_SE-nst-medium.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "20266cf58e93ca2140444b77398aea04"
+      },
+      "sv/sv_SE/nst/medium/sv_SE-nst-medium.onnx.json": {
+        "size_bytes": 4157,
+        "md5_digest": "3a95d9b88bb3214bf4d0d7fcf8a1aea9"
+      },
+      "sv/sv_SE/nst/medium/MODEL_CARD": {
+        "size_bytes": 306,
+        "md5_digest": "4a7cdb8f218a909b2b5e81d1903628da"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "sw_CD-lanfrica-medium": {
+    "key": "sw_CD-lanfrica-medium",
+    "name": "lanfrica",
+    "language": {
+      "code": "sw_CD",
+      "family": "sw",
+      "region": "CD",
+      "name_native": "Kiswahili",
+      "name_english": "Swahili",
+      "country_english": "Democratic Republic of the Congo"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "sw/sw_CD/lanfrica/medium/sw_CD-lanfrica-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "7b28078f0e76cb201dc8b512ea4bf4d6"
+      },
+      "sw/sw_CD/lanfrica/medium/sw_CD-lanfrica-medium.onnx.json": {
+        "size_bytes": 4905,
+        "md5_digest": "fee67ee6bbb0ad9d9376b0d1cf2923d1"
+      },
+      "sw/sw_CD/lanfrica/medium/MODEL_CARD": {
+        "size_bytes": 315,
+        "md5_digest": "225cc22fc4a35a83f2039988499baa85"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "tr_TR-dfki-medium": {
+    "key": "tr_TR-dfki-medium",
+    "name": "dfki",
+    "language": {
+      "code": "tr_TR",
+      "family": "tr",
+      "region": "TR",
+      "name_native": "Türkçe",
+      "name_english": "Turkish",
+      "country_english": "Turkey"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "tr/tr_TR/dfki/medium/tr_TR-dfki-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "f51287b350a042dd8d67b2b215145e5a"
+      },
+      "tr/tr_TR/dfki/medium/tr_TR-dfki-medium.onnx.json": {
+        "size_bytes": 4960,
+        "md5_digest": "683c97d5bf7588abb4d7b9ff556c9466"
+      },
+      "tr/tr_TR/dfki/medium/MODEL_CARD": {
+        "size_bytes": 319,
+        "md5_digest": "870d6bc19719328699449cb7b4dd56cf"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "tr_TR-fahrettin-medium": {
+    "key": "tr_TR-fahrettin-medium",
+    "name": "fahrettin",
+    "language": {
+      "code": "tr_TR",
+      "family": "tr",
+      "region": "TR",
+      "name_native": "Türkçe",
+      "name_english": "Turkish",
+      "country_english": "Turkey"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "tr/tr_TR/fahrettin/medium/tr_TR-fahrettin-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "3ab8730ec3a132c79c74a45c451372f8"
+      },
+      "tr/tr_TR/fahrettin/medium/tr_TR-fahrettin-medium.onnx.json": {
+        "size_bytes": 5022,
+        "md5_digest": "38b7beb509cb459da3c8f95841a59435"
+      },
+      "tr/tr_TR/fahrettin/medium/MODEL_CARD": {
+        "size_bytes": 279,
+        "md5_digest": "f0fe18e5a6b7615d59a89dfe4873247f"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "tr_TR-fettah-medium": {
+    "key": "tr_TR-fettah-medium",
+    "name": "fettah",
+    "language": {
+      "code": "tr_TR",
+      "family": "tr",
+      "region": "TR",
+      "name_native": "Türkçe",
+      "name_english": "Turkish",
+      "country_english": "Turkey"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "tr/tr_TR/fettah/medium/tr_TR-fettah-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "596984449bd075fc18e6412c66ed99c2"
+      },
+      "tr/tr_TR/fettah/medium/tr_TR-fettah-medium.onnx.json": {
+        "size_bytes": 4877,
+        "md5_digest": "583aa5f4bfac5237afb1cdbdf5bfc992"
+      },
+      "tr/tr_TR/fettah/medium/MODEL_CARD": {
+        "size_bytes": 276,
+        "md5_digest": "9c51c87dc191bd556c0634793c233d5c"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": false
+  },
+  "uk_UA-lada-x_low": {
+    "key": "uk_UA-lada-x_low",
+    "name": "lada",
+    "language": {
+      "code": "uk_UA",
+      "family": "uk",
+      "region": "UA",
+      "name_native": "украї́нська мо́ва",
+      "name_english": "Ukrainian",
+      "country_english": "Ukraine"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "uk/uk_UA/lada/x_low/uk_UA-lada-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "b84110e3923d64cdd4e0056a22090557"
+      },
+      "uk/uk_UA/lada/x_low/uk_UA-lada-x_low.onnx.json": {
+        "size_bytes": 4186,
+        "md5_digest": "c447c945fa6abcde575333fa479e005d"
+      },
+      "uk/uk_UA/lada/x_low/MODEL_CARD": {
+        "size_bytes": 267,
+        "md5_digest": "8de03ca7a0aee2a1c088638ec18fdb87"
+      }
+    },
+    "aliases": [
+      "uk-lada-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "uk_UA-ukrainian_tts-medium": {
+    "key": "uk_UA-ukrainian_tts-medium",
+    "name": "ukrainian_tts",
+    "language": {
+      "code": "uk_UA",
+      "family": "uk",
+      "region": "UA",
+      "name_native": "украї́нська мо́ва",
+      "name_english": "Ukrainian",
+      "country_english": "Ukraine"
+    },
+    "quality": "medium",
+    "num_speakers": 3,
+    "speaker_id_map": {
+      "lada": 0,
+      "mykyta": 1,
+      "tetiana": 2
+    },
+    "files": {
+      "uk/uk_UA/ukrainian_tts/medium/uk_UA-ukrainian_tts-medium.onnx": {
+        "size_bytes": 76735663,
+        "md5_digest": "3366c3d4f31cb77966fb14d042956b4f"
+      },
+      "uk/uk_UA/ukrainian_tts/medium/uk_UA-ukrainian_tts-medium.onnx.json": {
+        "size_bytes": 2002,
+        "md5_digest": "3bf9b2b1fcc8e599947cdda4af130498"
+      },
+      "uk/uk_UA/ukrainian_tts/medium/MODEL_CARD": {
+        "size_bytes": 266,
+        "md5_digest": "d615c1c54d0017f4eb42c95dabc5573b"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "vi_VN-25hours_single-low": {
+    "key": "vi_VN-25hours_single-low",
+    "name": "25hours_single",
+    "language": {
+      "code": "vi_VN",
+      "family": "vi",
+      "region": "VN",
+      "name_native": "Tiếng Việt",
+      "name_english": "Vietnamese",
+      "country_english": "Vietnam"
+    },
+    "quality": "low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "vi/vi_VN/25hours_single/low/vi_VN-25hours_single-low.onnx": {
+        "size_bytes": 63104526,
+        "md5_digest": "54ff8fb35b0084336377ddd10717e1fa"
+      },
+      "vi/vi_VN/25hours_single/low/vi_VN-25hours_single-low.onnx.json": {
+        "size_bytes": 4176,
+        "md5_digest": "d626bc458e9eb1a12650709bfc89d4a2"
+      },
+      "vi/vi_VN/25hours_single/low/MODEL_CARD": {
+        "size_bytes": 343,
+        "md5_digest": "25eb4744418cd7b8da0a9096dcfa6e61"
+      }
+    },
+    "aliases": [
+      "vi-25hours-single-low"
+    ],
+    "has_rt_variant": false
+  },
+  "vi_VN-vais1000-medium": {
+    "key": "vi_VN-vais1000-medium",
+    "name": "vais1000",
+    "language": {
+      "code": "vi_VN",
+      "family": "vi",
+      "region": "VN",
+      "name_native": "Tiếng Việt",
+      "name_english": "Vietnamese",
+      "country_english": "Vietnam"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "vi/vi_VN/vais1000/medium/vi_VN-vais1000-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "5e42428c4f6131f75557cf156c9c1526"
+      },
+      "vi/vi_VN/vais1000/medium/vi_VN-vais1000-medium.onnx.json": {
+        "size_bytes": 4860,
+        "md5_digest": "5ec9669253541d64ba97f60e422f1ad0"
+      },
+      "vi/vi_VN/vais1000/medium/MODEL_CARD": {
+        "size_bytes": 361,
+        "md5_digest": "1beeecba9042e5925b0c5fbd138c779d"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "vi_VN-vivos-x_low": {
+    "key": "vi_VN-vivos-x_low",
+    "name": "vivos",
+    "language": {
+      "code": "vi_VN",
+      "family": "vi",
+      "region": "VN",
+      "name_native": "Tiếng Việt",
+      "name_english": "Vietnamese",
+      "country_english": "Vietnam"
+    },
+    "quality": "x_low",
+    "num_speakers": 65,
+    "speaker_id_map": {
+      "VIVOSSPK13": 0,
+      "VIVOSSPK14": 1,
+      "VIVOSSPK15": 2,
+      "VIVOSSPK16": 3,
+      "VIVOSSPK17": 4,
+      "VIVOSSPK18": 5,
+      "VIVOSSPK19": 6,
+      "VIVOSSPK20": 7,
+      "VIVOSSPK21": 8,
+      "VIVOSSPK22": 9,
+      "VIVOSSPK26": 10,
+      "VIVOSSPK34": 11,
+      "VIVOSSPK40": 12,
+      "VIVOSSPK41": 13,
+      "VIVOSSPK42": 14,
+      "VIVOSSPK43": 15,
+      "VIVOSSPK44": 16,
+      "VIVOSSPK45": 17,
+      "VIVOSSPK46": 18,
+      "VIVOSSPK38": 19,
+      "VIVOSSPK31": 20,
+      "VIVOSSPK35": 21,
+      "VIVOSSPK01": 22,
+      "VIVOSSPK02": 23,
+      "VIVOSSPK03": 24,
+      "VIVOSSPK04": 25,
+      "VIVOSSPK05": 26,
+      "VIVOSSPK06": 27,
+      "VIVOSSPK07": 28,
+      "VIVOSSPK08": 29,
+      "VIVOSSPK09": 30,
+      "VIVOSSPK10": 31,
+      "VIVOSSPK11": 32,
+      "VIVOSSPK12": 33,
+      "VIVOSSPK27": 34,
+      "VIVOSSPK36": 35,
+      "VIVOSSPK33": 36,
+      "VIVOSSPK32": 37,
+      "VIVOSSPK29": 38,
+      "VIVOSSPK39": 39,
+      "VIVOSSPK25": 40,
+      "VIVOSSPK28": 41,
+      "VIVOSSPK30": 42,
+      "VIVOSSPK37": 43,
+      "VIVOSSPK23": 44,
+      "VIVOSSPK24": 45,
+      "VIVOSDEV02": 46,
+      "VIVOSDEV03": 47,
+      "VIVOSDEV01": 48,
+      "VIVOSDEV04": 49,
+      "VIVOSDEV05": 50,
+      "VIVOSDEV06": 51,
+      "VIVOSDEV07": 52,
+      "VIVOSDEV08": 53,
+      "VIVOSDEV09": 54,
+      "VIVOSDEV10": 55,
+      "VIVOSDEV11": 56,
+      "VIVOSDEV12": 57,
+      "VIVOSDEV13": 58,
+      "VIVOSDEV14": 59,
+      "VIVOSDEV15": 60,
+      "VIVOSDEV16": 61,
+      "VIVOSDEV17": 62,
+      "VIVOSDEV18": 63,
+      "VIVOSDEV19": 64
+    },
+    "files": {
+      "vi/vi_VN/vivos/x_low/vi_VN-vivos-x_low.onnx": {
+        "size_bytes": 27789413,
+        "md5_digest": "d5880d32e340f57489dcb9d4f1f7aa04"
+      },
+      "vi/vi_VN/vivos/x_low/vi_VN-vivos-x_low.onnx.json": {
+        "size_bytes": 5592,
+        "md5_digest": "708356072a75e33cff652f1b5d455795"
+      },
+      "vi/vi_VN/vivos/x_low/MODEL_CARD": {
+        "size_bytes": 272,
+        "md5_digest": "6bd1265a94a8f6bcce74a5b1145a7f95"
+      }
+    },
+    "aliases": [
+      "vi-vivos-x-low"
+    ],
+    "has_rt_variant": false
+  },
+  "zh_CN-huayan-medium": {
+    "key": "zh_CN-huayan-medium",
+    "name": "huayan",
+    "language": {
+      "code": "zh_CN",
+      "family": "zh",
+      "region": "CN",
+      "name_native": "简体中文",
+      "name_english": "Chinese",
+      "country_english": "China"
+    },
+    "quality": "medium",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "zh/zh_CN/huayan/medium/zh_CN-huayan-medium.onnx": {
+        "size_bytes": 63201294,
+        "md5_digest": "40cdb7930ff91b81574d5f0489e076ea"
+      },
+      "zh/zh_CN/huayan/medium/zh_CN-huayan-medium.onnx.json": {
+        "size_bytes": 4822,
+        "md5_digest": "1fda3ec1d0d3a5a74064397ea8fe0af0"
+      },
+      "zh/zh_CN/huayan/medium/MODEL_CARD": {
+        "size_bytes": 276,
+        "md5_digest": "b23255ace0cda4c2e02134d8a70c2e03"
+      }
+    },
+    "aliases": [],
+    "has_rt_variant": true
+  },
+  "zh_CN-huayan-x_low": {
+    "key": "zh_CN-huayan-x_low",
+    "name": "huayan",
+    "language": {
+      "code": "zh_CN",
+      "family": "zh",
+      "region": "CN",
+      "name_native": "简体中文",
+      "name_english": "Chinese",
+      "country_english": "China"
+    },
+    "quality": "x_low",
+    "num_speakers": 1,
+    "speaker_id_map": {},
+    "files": {
+      "zh/zh_CN/huayan/x_low/zh_CN-huayan-x_low.onnx": {
+        "size_bytes": 20628813,
+        "md5_digest": "2b96570db6becd09814a608c8d14a64f"
+      },
+      "zh/zh_CN/huayan/x_low/zh_CN-huayan-x_low.onnx.json": {
+        "size_bytes": 4164,
+        "md5_digest": "39efce50e05f04893ae656f9008698f7"
+      },
+      "zh/zh_CN/huayan/x_low/MODEL_CARD": {
+        "size_bytes": 237,
+        "md5_digest": "715587a977945498c5741b74eb81a1fd"
+      }
+    },
+    "aliases": [
+      "zh-cn-huayan-x-low"
+    ],
+    "has_rt_variant": false
+  }
+}

--- a/addon/synthDrivers/dengjen_neural_voices/helpers.py
+++ b/addon/synthDrivers/dengjen_neural_voices/helpers.py
@@ -11,6 +11,7 @@ from gui.settingsDialogs import NVDASettingsDialog, SpeechSettingsPanel
 PLUGIN_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 LIB_DIRECTORY = os.path.join(PLUGIN_DIRECTORY, "lib")
 BIN_DIRECTORY = os.path.join(PLUGIN_DIRECTORY, "bin")
+DATA_DIRECTORY = os.path.join(PLUGIN_DIRECTORY, "data")
 
 
 @contextlib.contextmanager

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -499,6 +499,12 @@ class TestVoicesCache:
         monkeypatch.setattr(voice_download, "PIPER_VOICES_JSON_LOCAL_CACHE", str(path))
         return path
 
+    @pytest.fixture
+    def bundled_path(self, tmp_path, monkeypatch):
+        path = tmp_path / "bundled-piper-voices.json"
+        monkeypatch.setattr(voice_download, "BUNDLED_PIPER_VOICES_JSON", str(path))
+        return path
+
     def test_get_voices_from_cache_returns_none_when_file_is_missing(self, cache_path):
         assert voice_download._get_voices_from_cache() is None
 
@@ -564,6 +570,58 @@ class TestVoicesCache:
             ]
             is True
         )
+
+    def _offline_request(self, monkeypatch):
+        fake_request = _FakeMureq(get_responses=[RuntimeError("network down")])
+        monkeypatch.setattr(voice_download, "request", fake_request)
+        return fake_request
+
+    def _no_installed_voices(self, monkeypatch):
+        monkeypatch.setattr(
+            voice_download.DengjenTextToSpeechSystem,
+            "load_piper_voices_from_nvda_config_dir",
+            classmethod(lambda cls, backend: []),
+        )
+
+    def test_falls_back_to_bundled_catalog_when_offline_and_no_local_cache(
+        self, cache_path, bundled_path, monkeypatch
+    ):
+        bundled_path.write_text(json.dumps({}), encoding="utf-8")
+        self._offline_request(monkeypatch)
+        self._no_installed_voices(monkeypatch)
+
+        result = voice_download.get_available_voices(force_online=False)
+
+        assert result == []
+
+    def test_falls_back_to_bundled_catalog_when_local_cache_is_corrupt_and_offline(
+        self, cache_path, bundled_path, monkeypatch
+    ):
+        cache_path.write_text("not json", encoding="utf-8")
+        bundled_path.write_text(json.dumps({}), encoding="utf-8")
+        self._offline_request(monkeypatch)
+        self._no_installed_voices(monkeypatch)
+
+        result = voice_download.get_available_voices(force_online=False)
+
+        assert result == []
+
+    def test_forced_refresh_raises_without_falling_back_to_bundled_catalog(
+        self, cache_path, bundled_path, monkeypatch
+    ):
+        bundled_path.write_text(json.dumps({}), encoding="utf-8")
+        self._offline_request(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="network down"):
+            voice_download.get_available_voices(force_online=True)
+
+    def test_raises_when_bundled_catalog_is_also_unavailable(
+        self, cache_path, bundled_path, monkeypatch
+    ):
+        self._offline_request(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="network down"):
+            voice_download.get_available_voices(force_online=False)
 
 
 def _cert_verification_error():

--- a/update_voice_catalog.py
+++ b/update_voice_catalog.py
@@ -1,0 +1,42 @@
+import json
+import sys
+import urllib.request
+
+PIPER_VOICE_LIST_URL = "https://huggingface.co/rhasspy/piper-voices/raw/v1.0.0/voices.json"
+RT_VOICE_LIST_URL = "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
+TARGET_PATH = "addon/synthDrivers/dengjen_neural_voices/data/piper-voices.json"
+
+
+def _fetch_json(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req) as response:
+        return json.loads(response.read().decode())
+
+
+print(f"Fetching {PIPER_VOICE_LIST_URL}...")
+try:
+    std_voices = _fetch_json(PIPER_VOICE_LIST_URL)
+except Exception as e:
+    print(f"Failed to fetch the standard voice list: {e}")
+    sys.exit(1)
+
+print(f"Fetching {RT_VOICE_LIST_URL}...")
+try:
+    rt_voices = _fetch_json(RT_VOICE_LIST_URL)
+except Exception as e:
+    print(f"Failed to fetch the RT voice list: {e}")
+    sys.exit(1)
+
+# Mirrors voice_download._refresh_voices_cache(): flags every standard voice
+# that has a matching fast (+RT) variant, same shape get_available_voices()
+# expects whether it's reading the user's local cache or this bundled file.
+rt_voice_names = {vdata["base"] for vdata in rt_voices.values()}
+voice_list = {}
+for vname, vdata in std_voices.items():
+    vdata["has_rt_variant"] = vname in rt_voice_names
+    voice_list[vname] = vdata
+
+with open(TARGET_PATH, "w", encoding="utf-8") as f:
+    json.dump(voice_list, f, ensure_ascii=False, indent=2)
+
+print(f"Wrote {len(voice_list)} voices to {TARGET_PATH}")

--- a/update_voice_catalog.py
+++ b/update_voice_catalog.py
@@ -2,8 +2,12 @@ import json
 import sys
 import urllib.request
 
-PIPER_VOICE_LIST_URL = "https://huggingface.co/rhasspy/piper-voices/raw/v1.0.0/voices.json"
-RT_VOICE_LIST_URL = "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
+PIPER_VOICE_LIST_URL = (
+    "https://huggingface.co/rhasspy/piper-voices/raw/v1.0.0/voices.json"
+)
+RT_VOICE_LIST_URL = (
+    "https://huggingface.co/datasets/mush42/piper-rt/raw/main/voices.json"
+)
 TARGET_PATH = "addon/synthDrivers/dengjen_neural_voices/data/piper-voices.json"
 
 


### PR DESCRIPTION
Closes #166.

## Summary

`get_available_voices()` only fell back to the on-disk cache when it already existed, so a first run (or any run without a route to both Hugging Face endpoints) got no voice list at all — even though "Install from local file" can already install a voice with zero network access.

## Changes

- Bundle a full `piper-voices.json` snapshot (RT variants merged in) at `addon/synthDrivers/dengjen_neural_voices/data/piper-voices.json`.
- New `update_voice_catalog.py` maintainer script to refresh that snapshot before a release, mirroring `update_grpc.py`/`update_cffi.py`.
- `get_available_voices()` falls back to the bundled snapshot when an implicit refresh fails and no usable local cache exists. An explicit "Refresh voices list" click (`force_online=True`) still raises, so the user sees the failure instead of silently getting stale data.
- `helpers.DATA_DIRECTORY` constant alongside the existing `LIB_DIRECTORY`/`BIN_DIRECTORY`.

## Test plan

- [x] Syntax check passes (`ruff check`).
- [x] `pytest` green: 477 passed, 17 skipped (Linux, stub suite) — 4 new tests cover cache-hit, corrupt-cache-and-offline, forced-refresh-raises, and bundled-catalog-also-unavailable.
- [ ] CI build + test green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline fallback catalog for available voices.
  * Voice catalogs now remain accessible when online refreshes fail, unless an online refresh is explicitly forced.
  * Added tooling to update the bundled voice catalog with standard and RT voice metadata.

* **Bug Fixes**
  * Improved resilience when local voice cache data is missing or corrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->