### PR TITLE
chore: drop legacy Piper naming and extract shared download infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ manifest.ini
 .sconsign.dblite
 /[0-9]*.[0-9]*.[0-9]*.json
 .venv/
+.venv-py313/
 .idea
 .coverage
 coverage.xml

--- a/addon/globalPlugins/dengjen_tts_global_plugin/download_infra.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/download_infra.py
@@ -136,16 +136,18 @@ def resumable_partial_size(target_file, expected_size):
 CONTENT_RANGE_TOTAL_REGEX = re.compile(r"bytes \d+-\d+/(\d+)")
 
 
-def archive_total_size(response, resume_offset):
+def archive_total_size(response):
     """The archive's full size, for a request that may itself be a resume.
 
     A 206 reports only the remaining bytes via Content-Length, so the total
     comes from Content-Range's `.../<total>` instead; a fresh 200 reports the
-    full size directly.
+    full size directly. An unparseable or wildcard Content-Range yields 0
+    (unknown), rather than a resume offset that would overshoot the max on
+    progress updates and fail the post-download size check.
     """
     if response.status == 206:
         match = CONTENT_RANGE_TOTAL_REGEX.match(response.getheader("Content-Range", ""))
-        return int(match.group(1)) if match else resume_offset
+        return int(match.group(1)) if match else 0
     return int(response.getheader("Content-Length", 0))
 
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/download_infra.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/download_infra.py
@@ -1,0 +1,282 @@
+"""Backend-agnostic voice-download machinery: redirect following, TLS
+trust-store-gap fallback, and resumable disk streaming. Shared by
+voice_download.py (Piper) and kokoro_download.py (Kokoro) -- neither format
+is relevant to any of the code in this file.
+
+Also holds BaseVoiceDownloader, the shared download/install/progress-dialog
+workflow both backends' downloader classes subclass -- the only part of this
+module that imports wx, gui, and core."""
+
+import math
+import os
+import re
+import shutil
+import ssl
+import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack, contextmanager
+from functools import lru_cache, partial
+from http.client import HTTPException
+
+import addonHandler
+import core
+import gui
+import wx
+from logHandler import log
+
+addonHandler.initTranslation()
+
+from . import DENGJEN_VOICES_DIR, helpers
+
+with helpers.import_bundled_library():
+    import mureq as request
+
+
+THREAD_POOL_EXECUTOR = ThreadPoolExecutor()
+REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+REDIRECT_LIMIT = 5
+DOWNLOAD_CHUNK_SIZE = 4096
+CACERT_PATH = os.path.join(helpers.LIB_DIRECTORY, "cacert.pem")
+
+
+@lru_cache(maxsize=1)
+def _fallback_ssl_context():
+    return ssl.create_default_context(cafile=CACERT_PATH)
+
+
+def _is_os_trust_store_gap(exc):
+
+    return isinstance(exc.__cause__, ssl.SSLCertVerificationError)
+
+
+def get_with_cert_fallback(url, **kwargs):
+    try:
+        return request.get(url, **kwargs)
+    except HTTPException as e:
+        if not _is_os_trust_store_gap(e):
+            raise
+        log.debug(
+            "OS trust store missing a root CA; retrying with the vendored CA bundle",
+            exc_info=True,
+        )
+        return request.get(url, ssl_context=_fallback_ssl_context(), **kwargs)
+
+
+@contextmanager
+def _yield_response_with_cert_fallback(method, url, headers=None, **kwargs):
+    with ExitStack() as stack:
+        try:
+            response = stack.enter_context(
+                request.yield_response(method, url, headers=headers, **kwargs)
+            )
+        except HTTPException as e:
+            if not _is_os_trust_store_gap(e):
+                raise
+            log.debug(
+                "OS trust store missing a root CA; retrying with the vendored CA bundle",
+                exc_info=True,
+            )
+            response = stack.enter_context(
+                request.yield_response(
+                    method,
+                    url,
+                    headers=headers,
+                    ssl_context=_fallback_ssl_context(),
+                    **kwargs,
+                )
+            )
+        yield response
+
+
+@contextmanager
+def follow_redirects(url, label, headers=None):
+
+    for _redirect in range(REDIRECT_LIMIT):
+        with _yield_response_with_cert_fallback(
+            "GET", url, headers=headers
+        ) as response:
+            if response.status in REDIRECT_STATUSES:
+                location = response.getheader("Location")
+                if not location:
+                    raise ValueError("Redirect without Location header.")
+                url = urllib.parse.urljoin(url, location)
+                continue
+
+            if response.status not in (200, 206):
+                raise RuntimeError(
+                    f"Download failed for {label} (status {response.status})"
+                )
+
+            content_type = response.getheader("Content-Type", "").lower()
+            if "text/html" in content_type or "xml" in content_type:
+                raise RuntimeError(
+                    f"Wrong content-type while downloading {label}: {content_type}"
+                )
+
+            yield response
+            return
+
+    raise RuntimeError(f"Too many redirects while downloading {label}")
+
+
+def resumable_partial_size(target_file, expected_size):
+    """Bytes of `target_file` already on disk that a Range request can resume from.
+
+    Returns 0 (start fresh) when nothing exists yet, or when a known
+    `expected_size` shows the leftover is stale/complete already.
+    """
+    if not os.path.exists(target_file):
+        return 0
+    existing_size = os.path.getsize(target_file)
+    if expected_size and existing_size >= expected_size:
+        return 0
+    return existing_size
+
+
+CONTENT_RANGE_TOTAL_REGEX = re.compile(r"bytes \d+-\d+/(\d+)")
+
+
+def archive_total_size(response, resume_offset):
+    """The archive's full size, for a request that may itself be a resume.
+
+    A 206 reports only the remaining bytes via Content-Length, so the total
+    comes from Content-Range's `.../<total>` instead; a fresh 200 reports the
+    full size directly.
+    """
+    if response.status == 206:
+        match = CONTENT_RANGE_TOTAL_REGEX.match(response.getheader("Content-Range", ""))
+        return int(match.group(1)) if match else resume_offset
+    return int(response.getheader("Content-Length", 0))
+
+
+def stream_to_file(
+    response, target_file, total_size, progress_callback, hasher=None, resume_offset=0
+):
+    """Streams `response` into `target_file`, resuming a prior partial download.
+
+    A resume is only honored when the server actually answered with 206 —
+    a 200 despite a Range request means it sent the full body from byte 0,
+    so any partial bytes already on disk are discarded and hashed anew.
+    """
+    is_resuming = resume_offset > 0 and response.status == 206
+    downloaded_til_now = resume_offset if is_resuming else 0
+    if is_resuming and hasher is not None:
+        with open(target_file, "rb") as existing:
+            for chunk in iter(partial(existing.read, DOWNLOAD_CHUNK_SIZE), b""):
+                hasher.update(chunk)
+    with open(target_file, "ab" if is_resuming else "wb") as file_buffer:
+        for chunk in iter(partial(response.read, DOWNLOAD_CHUNK_SIZE), b""):
+            file_buffer.write(chunk)
+            if hasher is not None:
+                hasher.update(chunk)
+            downloaded_til_now += len(chunk)
+            if total_size > 0:
+                progress_callback(math.floor((downloaded_til_now / total_size) * 100))
+
+
+class VoiceInstallError(Exception):
+    """Raised by a downloader's `_install` hook to signal a failed install."""
+
+
+class BaseVoiceDownloader:
+    def __init__(self, voice, success_callback):
+        self.voice = voice
+        self.success_callback = success_callback
+        # Stable across instances, so resumable_partial_size can find a prior attempt's file here.
+        self.download_dir = os.path.join(DENGJEN_VOICES_DIR, ".downloads", voice.key)
+        os.makedirs(self.download_dir, exist_ok=True)
+        self.progress_dialog = None
+
+    def update_progress(self, progress):
+        self._report_progress(
+            progress,
+            _("Downloaded: {progress}%").format(progress=progress),
+        )
+
+    def _report_progress(self, percent, message):
+        # download_work runs on a worker thread (see download() below);
+        # wx.ProgressDialog.Update() is not thread-safe, so every call must
+        # be marshalled onto the GUI thread via wx.CallAfter.
+        wx.CallAfter(self.progress_dialog.Update, percent, message)
+
+    def download(self):
+        self.progress_dialog = wx.ProgressDialog(
+            title=self._progress_title(),
+            message=_("Retrieving download information..."),
+            parent=gui.mainFrame,
+        )
+        self.progress_dialog.CenterOnScreen()
+        THREAD_POOL_EXECUTOR.submit(self._download_work).add_done_callback(
+            partial(self._done_callback_wrapper, self.done_callback)
+        )
+
+    def done_callback(self, result):
+        # Runs on the worker thread (add_done_callback fires on whichever
+        # thread completes it). _install runs here, not after the
+        # wx.CallAfter below, so disk I/O doesn't block the wx event loop.
+        has_error = isinstance(result, Exception)
+        install_error = None
+        if not has_error:
+            self._report_progress(0, _("Installing voice"))
+            try:
+                self._install(result)
+            except Exception as exc:
+                # A subclass's _install can raise more than VoiceInstallError
+                # (e.g. an unwrapped OSError); catching only that type let it
+                # escape this worker-thread callback, leaving the dialog open.
+                has_error = True
+                install_error = exc
+
+        wx.CallAfter(self._on_download_complete, has_error, install_error, result)
+
+    def _on_download_complete(self, has_error, install_error, result):
+        self.progress_dialog.Hide()
+        self.progress_dialog.Destroy()
+        del self.progress_dialog
+
+        if not has_error:
+            shutil.rmtree(self.download_dir, ignore_errors=True)
+            self.success_callback()
+            retval = gui.messageBox(
+                self._success_message(),
+                _("Voice downloaded"),
+                wx.YES_NO | wx.ICON_WARNING,
+                parent=gui.mainFrame,
+            )
+            if retval == wx.YES:
+                core.restart()
+        else:
+            gui.messageBox(
+                self._failure_message(),
+                _("Download failed"),
+                style=wx.ICON_ERROR,
+                parent=gui.mainFrame,
+            )
+            error = install_error if install_error is not None else result
+            log.error(f"Failed to download voice.\nException: {error}", exc_info=error)
+
+    @staticmethod
+    def _done_callback_wrapper(done_callback, future):
+        if done_callback is None:
+            return
+        try:
+            result = future.result()
+        except Exception as e:
+            done_callback(e)
+        else:
+            done_callback(result)
+
+    def _download_work(self):
+        raise NotImplementedError
+
+    def _install(self, result):
+        raise NotImplementedError
+
+    def _progress_title(self):
+        raise NotImplementedError
+
+    def _success_message(self):
+        raise NotImplementedError
+
+    def _failure_message(self):
+        raise NotImplementedError

