### PR TITLE
docs: add LinkedIn share link to support banner

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,4 +132,5 @@ If this repository saves you time and effort, please consider supporting it!
 
 - ⭐ [Star on GitHub](https://github.com/ZirekHQ/dengjen-nvda)
 - 🐦 [Share on Twitter](https://twitter.com/intent/tweet?text=Dengjen%20Neural%20Voices%20-%20local%20neural%20TTS%20for%20NVDA&url=https%3A%2F%2Fgithub.com%2FZirekHQ%2Fdengjen-nvda)
+- 💼 [Share on LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fgithub.com%2FZirekHQ%2Fdengjen-nvda)
 - 💖 [More ways to support](https://github.com/ZirekHQ) — Open Collective coming soon


### PR DESCRIPTION
## Summary

Adds a LinkedIn share-intent link next to the existing Twitter one in the README's support banner, reaching a different audience with the same one-line pattern.

## Changes

- `readme.md`: added a LinkedIn share-intent link line under "Support This Project".

## Test plan

- [x] Syntax check passes (Markdown-only change).
- [ ] CI build + test green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a “Share on LinkedIn” link to the “Support This Project” section, alongside existing sharing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->