--- a/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/kokoro_download.py
@@ -25,11 +25,11 @@ addonHandler.initTranslation()
 from dengjen_neural_voices.const import DENGJEN_KOKORO_VOICES_DIR
 from dengjen_neural_voices.domain import voice_metadata
 
-from .voice_download import (
-    _BaseVoiceDownloader,
-    _follow_redirects,
-    _stream_to_file,
-    _VoiceInstallError,
+from .download_infra import (
+    BaseVoiceDownloader,
+    VoiceInstallError,
+    follow_redirects,
+    stream_to_file,
 )
 
 KOKORO_REPO_RESOLVE_URL = (
@@ -122,12 +122,12 @@ def _download_to_file(relative_path, target_path):
     simultaneously would be material memory pressure inside NVDA."""
     url = f"{KOKORO_REPO_RESOLVE_URL}/{relative_path}"
     target_path.parent.mkdir(parents=True, exist_ok=True)
-    with _follow_redirects(url, relative_path) as response:
+    with follow_redirects(url, relative_path) as response:
         total_size = int(response.getheader("Content-Length", 0))
-        _stream_to_file(response, target_path, total_size, lambda _percent: None)
+        stream_to_file(response, target_path, total_size, lambda _percent: None)
 
 
-class KokoroVoiceDownloader(_BaseVoiceDownloader):
+class KokoroVoiceDownloader(BaseVoiceDownloader):
     """Downloads the shared model + vocab + every preset embedding in one
     install. `voice` is unused by the base class beyond `.key` (used in
     progress/success/failure message formatting)."""
@@ -215,7 +215,7 @@ class KokoroVoiceDownloader(_BaseVoiceDownloader):
             )
         except OSError as exc:
             log.exception("Failed to install the Kokoro voice", exc_info=True)
-            raise _VoiceInstallError from exc
+            raise VoiceInstallError from exc
 
 
 class KokoroCatalog:

--- a/addon/globalPlugins/dengjen_tts_global_plugin/model_catalog.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/model_catalog.py
@@ -1,7 +1,7 @@
 """ModelCatalog: the seam a `dengjen-tts` model backend implements so the
 voice manager can check install state without hardcoding Piper's shape.
 
-Piper's own browsing/preview/download UI (OnlineDengjenVoicesPanel) predates
+Piper's own browsing/preview/download UI (OnlinePiperVoicesPanel) predates
 this protocol and isn't rebuilt on top of it -- PiperCatalog exists to prove
 the protocol against a second, structurally different backend (Kokoro, see
 kokoro_download.py), not to replace working UI.
@@ -30,7 +30,7 @@ class PiperCatalog:
 
     def install(self, success_callback) -> None:
         raise NotImplementedError(
-            "Piper voices are installed per-voice via OnlineDengjenVoicesPanel, "
+            "Piper voices are installed per-voice via OnlinePiperVoicesPanel, "
             "not through ModelCatalog.install()"
         )
 

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -338,7 +338,7 @@ class PiperRTVoiceDownloader(BaseVoiceDownloader):
             with follow_redirects(
                 download_url, voice_name, headers=headers
             ) as response:
-                expected_size = archive_total_size(response, resume_offset)
+                expected_size = archive_total_size(response)
                 stream_to_file(
                     response,
                     target_file,
@@ -354,7 +354,7 @@ class PiperRTVoiceDownloader(BaseVoiceDownloader):
                 raise
             Path(target_file).unlink(missing_ok=True)
             with follow_redirects(download_url, voice_name) as response:
-                expected_size = archive_total_size(response, 0)
+                expected_size = archive_total_size(response)
                 stream_to_file(response, target_file, expected_size, progress_callback)
 
         return target_file, expected_size

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_download.py
@@ -1,23 +1,14 @@
 import json
-import math
 import os
 import re
 import shutil
-import ssl
 import tarfile
-import urllib.parse
-from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from enum import Enum, auto
 from fnmatch import fnmatch
-from functools import lru_cache, partial
 from hashlib import md5
-from http.client import HTTPException
 
 import addonHandler
-import core
-import gui
-import wx
 from languageHandler import normalizeLanguage
 from logHandler import log
 
@@ -26,12 +17,18 @@ addonHandler.initTranslation()
 from dengjen_neural_voices.domain import voice_metadata
 
 from . import DENGJEN_VOICES_DIR, DengjenGrpcBackend, DengjenTextToSpeechSystem, helpers
+from .download_infra import (
+    BaseVoiceDownloader,
+    VoiceInstallError,
+    archive_total_size,
+    follow_redirects,
+    get_with_cert_fallback,
+    resumable_partial_size,
+    stream_to_file,
+)
 
 with helpers.import_bundled_library():
-    from concurrent.futures import ThreadPoolExecutor
     from pathlib import Path
-
-    import mureq as request
 
 
 PIPER_VOICE_LIST_URL = (
@@ -58,11 +55,6 @@ VOICE_INFO_REGEX = re.compile(
     r"(?P<quality>(high|medium|low|x-low|x_low))",
     re.IGNORECASE,
 )
-THREAD_POOL_EXECUTOR = ThreadPoolExecutor()
-REDIRECT_STATUSES = (301, 302, 303, 307, 308)
-REDIRECT_LIMIT = 5
-DOWNLOAD_CHUNK_SIZE = 4096
-CACERT_PATH = os.path.join(helpers.LIB_DIRECTORY, "cacert.pem")
 
 
 class PiperVoiceQualityLevel(Enum):
@@ -197,248 +189,7 @@ class PiperVoice:
         return f"{RT_VOICE_DOWNLOAD_URL_PREFIX}/{rt_voice_key}.tar.gz"
 
 
-@lru_cache(maxsize=1)
-def _fallback_ssl_context():
-    return ssl.create_default_context(cafile=CACERT_PATH)
-
-
-def _is_os_trust_store_gap(exc):
-
-    return isinstance(exc.__cause__, ssl.SSLCertVerificationError)
-
-
-def _get_with_cert_fallback(url, **kwargs):
-    try:
-        return request.get(url, **kwargs)
-    except HTTPException as e:
-        if not _is_os_trust_store_gap(e):
-            raise
-        log.debug(
-            "OS trust store missing a root CA; retrying with the vendored CA bundle",
-            exc_info=True,
-        )
-        return request.get(url, ssl_context=_fallback_ssl_context(), **kwargs)
-
-
-@contextmanager
-def _yield_response_with_cert_fallback(method, url, headers=None, **kwargs):
-    with ExitStack() as stack:
-        try:
-            response = stack.enter_context(
-                request.yield_response(method, url, headers=headers, **kwargs)
-            )
-        except HTTPException as e:
-            if not _is_os_trust_store_gap(e):
-                raise
-            log.debug(
-                "OS trust store missing a root CA; retrying with the vendored CA bundle",
-                exc_info=True,
-            )
-            response = stack.enter_context(
-                request.yield_response(
-                    method,
-                    url,
-                    headers=headers,
-                    ssl_context=_fallback_ssl_context(),
-                    **kwargs,
-                )
-            )
-        yield response
-
-
-@contextmanager
-def _follow_redirects(url, label, headers=None):
-
-    for _redirect in range(REDIRECT_LIMIT):
-        with _yield_response_with_cert_fallback(
-            "GET", url, headers=headers
-        ) as response:
-            if response.status in REDIRECT_STATUSES:
-                location = response.getheader("Location")
-                if not location:
-                    raise ValueError("Redirect without Location header.")
-                url = urllib.parse.urljoin(url, location)
-                continue
-
-            if response.status not in (200, 206):
-                raise RuntimeError(
-                    f"Download failed for {label} (status {response.status})"
-                )
-
-            content_type = response.getheader("Content-Type", "").lower()
-            if "text/html" in content_type or "xml" in content_type:
-                raise RuntimeError(
-                    f"Wrong content-type while downloading {label}: {content_type}"
-                )
-
-            yield response
-            return
-
-    raise RuntimeError(f"Too many redirects while downloading {label}")
-
-
-def _resumable_partial_size(target_file, expected_size):
-    """Bytes of `target_file` already on disk that a Range request can resume from.
-
-    Returns 0 (start fresh) when nothing exists yet, or when a known
-    `expected_size` shows the leftover is stale/complete already.
-    """
-    if not os.path.exists(target_file):
-        return 0
-    existing_size = os.path.getsize(target_file)
-    if expected_size and existing_size >= expected_size:
-        return 0
-    return existing_size
-
-
-CONTENT_RANGE_TOTAL_REGEX = re.compile(r"bytes \d+-\d+/(\d+)")
-
-
-def _archive_total_size(response, resume_offset):
-    """The archive's full size, for a request that may itself be a resume.
-
-    A 206 reports only the remaining bytes via Content-Length, so the total
-    comes from Content-Range's `.../<total>` instead; a fresh 200 reports the
-    full size directly.
-    """
-    if response.status == 206:
-        match = CONTENT_RANGE_TOTAL_REGEX.match(response.getheader("Content-Range", ""))
-        return int(match.group(1)) if match else resume_offset
-    return int(response.getheader("Content-Length", 0))
-
-
-def _stream_to_file(
-    response, target_file, total_size, progress_callback, hasher=None, resume_offset=0
-):
-    """Streams `response` into `target_file`, resuming a prior partial download.
-
-    A resume is only honored when the server actually answered with 206 —
-    a 200 despite a Range request means it sent the full body from byte 0,
-    so any partial bytes already on disk are discarded and hashed anew.
-    """
-    is_resuming = resume_offset > 0 and response.status == 206
-    downloaded_til_now = resume_offset if is_resuming else 0
-    if is_resuming and hasher is not None:
-        with open(target_file, "rb") as existing:
-            for chunk in iter(partial(existing.read, DOWNLOAD_CHUNK_SIZE), b""):
-                hasher.update(chunk)
-    with open(target_file, "ab" if is_resuming else "wb") as file_buffer:
-        for chunk in iter(partial(response.read, DOWNLOAD_CHUNK_SIZE), b""):
-            file_buffer.write(chunk)
-            if hasher is not None:
-                hasher.update(chunk)
-            downloaded_til_now += len(chunk)
-            if total_size > 0:
-                progress_callback(math.floor((downloaded_til_now / total_size) * 100))
-
-
-class _VoiceInstallError(Exception):
-    """Raised by a downloader's `_install` hook to signal a failed install."""
-
-
-class _BaseVoiceDownloader:
-    def __init__(self, voice: PiperVoice, success_callback):
-        self.voice = voice
-        self.success_callback = success_callback
-        # Stable across instances, so _resumable_partial_size can find a prior attempt's file here.
-        self.download_dir = os.path.join(DENGJEN_VOICES_DIR, ".downloads", voice.key)
-        os.makedirs(self.download_dir, exist_ok=True)
-        self.progress_dialog = None
-
-    def update_progress(self, progress):
-        self._report_progress(
-            progress,
-            _("Downloaded: {progress}%").format(progress=progress),
-        )
-
-    def _report_progress(self, percent, message):
-        # download_work runs on a worker thread (see download() below);
-        # wx.ProgressDialog.Update() is not thread-safe, so every call must
-        # be marshalled onto the GUI thread via wx.CallAfter.
-        wx.CallAfter(self.progress_dialog.Update, percent, message)
-
-    def download(self):
-        self.progress_dialog = wx.ProgressDialog(
-            title=self._progress_title(),
-            message=_("Retrieving download information..."),
-            parent=gui.mainFrame,
-        )
-        self.progress_dialog.CenterOnScreen()
-        THREAD_POOL_EXECUTOR.submit(self._download_work).add_done_callback(
-            partial(self._done_callback_wrapper, self.done_callback)
-        )
-
-    def done_callback(self, result):
-        # Runs on the worker thread (a future's add_done_callback fires on
-        # whichever thread completes it -- see download()). _install does
-        # the actual disk I/O here rather than after the wx.CallAfter below,
-        # so writing a large voice to disk doesn't block the wx event loop.
-        has_error = isinstance(result, Exception)
-        install_error = None
-        if not has_error:
-            self._report_progress(0, _("Installing voice"))
-            try:
-                self._install(result)
-            except _VoiceInstallError as exc:
-                has_error = True
-                install_error = exc
-
-        wx.CallAfter(self._on_download_complete, has_error, install_error, result)
-
-    def _on_download_complete(self, has_error, install_error, result):
-        self.progress_dialog.Hide()
-        self.progress_dialog.Destroy()
-        del self.progress_dialog
-
-        if not has_error:
-            shutil.rmtree(self.download_dir, ignore_errors=True)
-            self.success_callback()
-            retval = gui.messageBox(
-                self._success_message(),
-                _("Voice downloaded"),
-                wx.YES_NO | wx.ICON_WARNING,
-                parent=gui.mainFrame,
-            )
-            if retval == wx.YES:
-                core.restart()
-        else:
-            gui.messageBox(
-                self._failure_message(),
-                _("Download failed"),
-                style=wx.ICON_ERROR,
-                parent=gui.mainFrame,
-            )
-            error = install_error if install_error is not None else result
-            log.error(f"Failed to download voice.\nException: {error}", exc_info=error)
-
-    @staticmethod
-    def _done_callback_wrapper(done_callback, future):
-        if done_callback is None:
-            return
-        try:
-            result = future.result()
-        except Exception as e:
-            done_callback(e)
-        else:
-            done_callback(result)
-
-    def _download_work(self):
-        raise NotImplementedError
-
-    def _install(self, result):
-        raise NotImplementedError
-
-    def _progress_title(self):
-        raise NotImplementedError
-
-    def _success_message(self):
-        raise NotImplementedError
-
-    def _failure_message(self):
-        raise NotImplementedError
-
-
-class PiperVoiceDownloader(_BaseVoiceDownloader):
+class PiperVoiceDownloader(BaseVoiceDownloader):
     def _progress_title(self):
 
         return _("Downloading voice {voice}").format(voice=self.voice.key)
@@ -478,14 +229,14 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
         target_file = os.path.join(download_dir, file.file_path.replace("/", os.sep))
         os.makedirs(os.path.dirname(target_file), exist_ok=True)
 
-        resume_offset = _resumable_partial_size(target_file, file.size_in_bytes)
+        resume_offset = resumable_partial_size(target_file, file.size_in_bytes)
         headers = {"Range": f"bytes={resume_offset}-"} if resume_offset else None
 
         hasher = md5(usedforsecurity=False)
-        with _follow_redirects(
+        with follow_redirects(
             file.download_url, file.file_path, headers=headers
         ) as response:
-            _stream_to_file(
+            stream_to_file(
                 response,
                 target_file,
                 file.size_in_bytes,
@@ -507,7 +258,7 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
             for __, target_file in mismatched:
                 # Otherwise the next attempt would "resume" from corrupt bytes.
                 Path(target_file).unlink(missing_ok=True)
-            raise _VoiceInstallError
+            raise VoiceInstallError
 
         voice_dir = Path(DENGJEN_VOICES_DIR).joinpath(self.voice.key)
         voice_dir.mkdir(parents=True, exist_ok=True)
@@ -531,10 +282,10 @@ class PiperVoiceDownloader(_BaseVoiceDownloader):
                 log.exception(f"Failed to copy file: {file}", exc_info=True)
                 copy_failed = True
         if copy_failed:
-            raise _VoiceInstallError
+            raise VoiceInstallError
 
 
-class PiperRTVoiceDownloader(_BaseVoiceDownloader):
+class PiperRTVoiceDownloader(BaseVoiceDownloader):
     def __init__(self, voice: PiperVoice, success_callback):
         self.rt_download_url = voice.get_rt_variant_download_url()
         super().__init__(voice, success_callback)
@@ -580,18 +331,31 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
         cls, download_url, voice_name, download_dir, progress_callback
     ):
         target_file = os.path.join(download_dir, voice_name)
-        resume_offset = _resumable_partial_size(target_file, expected_size=0)
+        resume_offset = resumable_partial_size(target_file, expected_size=0)
         headers = {"Range": f"bytes={resume_offset}-"} if resume_offset else None
 
-        with _follow_redirects(download_url, voice_name, headers=headers) as response:
-            expected_size = _archive_total_size(response, resume_offset)
-            _stream_to_file(
-                response,
-                target_file,
-                expected_size,
-                progress_callback,
-                resume_offset=resume_offset,
-            )
+        try:
+            with follow_redirects(
+                download_url, voice_name, headers=headers
+            ) as response:
+                expected_size = archive_total_size(response, resume_offset)
+                stream_to_file(
+                    response,
+                    target_file,
+                    expected_size,
+                    progress_callback,
+                    resume_offset=resume_offset,
+                )
+        except RuntimeError as exc:
+            # expected_size is unknown ahead of time, so a stale, already-
+            # complete leftover looks resumable and its Range request lands
+            # past EOF (416); discard it and restart once from scratch.
+            if not resume_offset or "(status 416)" not in str(exc):
+                raise
+            Path(target_file).unlink(missing_ok=True)
+            with follow_redirects(download_url, voice_name) as response:
+                expected_size = archive_total_size(response, 0)
+                stream_to_file(response, target_file, expected_size, progress_callback)
 
         return target_file, expected_size
 
@@ -600,7 +364,7 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
         if expected_size and os.path.getsize(target_file) != expected_size:
             log.error("Downloaded archive size does not match the expected size")
             Path(target_file).unlink(missing_ok=True)
-            raise _VoiceInstallError
+            raise VoiceInstallError
         try:
             install_voice_from_tar_archive(target_file, DENGJEN_VOICES_DIR)
         except Exception:
@@ -609,7 +373,7 @@ class PiperRTVoiceDownloader(_BaseVoiceDownloader):
             # EOF and get a 416 forever, since this archive has no known
             # expected_size to catch it as stale beforehand.
             Path(target_file).unlink(missing_ok=True)
-            raise _VoiceInstallError
+            raise VoiceInstallError
 
 
 def _voice_key_from_filename(stem):
@@ -753,10 +517,10 @@ def _get_voices_from_cache(path=None):
 
 
 def _refresh_voices_cache():
-    std_resp = _get_with_cert_fallback(PIPER_VOICE_LIST_URL)
+    std_resp = get_with_cert_fallback(PIPER_VOICE_LIST_URL)
     std_resp.raise_for_status()
     std_voices = std_resp.json()
-    rt_resp = _get_with_cert_fallback(RT_VOICE_LIST_URL)
+    rt_resp = get_with_cert_fallback(RT_VOICE_LIST_URL)
     rt_resp.raise_for_status()
     rt_voice_names = {vdata["base"] for vdata in rt_resp.json().values()}
     voice_list = {}

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -22,6 +22,7 @@ from . import (
     DengjenGrpcBackend,
     DengjenTextToSpeechSystem,
     aio,
+    download_infra,
     helpers,
     model_catalog,
     voice_download,
@@ -280,7 +281,7 @@ class InstalledDengjenVoicesPanel(SizedPanel):
             self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
 
 
-class OnlineDengjenVoicesPanel(SizedPanel):
+class OnlinePiperVoicesPanel(SizedPanel):
     def __init__(self, parent):
         super().__init__(parent, -1)
         self.__already_populated = threading.Event()
@@ -338,7 +339,7 @@ class OnlineDengjenVoicesPanel(SizedPanel):
         if not force_online and self.__already_populated.is_set():
             return
         AsyncSnakDialog(
-            executor=voice_download.THREAD_POOL_EXECUTOR,
+            executor=download_infra.THREAD_POOL_EXECUTOR,
             func=functools.partial(
                 voice_download.get_available_voices, force_online=force_online
             ),
@@ -523,7 +524,7 @@ class DengjenVoiceManagerDialog(SimpleDialog):
             ),
             (
                 _("Download"),
-                OnlineDengjenVoicesPanel(self.notebookCtrl),
+                OnlinePiperVoicesPanel(self.notebookCtrl),
             ),
             (
                 _("Kokoro"),
@@ -560,7 +561,7 @@ class DengjenVoiceManagerDialog(SimpleDialog):
 
 
 def play_remote_mp3(mp3_url):
-    resp = voice_download.request.get(mp3_url)
+    resp = download_infra.request.get(mp3_url)
     resp.raise_for_status()
     decoded_file = miniaudio.decode(resp.body, nchannels=1, sample_rate=22050)
     with tempfile.TemporaryDirectory() as tempdir:

--- a/addon/installTasks.py
+++ b/addon/installTasks.py
@@ -19,17 +19,17 @@ addonHandler.initTranslation()
 
 
 _DIR = os.path.abspath(os.path.dirname(__file__))
-_PIPER_SYNTH_DIR = os.path.join(_DIR, "synthDrivers", "dengjen_neural_voices")
-LIB_DIR = os.path.join(_PIPER_SYNTH_DIR, "lib")
-BIN_DIR = os.path.join(_PIPER_SYNTH_DIR, "bin")
+_SYNTH_DRIVER_DIR = os.path.join(_DIR, "synthDrivers", "dengjen_neural_voices")
+LIB_DIR = os.path.join(_SYNTH_DRIVER_DIR, "lib")
+BIN_DIR = os.path.join(_SYNTH_DRIVER_DIR, "bin")
 
 
-def _load_voice_migration(piper_synth_dir=_PIPER_SYNTH_DIR):
+def _load_voice_migration(synth_driver_dir=_SYNTH_DRIVER_DIR):
     """By file path, not import: the synth package pulls in grpc and the
     bundled Windows libraries at import time, which install must not need."""
     spec = importlib.util.spec_from_file_location(
         "_dengjen_voice_migration",
-        os.path.join(piper_synth_dir, "voice_migration.py"),
+        os.path.join(synth_driver_dir, "voice_migration.py"),
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -37,7 +37,7 @@ def _load_voice_migration(piper_synth_dir=_PIPER_SYNTH_DIR):
 
 
 voice_migration = _load_voice_migration()
-del _DIR, _PIPER_SYNTH_DIR
+del _DIR, _SYNTH_DRIVER_DIR
 
 OLD_ADDON_NAME = voice_migration.OLD_ADDON_NAME
 CONFIG_SECTION = "dengjen_neural_voices"

--- a/addon/synthDrivers/dengjen_neural_voices/aio.py
+++ b/addon/synthDrivers/dengjen_neural_voices/aio.py
@@ -66,7 +66,7 @@ class AsyncEngine:
             if self._executor is None or self._executor_is_shutdown:
                 max_workers = max(1, (os.cpu_count() or 2) // 2)
                 self._executor = ThreadPoolExecutor(
-                    max_workers=max_workers, thread_name_prefix="piper4nvda_executor"
+                    max_workers=max_workers, thread_name_prefix="dengjen_executor"
                 )
                 self._executor_is_shutdown = False
 
@@ -95,7 +95,7 @@ class AsyncEngine:
                 target=_thread_target,
                 args=(self._event_loop,),
                 daemon=True,
-                name="piper4nvda_asyncio",
+                name="dengjen_asyncio",
             )
             self._loop_thread.start()
             if not self._loop_running.wait(timeout=LOOP_STARTUP_TIMEOUT):

--- a/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
+++ b/addon/synthDrivers/dengjen_neural_voices/domain/tts_system.py
@@ -279,7 +279,7 @@ class DengjenTextToSpeechSystem:
             try:
                 voice = self.voices[0]
             except IndexError:
-                raise VoiceNotFoundError("No Piper voices found")
+                raise VoiceNotFoundError("No voices found")
             self.speech_options = SpeechOptions(voice=voice)
 
     @contextmanager

--- a/tests/test_async_engine.py
+++ b/tests/test_async_engine.py
@@ -152,7 +152,7 @@ class TestCallThreaded:
 
         name = which_thread().result(timeout=5)
         assert name != threading.current_thread().name
-        assert name.startswith("piper4nvda_executor")
+        assert name.startswith("dengjen_executor")
 
     def test_preserves_the_wrapped_function_metadata(self, running_engine):
         @running_engine.call_threaded

--- a/tests/test_download_infra.py
+++ b/tests/test_download_infra.py
@@ -1,0 +1,280 @@
+"""
+Tests for download_infra.py: the backend-agnostic HTTP download machinery
+shared by voice_download.py (Piper) and kokoro_download.py (Kokoro) --
+redirect following, TLS trust-store-gap fallback, and resumable streaming to
+disk.
+
+Network is never exercised: `request` (mureq, the vendored HTTP client) is
+monkeypatched per-test with canned responses.
+"""
+
+import hashlib
+import io
+import os
+import ssl
+from contextlib import contextmanager
+from http.client import HTTPException
+from unittest.mock import MagicMock
+
+import addonHandler
+import pytest
+
+from tests.conftest import GLOBAL_PLUGIN_PKG_DIR, load_module_from_path
+
+addonHandler.initTranslation()
+
+# Loaded under a private name deliberately: this file never goes through
+# voice_download.py, so reusing the canonical dotted name here would risk
+# clobbering the real module or creating test-collection-order dependence.
+download_infra = load_module_from_path(
+    "dengjen_tts_global_plugin._download_infra_under_test",
+    os.path.join(GLOBAL_PLUGIN_PKG_DIR, "download_infra.py"),
+    package="dengjen_tts_global_plugin",
+)
+
+
+class _FakeResponse:
+    """Stands in for a mureq Response: status/headers/chunked-read/json."""
+
+    def __init__(self, status=200, headers=None, body=b"", json_data=None):
+        self.status = status
+        self._headers = headers or {}
+        self._body = io.BytesIO(body)
+        self._json_data = json_data
+
+    def getheader(self, name, default=None):
+        return self._headers.get(name, default)
+
+    def read(self, size=-1):
+        return self._body.read(size)
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise RuntimeError(f"status {self.status}")
+
+
+class _FakeMureq:
+    """Stands in for the `mureq` module download_infra imports as `request`.
+
+    `get_responses` feeds sequential calls to `.get()`; `stream_responses`
+    feeds sequential `.yield_response()` calls (one per redirect hop).
+    """
+
+    def __init__(self, get_responses=None, stream_responses=None):
+        self._get_responses = list(get_responses or [])
+        self._stream_responses = list(stream_responses or [])
+        self.get_urls = []
+        self.yield_urls = []
+        self.get_calls = []
+        self.yield_calls = []
+
+    def get(self, url, **kwargs):
+        self.get_urls.append(url)
+        self.get_calls.append(kwargs)
+        item = self._get_responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    @contextmanager
+    def yield_response(self, method, url, **kwargs):
+        self.yield_urls.append(url)
+        self.yield_calls.append(kwargs)
+        assert self._stream_responses, "no more fake stream responses queued"
+        item = self._stream_responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        yield item
+
+
+def _cert_verification_error():
+    """An HTTPException as mureq wraps a TLS trust-store failure, i.e. with
+    the original ssl.SSLCertVerificationError preserved as __cause__."""
+    exc = HTTPException("certificate verify failed")
+    exc.__cause__ = ssl.SSLCertVerificationError(
+        "unable to get local issuer certificate"
+    )
+    return exc
+
+
+class TestCertVerificationFallback:
+    """`get_with_cert_fallback`/`_yield_response_with_cert_fallback` retry
+    once against the vendored CA bundle when the OS trust store is missing a
+    root CA (issue #132), but must not mask unrelated HTTPExceptions."""
+
+    @pytest.fixture
+    def fallback_context(self, monkeypatch):
+        sentinel = object()
+        monkeypatch.setattr(download_infra, "_fallback_ssl_context", lambda: sentinel)
+        return sentinel
+
+    def test_get_retries_with_fallback_context_on_cert_error(
+        self, monkeypatch, fallback_context
+    ):
+        fake_request = _FakeMureq(
+            get_responses=[
+                _cert_verification_error(),
+                _FakeResponse(status=200, json_data={"ok": True}),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        result = download_infra.get_with_cert_fallback(
+            "https://example.com/voices.json"
+        )
+
+        assert result.json() == {"ok": True}
+        assert len(fake_request.get_calls) == 2
+        assert "ssl_context" not in fake_request.get_calls[0]
+        assert fake_request.get_calls[1]["ssl_context"] is fallback_context
+
+    def test_get_does_not_retry_on_unrelated_http_exception(self, monkeypatch):
+        fake_request = _FakeMureq(get_responses=[HTTPException("connection reset")])
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with pytest.raises(HTTPException, match="connection reset"):
+            download_infra.get_with_cert_fallback("https://example.com/voices.json")
+
+        assert len(fake_request.get_calls) == 1
+
+    def test_yield_response_retries_with_fallback_context_on_cert_error(
+        self, monkeypatch, fallback_context
+    ):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _cert_verification_error(),
+                _FakeResponse(status=200, body=b"voice-bytes"),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with download_infra._yield_response_with_cert_fallback(
+            "GET", "https://example.com/voice.onnx"
+        ) as response:
+            assert response.read() == b"voice-bytes"
+
+        assert len(fake_request.yield_calls) == 2
+        assert "ssl_context" not in fake_request.yield_calls[0]
+        assert fake_request.yield_calls[1]["ssl_context"] is fallback_context
+
+    def test_yield_response_does_not_retry_on_unrelated_http_exception(
+        self, monkeypatch
+    ):
+        fake_request = _FakeMureq(stream_responses=[HTTPException("connection reset")])
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with (
+            pytest.raises(HTTPException, match="connection reset"),
+            download_infra._yield_response_with_cert_fallback(
+                "GET", "https://example.com/voice.onnx"
+            ),
+        ):
+            pass
+
+        assert len(fake_request.yield_calls) == 1
+
+    def test_fallback_ssl_context_loads_the_vendored_cacert_bundle(self):
+        download_infra._fallback_ssl_context.cache_clear()
+        context = download_infra._fallback_ssl_context()
+        assert isinstance(context, ssl.SSLContext)
+
+
+class TestResumablePartialSize:
+    """`resumable_partial_size` decides whether a leftover file from a
+    previous attempt is safe to resume from (issue #167)."""
+
+    def test_returns_zero_when_no_partial_exists(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        assert download_infra.resumable_partial_size(str(target), 100) == 0
+
+    def test_returns_existing_size_when_smaller_than_expected(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"x" * 40)
+        assert download_infra.resumable_partial_size(str(target), 100) == 40
+
+    def test_discards_a_partial_at_or_past_the_expected_size(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"x" * 100)
+        assert download_infra.resumable_partial_size(str(target), 100) == 0
+
+    def test_resumes_regardless_of_size_when_expected_size_is_unknown(self, tmp_path):
+        target = tmp_path / "voice.tar.gz"
+        target.write_bytes(b"x" * 100)
+        assert download_infra.resumable_partial_size(str(target), 0) == 100
+
+
+class TestStreamToFileResume:
+    """`stream_to_file` appends to a partial file when the server honors the
+    Range request (206), and restarts from scratch when it doesn't (issue #167)."""
+
+    def test_appends_and_extends_the_hash_when_the_server_sends_206(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"already-")
+        response = _FakeResponse(status=206, body=b"downloaded")
+        hasher = hashlib.md5(usedforsecurity=False)
+
+        download_infra.stream_to_file(
+            response, str(target), 18, MagicMock(), hasher, resume_offset=8
+        )
+
+        assert target.read_bytes() == b"already-downloaded"
+        assert hasher.hexdigest() == hashlib.md5(b"already-downloaded").hexdigest()
+
+    def test_overwrites_from_scratch_when_the_server_ignores_the_range(self, tmp_path):
+        target = tmp_path / "voice.onnx"
+        target.write_bytes(b"stale-partial-bytes")
+        response = _FakeResponse(status=200, body=b"full-body")
+        hasher = hashlib.md5(usedforsecurity=False)
+
+        download_infra.stream_to_file(
+            response, str(target), 9, MagicMock(), hasher, resume_offset=20
+        )
+
+        assert target.read_bytes() == b"full-body"
+        assert hasher.hexdigest() == hashlib.md5(b"full-body").hexdigest()
+
+
+class TestFollowRedirectsRangeSupport:
+    """`follow_redirects` forwards a Range header for resumed downloads and
+    accepts 206 Partial Content as a terminal (non-redirect) status (issue #167)."""
+
+    def test_forwards_headers_to_the_underlying_request(self, monkeypatch):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=b"rest-of-file",
+                ),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with download_infra.follow_redirects(
+            "https://example.com/voice.onnx",
+            "voice.onnx",
+            headers={"Range": "bytes=8-"},
+        ) as response:
+            assert response.read() == b"rest-of-file"
+
+        assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=8-"}
+
+    def test_accepts_206_as_a_terminal_status(self, monkeypatch):
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(
+                    status=206,
+                    headers={"Content-Type": "application/octet-stream"},
+                    body=b"rest-of-file",
+                ),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with download_infra.follow_redirects(
+            "https://example.com/voice.onnx", "voice.onnx"
+        ) as response:
+            assert response.status == 206

--- a/tests/test_download_infra.py
+++ b/tests/test_download_infra.py
@@ -206,6 +206,29 @@ class TestResumablePartialSize:
         assert download_infra.resumable_partial_size(str(target), 0) == 100
 
 
+class TestArchiveTotalSize:
+    """`archive_total_size` derives the full archive size from a response
+    that may itself be a resumed (206) request."""
+
+    def test_returns_content_length_for_a_fresh_200(self):
+        response = _FakeResponse(status=200, headers={"Content-Length": "1234"})
+        assert download_infra.archive_total_size(response) == 1234
+
+    def test_parses_the_total_from_a_206_content_range(self):
+        response = _FakeResponse(
+            status=206, headers={"Content-Range": "bytes 500-999/1234"}
+        )
+        assert download_infra.archive_total_size(response) == 1234
+
+    def test_returns_zero_for_an_unparseable_206_content_range(self):
+        response = _FakeResponse(status=206, headers={"Content-Range": "bytes */1234x"})
+        assert download_infra.archive_total_size(response) == 0
+
+    def test_returns_zero_when_a_206_omits_content_range(self):
+        response = _FakeResponse(status=206, headers={})
+        assert download_infra.archive_total_size(response) == 0
+
+
 class TestStreamToFileResume:
     """`stream_to_file` appends to a partial file when the server honors the
     Range request (206), and restarts from scratch when it doesn't (issue #167)."""

--- a/tests/test_driver_lifecycle.py
+++ b/tests/test_driver_lifecycle.py
@@ -25,7 +25,7 @@ _GRPC_CLIENT_PATH = os.path.join(_PKG_DIR, "adapters", "dengjen_grpc", "__init__
 _SHIM_INIT_PATH = os.path.join(_PKG_DIR, "__init__.py")
 _SYNTH_DRIVER_PATH = os.path.join(_PKG_DIR, "adapters", "nvda", "synth_driver.py")
 
-_LOOP_THREAD_NAME = "piper4nvda_asyncio"
+_LOOP_THREAD_NAME = "dengjen_asyncio"
 
 
 def _load_module_function(path, name, namespace):

--- a/tests/test_install_tasks.py
+++ b/tests/test_install_tasks.py
@@ -79,7 +79,7 @@ class TestModulePaths:
 
     def test_private_path_temporaries_are_cleaned_off_the_module(self):
         assert not hasattr(install_tasks, "_DIR")
-        assert not hasattr(install_tasks, "_PIPER_SYNTH_DIR")
+        assert not hasattr(install_tasks, "_SYNTH_DRIVER_DIR")
 
 
 class TestForceKillDengjenGrpcServer:

--- a/tests/test_kokoro_download.py
+++ b/tests/test_kokoro_download.py
@@ -1,8 +1,8 @@
 """
 Tests for kokoro_download.py: generates the exact config.json dengjen-tts's
 kokoro::config::load_config expects, and drives the download/install via the
-existing _BaseVoiceDownloader machinery. Network is never exercised here --
-_do_download_file/_stream_to_file are exercised by voice_download.py's own
+existing BaseVoiceDownloader machinery. Network is never exercised here --
+_do_download_file/stream_to_file are exercised by voice_download.py's own
 tests already; these tests cover kokoro_download.py's own logic only.
 """
 
@@ -108,7 +108,7 @@ class TestKokoroVoiceDownloaderInstall:
             },
         }
 
-        with pytest.raises(kokoro_download._VoiceInstallError):
+        with pytest.raises(kokoro_download.VoiceInstallError):
             downloader._install(result)
 
         install_dir = tmp_path / "kokoro-multilingual"

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -18,11 +18,10 @@ import hashlib
 import io
 import json
 import os
-import ssl
+import sys
 import tarfile
 from concurrent.futures import Future
 from contextlib import contextmanager
-from http.client import HTTPException
 from unittest.mock import MagicMock
 
 import addonHandler
@@ -38,6 +37,10 @@ voice_download = load_module_from_path(
     os.path.join(GLOBAL_PLUGIN_PKG_DIR, "voice_download.py"),
     package="dengjen_tts_global_plugin",
 )
+# voice_download's own `from .download_infra import ...` already resolved
+# and cached the real submodule under this dotted name; loading a second,
+# differently-named copy here would make it unreachable via monkeypatch.
+download_infra = sys.modules["dengjen_tts_global_plugin.download_infra"]
 
 PiperVoice = voice_download.PiperVoice
 PiperVoiceFile = voice_download.PiperVoiceFile
@@ -513,7 +516,7 @@ class TestVoicesCache:
     ):
         cache_path.write_text(json.dumps({}), encoding="utf-8")
         fake_request = _FakeMureq()
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         monkeypatch.setattr(
             voice_download.DengjenTextToSpeechSystem,
             "load_piper_voices_from_nvda_config_dir",
@@ -551,7 +554,7 @@ class TestVoicesCache:
                 _FakeResponse(status=200, json_data=rt_payload),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         monkeypatch.setattr(
             voice_download.DengjenTextToSpeechSystem,
             "load_piper_voices_from_nvda_config_dir",
@@ -573,7 +576,7 @@ class TestVoicesCache:
 
     def _offline_request(self, monkeypatch):
         fake_request = _FakeMureq(get_responses=[RuntimeError("network down")])
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         return fake_request
 
     def _no_installed_voices(self, monkeypatch):
@@ -624,196 +627,6 @@ class TestVoicesCache:
             voice_download.get_available_voices(force_online=False)
 
 
-def _cert_verification_error():
-    """An HTTPException as mureq wraps a TLS trust-store failure, i.e. with
-    the original ssl.SSLCertVerificationError preserved as __cause__."""
-    exc = HTTPException("certificate verify failed")
-    exc.__cause__ = ssl.SSLCertVerificationError(
-        "unable to get local issuer certificate"
-    )
-    return exc
-
-
-class TestCertVerificationFallback:
-    """`_get_with_cert_fallback`/`_yield_response_with_cert_fallback` retry
-    once against the vendored CA bundle when the OS trust store is missing a
-    root CA (issue #132), but must not mask unrelated HTTPExceptions."""
-
-    @pytest.fixture
-    def fallback_context(self, monkeypatch):
-        sentinel = object()
-        monkeypatch.setattr(voice_download, "_fallback_ssl_context", lambda: sentinel)
-        return sentinel
-
-    def test_get_retries_with_fallback_context_on_cert_error(
-        self, monkeypatch, fallback_context
-    ):
-        fake_request = _FakeMureq(
-            get_responses=[
-                _cert_verification_error(),
-                _FakeResponse(status=200, json_data={"ok": True}),
-            ]
-        )
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        result = voice_download._get_with_cert_fallback(
-            "https://example.com/voices.json"
-        )
-
-        assert result.json() == {"ok": True}
-        assert len(fake_request.get_calls) == 2
-        assert "ssl_context" not in fake_request.get_calls[0]
-        assert fake_request.get_calls[1]["ssl_context"] is fallback_context
-
-    def test_get_does_not_retry_on_unrelated_http_exception(self, monkeypatch):
-        fake_request = _FakeMureq(get_responses=[HTTPException("connection reset")])
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        with pytest.raises(HTTPException, match="connection reset"):
-            voice_download._get_with_cert_fallback("https://example.com/voices.json")
-
-        assert len(fake_request.get_calls) == 1
-
-    def test_yield_response_retries_with_fallback_context_on_cert_error(
-        self, monkeypatch, fallback_context
-    ):
-        fake_request = _FakeMureq(
-            stream_responses=[
-                _cert_verification_error(),
-                _FakeResponse(status=200, body=b"voice-bytes"),
-            ]
-        )
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        with voice_download._yield_response_with_cert_fallback(
-            "GET", "https://example.com/voice.onnx"
-        ) as response:
-            assert response.read() == b"voice-bytes"
-
-        assert len(fake_request.yield_calls) == 2
-        assert "ssl_context" not in fake_request.yield_calls[0]
-        assert fake_request.yield_calls[1]["ssl_context"] is fallback_context
-
-    def test_yield_response_does_not_retry_on_unrelated_http_exception(
-        self, monkeypatch
-    ):
-        fake_request = _FakeMureq(stream_responses=[HTTPException("connection reset")])
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        with (
-            pytest.raises(HTTPException, match="connection reset"),
-            voice_download._yield_response_with_cert_fallback(
-                "GET", "https://example.com/voice.onnx"
-            ),
-        ):
-            pass
-
-        assert len(fake_request.yield_calls) == 1
-
-    def test_fallback_ssl_context_loads_the_vendored_cacert_bundle(self):
-        voice_download._fallback_ssl_context.cache_clear()
-        context = voice_download._fallback_ssl_context()
-        assert isinstance(context, ssl.SSLContext)
-
-
-class TestResumablePartialSize:
-    """`_resumable_partial_size` decides whether a leftover file from a
-    previous attempt is safe to resume from (issue #167)."""
-
-    def test_returns_zero_when_no_partial_exists(self, tmp_path):
-        target = tmp_path / "voice.onnx"
-        assert voice_download._resumable_partial_size(str(target), 100) == 0
-
-    def test_returns_existing_size_when_smaller_than_expected(self, tmp_path):
-        target = tmp_path / "voice.onnx"
-        target.write_bytes(b"x" * 40)
-        assert voice_download._resumable_partial_size(str(target), 100) == 40
-
-    def test_discards_a_partial_at_or_past_the_expected_size(self, tmp_path):
-        target = tmp_path / "voice.onnx"
-        target.write_bytes(b"x" * 100)
-        assert voice_download._resumable_partial_size(str(target), 100) == 0
-
-    def test_resumes_regardless_of_size_when_expected_size_is_unknown(self, tmp_path):
-        target = tmp_path / "voice.tar.gz"
-        target.write_bytes(b"x" * 100)
-        assert voice_download._resumable_partial_size(str(target), 0) == 100
-
-
-class TestStreamToFileResume:
-    """`_stream_to_file` appends to a partial file when the server honors the
-    Range request (206), and restarts from scratch when it doesn't (issue #167)."""
-
-    def test_appends_and_extends_the_hash_when_the_server_sends_206(self, tmp_path):
-        target = tmp_path / "voice.onnx"
-        target.write_bytes(b"already-")
-        response = _FakeResponse(status=206, body=b"downloaded")
-        hasher = hashlib.md5(usedforsecurity=False)
-
-        voice_download._stream_to_file(
-            response, str(target), 18, MagicMock(), hasher, resume_offset=8
-        )
-
-        assert target.read_bytes() == b"already-downloaded"
-        assert hasher.hexdigest() == hashlib.md5(b"already-downloaded").hexdigest()
-
-    def test_overwrites_from_scratch_when_the_server_ignores_the_range(self, tmp_path):
-        target = tmp_path / "voice.onnx"
-        target.write_bytes(b"stale-partial-bytes")
-        response = _FakeResponse(status=200, body=b"full-body")
-        hasher = hashlib.md5(usedforsecurity=False)
-
-        voice_download._stream_to_file(
-            response, str(target), 9, MagicMock(), hasher, resume_offset=20
-        )
-
-        assert target.read_bytes() == b"full-body"
-        assert hasher.hexdigest() == hashlib.md5(b"full-body").hexdigest()
-
-
-class TestFollowRedirectsRangeSupport:
-    """`_follow_redirects` forwards a Range header for resumed downloads and
-    accepts 206 Partial Content as a terminal (non-redirect) status (issue #167)."""
-
-    def test_forwards_headers_to_the_underlying_request(self, monkeypatch):
-        fake_request = _FakeMureq(
-            stream_responses=[
-                _FakeResponse(
-                    status=206,
-                    headers={"Content-Type": "application/octet-stream"},
-                    body=b"rest-of-file",
-                ),
-            ]
-        )
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        with voice_download._follow_redirects(
-            "https://example.com/voice.onnx",
-            "voice.onnx",
-            headers={"Range": "bytes=8-"},
-        ) as response:
-            assert response.read() == b"rest-of-file"
-
-        assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=8-"}
-
-    def test_accepts_206_as_a_terminal_status(self, monkeypatch):
-        fake_request = _FakeMureq(
-            stream_responses=[
-                _FakeResponse(
-                    status=206,
-                    headers={"Content-Type": "application/octet-stream"},
-                    body=b"rest-of-file",
-                ),
-            ]
-        )
-        monkeypatch.setattr(voice_download, "request", fake_request)
-
-        with voice_download._follow_redirects(
-            "https://example.com/voice.onnx", "voice.onnx"
-        ) as response:
-            assert response.status == 206
-
-
 class TestPiperVoiceDownloaderFileTransfer:
     """`_do_download_file` is where redirect/content-type/hash bugs would
     actually surface — HuggingFace serves every file through a redirect."""
@@ -836,7 +649,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(body)
         result_file, target, digest = PiperVoiceDownloader._do_download_file(
             file, str(tmp_path), MagicMock()
@@ -860,7 +673,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(body)
         __, target, __ = PiperVoiceDownloader._do_download_file(
             file, str(tmp_path), MagicMock()
@@ -874,9 +687,9 @@ class TestPiperVoiceDownloaderFileTransfer:
             status=302, headers={"Location": "https://example.com/again"}
         )
         fake_request = _FakeMureq(
-            stream_responses=[redirect] * voice_download.REDIRECT_LIMIT
+            stream_responses=[redirect] * download_infra.REDIRECT_LIMIT
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
         with pytest.raises(RuntimeError, match="Too many redirects"):
@@ -886,7 +699,7 @@ class TestPiperVoiceDownloaderFileTransfer:
         fake_request = _FakeMureq(
             stream_responses=[_FakeResponse(status=302, headers={})]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
         with pytest.raises(ValueError, match="Redirect without Location header"):
@@ -900,7 +713,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
         with pytest.raises(RuntimeError, match="Wrong content-type"):
@@ -908,7 +721,7 @@ class TestPiperVoiceDownloaderFileTransfer:
 
     def test_raises_on_non_redirect_error_status(self, tmp_path, monkeypatch):
         fake_request = _FakeMureq(stream_responses=[_FakeResponse(status=404)])
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(b"x")
         callback = MagicMock()
         with pytest.raises(RuntimeError, match="Download failed"):
@@ -931,7 +744,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(body)
 
         __, target, digest = PiperVoiceDownloader._do_download_file(
@@ -959,7 +772,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         file = self._file(body)
 
         __, target, digest = PiperVoiceDownloader._do_download_file(
@@ -991,7 +804,7 @@ class TestPiperVoiceDownloaderFileTransfer:
                 for b in bodies
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         voice = _piper_voice(files=files)
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
         downloader.progress_dialog = MagicMock()
@@ -1009,6 +822,7 @@ class TestBaseVoiceDownloaderDownloadDir:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         voice = _piper_voice(key="en_US-lessac-medium")
 
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1022,6 +836,7 @@ class TestBaseVoiceDownloaderDownloadDir:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
         downloader.progress_dialog = MagicMock()
@@ -1055,12 +870,13 @@ class TestPiperVoiceDownloaderDoneCallback:
     def test_success_copies_files_and_offers_a_restart(self, tmp_path, monkeypatch):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
-        monkeypatch.setattr(voice_download.wx, "YES", "YES")
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra.wx, "YES", "YES")
         monkeypatch.setattr(
-            voice_download.gui, "messageBox", MagicMock(return_value="YES")
+            download_infra.gui, "messageBox", MagicMock(return_value="YES")
         )
         restart_mock = MagicMock()
-        monkeypatch.setattr(voice_download.core, "restart", restart_mock)
+        monkeypatch.setattr(download_infra.core, "restart", restart_mock)
 
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1079,8 +895,9 @@ class TestPiperVoiceDownloaderDoneCallback:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
 
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1100,7 +917,8 @@ class TestPiperVoiceDownloaderDoneCallback:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
-        monkeypatch.setattr(voice_download.gui, "messageBox", MagicMock())
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra.gui, "messageBox", MagicMock())
 
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1135,11 +953,12 @@ class TestPiperVoiceDownloaderDoneCallback:
     def test_copy_failure_reports_failure_without_crashing(self, tmp_path, monkeypatch):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         monkeypatch.setattr(
             voice_download.shutil, "copy", MagicMock(side_effect=OSError("disk full"))
         )
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
 
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1156,8 +975,9 @@ class TestPiperVoiceDownloaderDoneCallback:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
 
         voice = _piper_voice(key="en_US-lessac-medium")
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
@@ -1166,6 +986,30 @@ class TestPiperVoiceDownloaderDoneCallback:
         downloader.done_callback(RuntimeError("network exploded"))
 
         assert not (voices_dir / "en_US-lessac-medium").exists()
+        downloader.success_callback.assert_not_called()
+        messagebox_mock.assert_called_once()
+
+    def test_install_error_other_than_voice_install_error_is_still_reported(
+        self, tmp_path, monkeypatch
+    ):
+        voices_dir = tmp_path / "voices"
+        monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(
+            voice_download.Path, "mkdir", MagicMock(side_effect=OSError("disk full"))
+        )
+        messagebox_mock = MagicMock()
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
+
+        voice = _piper_voice(key="en_US-lessac-medium")
+        downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
+        downloader.progress_dialog = MagicMock()
+        file, src, digest = self._downloaded(tmp_path, b"model-bytes")
+
+        # _install's voice_dir.mkdir() is unwrapped, so a raw OSError there
+        # used to escape done_callback's `except VoiceInstallError` entirely.
+        downloader.done_callback([(file, src, digest)])
+
         downloader.success_callback.assert_not_called()
         messagebox_mock.assert_called_once()
 
@@ -1186,7 +1030,7 @@ class TestPiperRTVoiceDownloader:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         target, expected_size = PiperRTVoiceDownloader._do_download_archive(
             "https://example.com/voice.tar.gz",
             "voice.tar.gz",
@@ -1214,7 +1058,7 @@ class TestPiperRTVoiceDownloader:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
 
         target, expected_size = PiperRTVoiceDownloader._do_download_archive(
             "https://example.com/voice.tar.gz",
@@ -1228,17 +1072,74 @@ class TestPiperRTVoiceDownloader:
         assert expected_size == len(already) + len(rest)
         assert fake_request.yield_calls[0]["headers"] == {"Range": "bytes=8-"}
 
+    def test_do_download_archive_restarts_from_scratch_on_416_from_a_stale_leftover(
+        self, tmp_path, monkeypatch
+    ):
+        stale = b"already-complete-archive"
+        (tmp_path / "voice.tar.gz").write_bytes(stale)
+        full_body = b"fresh-archive-bytes"
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(status=416, headers={}, body=b""),
+                _FakeResponse(
+                    status=200,
+                    headers={"Content-Length": str(len(full_body))},
+                    body=full_body,
+                ),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        target, expected_size = PiperRTVoiceDownloader._do_download_archive(
+            "https://example.com/voice.tar.gz",
+            "voice.tar.gz",
+            str(tmp_path),
+            MagicMock(),
+        )
+
+        with open(target, "rb") as f:
+            assert f.read() == full_body
+        assert expected_size == len(full_body)
+        assert fake_request.yield_calls[0]["headers"] == {
+            "Range": f"bytes={len(stale)}-"
+        }
+        assert not fake_request.yield_calls[1].get("headers")
+
+    def test_do_download_archive_reraises_a_non_416_failure_without_deleting(
+        self, tmp_path, monkeypatch
+    ):
+        leftover = b"partial-bytes"
+        target_path = tmp_path / "voice.tar.gz"
+        target_path.write_bytes(leftover)
+        fake_request = _FakeMureq(
+            stream_responses=[
+                _FakeResponse(status=500, headers={}, body=b""),
+            ]
+        )
+        monkeypatch.setattr(download_infra, "request", fake_request)
+
+        with pytest.raises(RuntimeError, match=r"\(status 500\)"):
+            PiperRTVoiceDownloader._do_download_archive(
+                "https://example.com/voice.tar.gz",
+                "voice.tar.gz",
+                str(tmp_path),
+                MagicMock(),
+            )
+
+        assert target_path.read_bytes() == leftover
+
     def test_success_installs_the_archive_and_offers_a_restart(
         self, tmp_path, monkeypatch
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
-        monkeypatch.setattr(voice_download.wx, "YES", "YES")
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra.wx, "YES", "YES")
         monkeypatch.setattr(
-            voice_download.gui, "messageBox", MagicMock(return_value="YES")
+            download_infra.gui, "messageBox", MagicMock(return_value="YES")
         )
         restart_mock = MagicMock()
-        monkeypatch.setattr(voice_download.core, "restart", restart_mock)
+        monkeypatch.setattr(download_infra.core, "restart", restart_mock)
 
         tar_path = _make_tar(
             tmp_path,
@@ -1266,8 +1167,9 @@ class TestPiperRTVoiceDownloader:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
 
         not_a_tar = tmp_path / "corrupt.tar.gz"
         not_a_tar.write_bytes(b"not actually a tar file")
@@ -1286,8 +1188,9 @@ class TestPiperRTVoiceDownloader:
     ):
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
 
         archive = tmp_path / "truncated.tar.gz"
         archive.write_bytes(b"only-part-of-the-archive")
@@ -1319,19 +1222,19 @@ class _SyncExecutor:
 
 class TestDownloadWiresProgressDialogToInstall:
     """`.download()`, `_progress_title`, `_success_message`, and
-    `_failure_message` are the shared _BaseVoiceDownloader machinery neither
+    `_failure_message` are the shared BaseVoiceDownloader machinery neither
     class's other tests exercise -- those go through done_callback()/
     download_voice_files()/download_voice_archive() directly instead."""
 
     @pytest.fixture
     def sync_executor(self, monkeypatch):
-        monkeypatch.setattr(voice_download, "THREAD_POOL_EXECUTOR", _SyncExecutor())
+        monkeypatch.setattr(download_infra, "THREAD_POOL_EXECUTOR", _SyncExecutor())
 
     @pytest.fixture
     def progress_dialog(self, monkeypatch):
         instance = MagicMock()
         dialog_cls = MagicMock(return_value=instance)
-        monkeypatch.setattr(voice_download.wx, "ProgressDialog", dialog_cls)
+        monkeypatch.setattr(download_infra.wx, "ProgressDialog", dialog_cls)
         return dialog_cls, instance
 
     def test_standard_download_uses_the_voice_progress_title_and_installs(
@@ -1340,6 +1243,7 @@ class TestDownloadWiresProgressDialogToInstall:
         dialog_cls, __ = progress_dialog
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         body = b"model-bytes"
         file = PiperVoiceFile(
             file_path="en/en_US-lessac-medium.onnx",
@@ -1355,7 +1259,7 @@ class TestDownloadWiresProgressDialogToInstall:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         voice = _piper_voice(key="en_US-lessac-medium", files=[file])
         downloader = PiperVoiceDownloader(voice, success_callback=MagicMock())
 
@@ -1375,6 +1279,7 @@ class TestDownloadWiresProgressDialogToInstall:
         dialog_cls, __ = progress_dialog
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         tar_path = _make_tar(
             tmp_path,
             "en_US-lessac-medium.tar.gz",
@@ -1391,7 +1296,7 @@ class TestDownloadWiresProgressDialogToInstall:
                 ),
             ]
         )
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
         voice = _piper_voice(key="en_US-lessac-medium", has_rt_variant=True)
         downloader = PiperRTVoiceDownloader(voice, success_callback=MagicMock())
 
@@ -1413,10 +1318,11 @@ class TestDownloadWiresProgressDialogToInstall:
 
         voices_dir = tmp_path / "voices"
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(voices_dir))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(voices_dir))
         messagebox_mock = MagicMock()
-        monkeypatch.setattr(voice_download.gui, "messageBox", messagebox_mock)
+        monkeypatch.setattr(download_infra.gui, "messageBox", messagebox_mock)
         fake_request = _FakeMureq(stream_responses=[_FakeResponse(status=404)])
-        monkeypatch.setattr(voice_download, "request", fake_request)
+        monkeypatch.setattr(download_infra, "request", fake_request)
 
         voice = _piper_voice(
             key="en_US-lessac-medium",
@@ -1441,6 +1347,7 @@ class TestDownloadWiresProgressDialogToInstall:
 class TestVoiceJsonSidecarWrittenOnInstall:
     def test_install_writes_voice_json_sidecar(self, tmp_path, monkeypatch):
         monkeypatch.setattr(voice_download, "DENGJEN_VOICES_DIR", str(tmp_path))
+        monkeypatch.setattr(download_infra, "DENGJEN_VOICES_DIR", str(tmp_path))
         language = PiperVoiceLanguage(
             code="en_US",
             family="English",

--- a/tests/test_voice_download.py
+++ b/tests/test_voice_download.py
@@ -1117,13 +1117,15 @@ class TestPiperRTVoiceDownloader:
             ]
         )
         monkeypatch.setattr(download_infra, "request", fake_request)
+        voices_dir = str(tmp_path)
+        progress_reporter = MagicMock()
 
         with pytest.raises(RuntimeError, match=r"\(status 500\)"):
             PiperRTVoiceDownloader._do_download_archive(
                 "https://example.com/voice.tar.gz",
                 "voice.tar.gz",
-                str(tmp_path),
-                MagicMock(),
+                voices_dir,
+                progress_reporter,
             )
 
         assert target_path.read_bytes() == leftover

--- a/tests_gui/conftest.py
+++ b/tests_gui/conftest.py
@@ -56,7 +56,7 @@ def sync_call_after(monkeypatch):
 
 
 class _SyncExecutor:
-    """Stand-in for voice_download.THREAD_POOL_EXECUTOR / aio.ENGINE.executor:
+    """Stand-in for download_infra.THREAD_POOL_EXECUTOR / aio.ENGINE.executor:
     runs the callable on the calling thread and hands back a settled Future, so
     done-callbacks are assertable inline."""
 

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -74,7 +74,7 @@ def offline(voice_manager, monkeypatch, sync_executor):
         voice_manager.voice_download, "get_available_voices", lambda **kw: []
     )
     monkeypatch.setattr(
-        voice_manager.voice_download, "THREAD_POOL_EXECUTOR", sync_executor
+        voice_manager.download_infra, "THREAD_POOL_EXECUTOR", sync_executor
     )
 
 
@@ -238,7 +238,7 @@ class TestOnlinePanelControls:
             fake_get_available_voices,
         )
         monkeypatch.setattr(
-            voice_manager.voice_download, "THREAD_POOL_EXECUTOR", sync_executor
+            voice_manager.download_infra, "THREAD_POOL_EXECUTOR", sync_executor
         )
 
         refresh_btn = _find_child_of_type(panel, wx.Button)
@@ -424,7 +424,7 @@ class TestNotebookPageChanged:
             fake_get_available_voices,
         )
         monkeypatch.setattr(
-            voice_manager.voice_download, "THREAD_POOL_EXECUTOR", sync_executor
+            voice_manager.download_infra, "THREAD_POOL_EXECUTOR", sync_executor
         )
         online_panel = dialog.notebookCtrl.GetPage(1)
 


### PR DESCRIPTION
Closes #139.

## Summary

Drops legacy "Piper"-branded internal naming from `addon/` now that Kokoro is a second backend, and pulls the download machinery `kokoro_download.py` was already reaching into `voice_download.py`'s private names for out into a shared `download_infra.py`.

## Changes

- `aio.py`: renamed the executor/event-loop thread names from `piper4nvda_*` to `dengjen_*`.
- `installTasks.py`: renamed `_PIPER_SYNTH_DIR` to `_SYNTH_DRIVER_DIR`.
- `domain/tts_system.py`: fixed the stale `"No Piper voices found"` exception message (never surfaced to users — reaches only the NVDA log).
- `voice_manager.py`: renamed `OnlineDengjenVoicesPanel` to `OnlinePiperVoicesPanel`, since it lists Piper's online catalog specifically and Kokoro now has its own tab; also fixed two stale references in `model_catalog.py`'s docstring/error message.
- New `download_infra.py`: extracted the backend-agnostic redirect-following, TLS trust-store-gap fallback, resumable disk streaming, and the shared `BaseVoiceDownloader` workflow out of `voice_download.py`. `voice_download.py` keeps only Piper-specific catalog/download code; `kokoro_download.py` and `voice_manager.py` import the shared pieces from `download_infra.py` instead of reaching into `voice_download.py`'s private names.
- `download_infra.py`'s cross-module API (`BaseVoiceDownloader`, `VoiceInstallError`, `follow_redirects`, `get_with_cert_fallback`, `stream_to_file`, `resumable_partial_size`, `archive_total_size`) is public — no leading underscore — since that's exactly what these names are for; the three names nothing outside this file uses stay private.
- Test coverage for the moved functions moved to a new `tests/test_download_infra.py`; the tests remaining in `tests/test_voice_download.py` had their `request`/`THREAD_POOL_EXECUTOR`/`DENGJEN_VOICES_DIR`/`gui`/`wx`/`core` monkeypatches retargeted, since Python resolves a function's globals against its defining module.
- Two pre-existing download-flow bugs CodeRabbit flagged against this diff, fixed with regression tests: `done_callback` now catches `Exception` (not just `VoiceInstallError`) from `_install`, since `PiperVoiceDownloader._install`'s unwrapped `voice_dir.mkdir()` could otherwise escape the worker-thread callback silently and leave the progress dialog stuck open; and `PiperRTVoiceDownloader._do_download_archive` now discards a stale, already-complete leftover archive and retries once from scratch instead of failing on a Range request past EOF (416).
- No persisted-state changes (on-disk `voices/piper/` path, config keys) and no other user-facing behavior changes.

## Test plan

- [x] `pytest` (isolated Python 3.13 venv — ambient repo Python is 3.14 and can't import the vendored protobuf lib): 481 passed, 17 skipped, 0 failures.
- [x] `ruff check` / `ruff format --check`: clean.
- [x] Repo-wide grep for residual `piper4nvda`, `_PIPER_SYNTH_DIR`, `OnlineDengjenVoicesPanel`, `"No Piper voices found"`: clean.
- [x] CI green (`test`, `e2e`, `test_matrix` on both `windows-latest`/`ubuntu-latest`, `Windows coverage`, `lint`, `build`, `Sonar`, `CodeQL`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable voice downloads with resumable transfers, redirect handling, and improved certificate compatibility.
  * Added clearer progress, success, and failure feedback during voice installation.
  * Expanded shared download support for Piper and Kokoro voices.
* **Improvements**
  * Improved recovery when interrupted downloads leave stale partial files.
  * Renamed the online voice panel to clarify that it provides Piper voices.
  * Updated user-facing messages to reflect support for multiple voice backends.
* **Tests**
  * Added coverage for download recovery, redirects, certificate fallback, and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->