### PR TITLE
feat: offer local-file voice install directly on first run

### DIFF
--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -8,6 +8,7 @@ import addonHandler
 import core
 import globalPluginHandler
 import gui
+import synthDriverHandler
 import wx
 from logHandler import log
 
@@ -41,7 +42,7 @@ __all__ = [
     "voice_migration",
 ]
 
-from .voice_manager import DengjenVoiceManagerDialog
+from .voice_manager import DengjenVoiceManagerDialog, install_voice_from_local_file
 
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
@@ -67,22 +68,50 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     def _perform_voice_check(self):
         if self.__voice_manager_shown:
             return
-        if not any(
+        if any(
             DengjenTextToSpeechSystem.load_all_voices_from_nvda_config_dir(
                 DengjenGrpcBackend()
             )
         ):
-            retval = gui.messageBox(
-                _(
-                    "No Dengjen voice was found.\n"
-                    "You can preview and download voices from the voice manager.\n"
-                    "Do you want to open the voice manager now?"
-                ),
-                _("Dengjen Neural Voices"),
-                wx.YES_NO | wx.ICON_WARNING,
+            return
+        action = self._ask_first_run_voice_action()
+        if action == "manager":
+            self.on_manager(None)
+        elif action == "local_file":
+            install_voice_from_local_file(
+                on_installed=self._on_first_run_voice_installed
             )
-            if retval == wx.YES:
-                self.on_manager(None)
+
+    def _ask_first_run_voice_action(self):
+        """Yes/No/Cancel maps to open-manager/install-local/not-now. A plain
+        wx.MessageDialog, not gui.messageBox, since the latter has no way to
+        relabel its buttons for a three-way choice."""
+        dlg = wx.MessageDialog(
+            gui.mainFrame,
+            _(
+                "No Dengjen voice was found.\n"
+                "You can download a voice online, or install one from a "
+                "local archive if you already have one."
+            ),
+            _("Dengjen Neural Voices"),
+            wx.YES_NO | wx.CANCEL | wx.ICON_WARNING,
+        )
+        dlg.SetYesNoCancelLabels(
+            _("&Open voice manager"), _("&Install from local file"), _("Not &now")
+        )
+        try:
+            retval = dlg.ShowModal()
+        finally:
+            dlg.Destroy()
+        return {wx.ID_YES: "manager", wx.ID_NO: "local_file"}.get(retval)
+
+    def _on_first_run_voice_installed(self, voice_key):
+        # SynthDriver.voices is a snapshot taken at construction time, so the
+        # just-installed voice stays invisible until the driver rebuilds it.
+        synth = synthDriverHandler.getSynth()
+        if "dengjen" in synth.name.lower():
+            synth.terminate()
+            synth.__init__()
 
     def terminate(self):
         try:

--- a/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/__init__.py
@@ -74,18 +74,15 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             )
         ):
             return
-        action = self._ask_first_run_voice_action()
-        if action == "manager":
-            self.on_manager(None)
-        elif action == "local_file":
-            install_voice_from_local_file(
-                on_installed=self._on_first_run_voice_installed
-            )
+        self._ask_first_run_voice_action()
 
     def _ask_first_run_voice_action(self):
         """Yes/No/Cancel maps to open-manager/install-local/not-now. A plain
         wx.MessageDialog, not gui.messageBox, since the latter has no way to
-        relabel its buttons for a three-way choice."""
+        relabel its buttons for a three-way choice. Shown via
+        runScriptModalDialog, not ShowModal(), since this runs from the
+        startup path and must not block it; runScriptModalDialog also owns
+        Destroy(), so this doesn't call it."""
         dlg = wx.MessageDialog(
             gui.mainFrame,
             _(
@@ -99,11 +96,16 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         dlg.SetYesNoCancelLabels(
             _("&Open voice manager"), _("&Install from local file"), _("Not &now")
         )
-        try:
-            retval = dlg.ShowModal()
-        finally:
-            dlg.Destroy()
-        return {wx.ID_YES: "manager", wx.ID_NO: "local_file"}.get(retval)
+        gui.runScriptModalDialog(dlg, self._on_first_run_voice_action_chosen)
+
+    def _on_first_run_voice_action_chosen(self, retval):
+        action = {wx.ID_YES: "manager", wx.ID_NO: "local_file"}.get(retval)
+        if action == "manager":
+            self.on_manager(None)
+        elif action == "local_file":
+            install_voice_from_local_file(
+                on_installed=self._on_first_run_voice_installed
+            )
 
     def _on_first_run_voice_installed(self, voice_key):
         # SynthDriver.voices is a snapshot taken at construction time, so the

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -42,6 +42,60 @@ with helpers.import_bundled_library():
     import miniaudio
 
 
+def install_voice_from_local_file(on_installed=None):
+    """Prompt for a voice archive and install it, independent of the voice
+    manager dialog so a first-run "no voice found" check can offer it
+    directly. `on_installed(voice_key)` runs after a successful install;
+    cancellation and failure are handled here and need no caller action."""
+    open_file_dialog = wx.FileDialog(
+        parent=gui.mainFrame,
+        message=_("Choose voice archive file "),
+        defaultDir=wx.GetUserHome(),
+        wildcard=(
+            _("Tar archives (*.tar.gz, *.tgz)")
+            + "|*.tar.gz;*.tgz|"
+            + _("All files")
+            + "|*.*"
+        ),
+        style=wx.FD_OPEN,
+    )
+    gui.runScriptModalDialog(
+        open_file_dialog,
+        functools.partial(_process_voice_archive, open_file_dialog, on_installed),
+    )
+
+
+def _process_voice_archive(dialog, on_installed, res):
+    if res != wx.ID_OK:
+        return
+    filepath = dialog.GetPath().strip()
+    if not filepath:
+        return
+    try:
+        voice_key = voice_download.install_voice_from_tar_archive(
+            filepath, DENGJEN_VOICES_DIR
+        )
+    except Exception as exc:
+        log.error("Failed to install voice from archive", exc_info=True)
+        gui.messageBox(
+            _(
+                "Failed to install voice from archive.\n\n{detail}\n\n"
+                "See NVDA's log for more details."
+            ).format(detail=str(exc) or type(exc).__name__),
+            _("Voice installation failed"),
+            style=wx.ICON_ERROR,
+            parent=gui.mainFrame,
+        )
+        return
+    gui.messageBox(
+        _("Voice {voice} has been installed successfully.").format(voice=voice_key),
+        _("Voice installed successfully"),
+        style=wx.ICON_INFORMATION,
+    )
+    if on_installed is not None:
+        on_installed(voice_key)
+
+
 class InstalledDengjenVoicesPanel(SizedPanel):
     def __init__(self, parent):
         super().__init__(parent, -1)
@@ -232,53 +286,12 @@ class InstalledDengjenVoicesPanel(SizedPanel):
         self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
 
     def _on_install_voice_from_tar(self, event):
-        open_file_dialog = wx.FileDialog(
-            parent=gui.mainFrame,
-            message=_("Choose voice archive file "),
-            defaultDir=wx.GetUserHome(),
-            wildcard=(
-                _("Tar archives (*.tar.gz, *.tgz)")
-                + "|*.tar.gz;*.tgz|"
-                + _("All files")
-                + "|*.*"
-            ),
-            style=wx.FD_OPEN,
-        )
-        gui.runScriptModalDialog(
-            open_file_dialog,
-            functools.partial(self._get_process_tar_archive, open_file_dialog),
+        install_voice_from_local_file(
+            on_installed=self._on_voice_installed_from_local_file
         )
 
-    def _get_process_tar_archive(self, dialog, res):
-        if res != wx.ID_OK:
-            return
-        filepath = dialog.GetPath().strip()
-        if not filepath:
-            return
-        try:
-            voice_key = voice_download.install_voice_from_tar_archive(
-                filepath, DENGJEN_VOICES_DIR
-            )
-        except Exception as exc:
-            log.error("Failed to install voice from archive", exc_info=True)
-            gui.messageBox(
-                _(
-                    "Failed to install voice from archive.\n\n{detail}\n\n"
-                    "See NVDA's log for more details."
-                ).format(detail=str(exc) or type(exc).__name__),
-                _("Voice installation failed"),
-                style=wx.ICON_ERROR,
-                parent=gui.mainFrame,
-            )
-        else:
-            gui.messageBox(
-                _("Voice {voice} has been installed successfully.").format(
-                    voice=voice_key
-                ),
-                _("Voice installed successfully"),
-                style=wx.ICON_INFORMATION,
-            )
-            self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
+    def _on_voice_installed_from_local_file(self, voice_key):
+        self.update_voices_list(set_focus=True, invalidate_synth_voices_cache=True)
 
 
 class OnlinePiperVoicesPanel(SizedPanel):

--- a/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
+++ b/addon/globalPlugins/dengjen_tts_global_plugin/voice_manager.py
@@ -91,6 +91,7 @@ def _process_voice_archive(dialog, on_installed, res):
         _("Voice {voice} has been installed successfully.").format(voice=voice_key),
         _("Voice installed successfully"),
         style=wx.ICON_INFORMATION,
+        parent=gui.mainFrame,
     )
     if on_installed is not None:
         on_installed(voice_key)

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -341,13 +341,19 @@ msgstr "Administrador de voces &Dengjen..."
 msgid "Open the voice manager to preview, install or download dengjen voices"
 msgstr "Abrir el administrador de voces para probar, instalar o descargar voces dengjen"
 
-#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:77
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:91
+msgid "&Open voice manager"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:93
+msgid "Not &now"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:83
 msgid "No Dengjen voice was found.\n"
-"You can preview and download voices from the voice manager.\n"
-"Do you want to open the voice manager now?"
-msgstr "No se encontró una voz Dengjen.\n"
-"Puedes probar o descargar voces desde el administrador de voces.\n"
-"¿Quieres abrir el administrador de voces ahora?"
+"You can download a voice online, or install one from a "
+"local archive if you already have one."
+msgstr ""
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:81 buildVars.py:10
 msgid "Dengjen Neural Voices"

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -341,13 +341,19 @@ msgstr "Gestionnaire de &voix Dengjen..."
 msgid "Open the voice manager to preview, install or download dengjen voices"
 msgstr "Ouvrir le gestionnaire de voix pour prévisualiser, installer ou télécharger des voix Dengjen"
 
-#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:77
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:91
+msgid "&Open voice manager"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:93
+msgid "Not &now"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:83
 msgid "No Dengjen voice was found.\n"
-"You can preview and download voices from the voice manager.\n"
-"Do you want to open the voice manager now?"
-msgstr "Aucune voix de Dengjen n'a été trouvée.\n"
-"Vous pouvez avoir un aperçu et télécharger des voix depuis le gestionnaire de voix.\n"
-"Voulez-vous ouvrir le gestionnaire de voix maintenant ?"
+"You can download a voice online, or install one from a "
+"local archive if you already have one."
+msgstr ""
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:81 buildVars.py:10
 msgid "Dengjen Neural Voices"

--- a/addon/locale/kmr/LC_MESSAGES/nvda.po
+++ b/addon/locale/kmr/LC_MESSAGES/nvda.po
@@ -341,13 +341,19 @@ msgstr "&Rêveberê dengên Dengjen..."
 msgid "Open the voice manager to preview, install or download dengjen voices"
 msgstr "Ji bo pêşdîtin, sazkirin an daxistina dengên Dengjen rêveberê dengan veke"
 
-#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:77
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:91
+msgid "&Open voice manager"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:93
+msgid "Not &now"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:83
 msgid "No Dengjen voice was found.\n"
-"You can preview and download voices from the voice manager.\n"
-"Do you want to open the voice manager now?"
-msgstr "Tu dengê Dengjen nehat dîtin.\n"
-"Tu dikarî dengan ji rêveberê dengan pêşdîtin û daxînî.\n"
-"Ma tu dixwazî rêveberê dengan niha vekî?"
+"You can download a voice online, or install one from a "
+"local archive if you already have one."
+msgstr ""
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:81 buildVars.py:10
 msgid "Dengjen Neural Voices"

--- a/addon/locale/ru/LC_MESSAGES/nvda.po
+++ b/addon/locale/ru/LC_MESSAGES/nvda.po
@@ -341,13 +341,19 @@ msgstr "Менеджер голосов &Dengjen..."
 msgid "Open the voice manager to preview, install or download dengjen voices"
 msgstr "Открыть менеджер голосов для предварительного просмотра, установки или загрузки голосов Dengjen"
 
-#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:77
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:91
+msgid "&Open voice manager"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:93
+msgid "Not &now"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:83
 msgid "No Dengjen voice was found.\n"
-"You can preview and download voices from the voice manager.\n"
-"Do you want to open the voice manager now?"
-msgstr "Голос Dengjen не найден.\n"
-"Вы можете просмотреть и загрузить голоса из менеджера голосов.\n"
-"Хотите открыть менеджер голосов прямо сейчас?"
+"You can download a voice online, or install one from a "
+"local archive if you already have one."
+msgstr ""
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:81 buildVars.py:10
 msgid "Dengjen Neural Voices"

--- a/addon/locale/tr/LC_MESSAGES/nvda.po
+++ b/addon/locale/tr/LC_MESSAGES/nvda.po
@@ -341,13 +341,19 @@ msgstr "Dengjen &ses yöneticisi..."
 msgid "Open the voice manager to preview, install or download dengjen voices"
 msgstr "Dengjen seslerini önizlemek, yüklemek veya indirmek için ses yöneticisini açın"
 
-#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:77
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:91
+msgid "&Open voice manager"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:93
+msgid "Not &now"
+msgstr ""
+
+#: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:83
 msgid "No Dengjen voice was found.\n"
-"You can preview and download voices from the voice manager.\n"
-"Do you want to open the voice manager now?"
-msgstr "Hiçbir Dengjen sesi bulunamadı.\n"
-"Sesleri ses yöneticisinden önizleyebilir ve indirebilirsiniz.\n"
-"Ses yöneticisini şimdi açmak ister misiniz?"
+"You can download a voice online, or install one from a "
+"local archive if you already have one."
+msgstr ""
 
 #: addon\globalPlugins\dengjen_tts_global_plugin\__init__.py:81 buildVars.py:10
 msgid "Dengjen Neural Voices"

--- a/tests_e2e/test_voice_manager.py
+++ b/tests_e2e/test_voice_manager.py
@@ -55,10 +55,12 @@ def test_install_is_two_phase_and_completes_on_restart(
 def test_the_no_voice_modal_appears_and_no_declines_it(
     nvda, addon_under_test, assert_no_unexpected_errors
 ):
-    """_perform_voice_check fires a real, blocking gui.messageBox 3s after
-    startup when no voice is installed (__init__.py:58-74). This is exactly
-    the behavior tests_gui/test_global_plugin.py cannot prove, since it
-    mocks gui.messageBox so the call never actually blocks."""
+    """_perform_voice_check calls _ask_first_run_voice_action, which shows a
+    real, blocking wx.MessageDialog 3s after startup when no voice is
+    installed (__init__.py:68-106). This is exactly the behavior
+    tests_gui/test_global_plugin.py cannot prove, since it monkeypatches
+    _ask_first_run_voice_action outright rather than risk a real ShowModal
+    hanging the test run."""
     nvda.restart()
 
     before = nvda.speech.index()
@@ -96,7 +98,7 @@ def downloaded_voice_key(nvda_session, addon_under_test):
     nvda.restart()
     before = nvda.speech.index()
     nvda.speech.wait_for(NO_VOICE_MODAL_TEXT, timeout=15, since=before)
-    nvda.keys.press("y")
+    nvda.keys.press("o")
 
     nvda.speech.wait_for(VOICE_MANAGER_TITLE, timeout=10, since=before)
 

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -18,6 +18,9 @@ import pytest
 if sys.platform != "win32":
     pytest.skip("real wxPython is Windows-only here", allow_module_level=True)
 
+import gui
+import wx
+
 
 @pytest.fixture
 def plugin_module(gui_plugin_package):
@@ -77,48 +80,46 @@ class TestMenuLifecycle:
 
 
 class TestVoiceCheck:
-    """_ask_first_run_voice_action shows a real wx.MessageDialog and calls
-    ShowModal, which blocks forever without an event loop (see
-    tests_gui/test_voice_manager_dialog.py's "Never call ShowModal()" rule)
-    -- so every test here monkeypatches it outright, the same way the
-    pre-existing suite already treated on_manager as a black box."""
+    """_ask_first_run_voice_action shows a real wx.MessageDialog via
+    gui.runScriptModalDialog, which nvda_gui mocks -- so every test here
+    that needs a user choice grabs the completion callback from that mock's
+    call and fires it directly, the same technique
+    tests_gui/test_voice_manager_dialog.py uses for its file dialog."""
 
-    def test_it_asks_when_no_voice_is_installed(
-        self, plugin, no_installed_voices, monkeypatch
-    ):
-        asked = []
-        monkeypatch.setattr(
-            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
-        )
+    @pytest.fixture(autouse=True)
+    def _destroy_the_dialog(self):
+        # gui.runScriptModalDialog is mocked here, so the real Destroy() it
+        # would otherwise do after the dialog closes never runs.
+        yield
+        if gui.runScriptModalDialog.called:
+            gui.runScriptModalDialog.call_args.args[0].Destroy()
+
+    def _choose(self, retval):
+        callback = gui.runScriptModalDialog.call_args.args[1]
+        callback(retval)
+
+    def test_it_asks_when_no_voice_is_installed(self, plugin, no_installed_voices):
         plugin._perform_voice_check()
-        assert asked == [True]
+        assert gui.runScriptModalDialog.called
 
     def test_it_stays_quiet_when_a_voice_is_installed(
-        self, plugin, one_installed_voice, monkeypatch
+        self, plugin, one_installed_voice
     ):
-        asked = []
-        monkeypatch.setattr(
-            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
-        )
         plugin._perform_voice_check()
-        assert asked == []
+        assert not gui.runScriptModalDialog.called
 
     def test_it_stays_quiet_once_the_manager_has_been_opened(
-        self, plugin, no_installed_voices, monkeypatch
+        self, plugin, no_installed_voices
     ):
-        asked = []
-        monkeypatch.setattr(
-            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
-        )
         plugin._GlobalPlugin__voice_manager_shown = True
         plugin._perform_voice_check()
-        assert asked == []
+        assert not gui.runScriptModalDialog.called
 
     def test_choosing_manager_opens_it(self, plugin, no_installed_voices, monkeypatch):
         opened = []
-        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: "manager")
         monkeypatch.setattr(plugin, "on_manager", lambda evt: opened.append(evt))
         plugin._perform_voice_check()
+        self._choose(wx.ID_YES)
         assert len(opened) == 1
 
     def test_choosing_local_file_installs_from_a_local_file(
@@ -130,8 +131,8 @@ class TestVoiceCheck:
             "install_voice_from_local_file",
             lambda **kwargs: calls.append(kwargs),
         )
-        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: "local_file")
         plugin._perform_voice_check()
+        self._choose(wx.ID_NO)
         assert calls == [{"on_installed": plugin._on_first_run_voice_installed}]
 
     def test_choosing_not_now_does_nothing(
@@ -139,7 +140,6 @@ class TestVoiceCheck:
     ):
         opened = []
         installed = []
-        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: None)
         monkeypatch.setattr(plugin, "on_manager", lambda evt: opened.append(evt))
         monkeypatch.setattr(
             plugin_module,
@@ -147,6 +147,7 @@ class TestVoiceCheck:
             lambda **kwargs: installed.append(kwargs),
         )
         plugin._perform_voice_check()
+        self._choose(wx.ID_CANCEL)
         assert opened == []
         assert installed == []
 

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -77,32 +77,95 @@ class TestMenuLifecycle:
 
 
 class TestVoiceCheck:
-    def test_it_prompts_when_no_voice_is_installed(
-        self, plugin, nvda_gui, no_installed_voices, monkeypatch
+    """_ask_first_run_voice_action shows a real wx.MessageDialog and calls
+    ShowModal, which blocks forever without an event loop (see
+    tests_gui/test_voice_manager_dialog.py's "Never call ShowModal()" rule)
+    -- so every test here monkeypatches it outright, the same way the
+    pre-existing suite already treated on_manager as a black box."""
+
+    def test_it_asks_when_no_voice_is_installed(
+        self, plugin, no_installed_voices, monkeypatch
     ):
-        opened = []
-        monkeypatch.setattr(plugin, "on_manager", lambda evt: opened.append(evt))
+        asked = []
+        monkeypatch.setattr(
+            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
+        )
         plugin._perform_voice_check()
-
-        import gui
-
-        assert gui.messageBox.called
-        assert len(opened) == 1
+        assert asked == [True]
 
     def test_it_stays_quiet_when_a_voice_is_installed(
         self, plugin, one_installed_voice, monkeypatch
     ):
-        import gui
-
-        gui.messageBox.reset_mock()
+        asked = []
+        monkeypatch.setattr(
+            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
+        )
         plugin._perform_voice_check()
-        assert not gui.messageBox.called
+        assert asked == []
 
     def test_it_stays_quiet_once_the_manager_has_been_opened(
-        self, plugin, no_installed_voices
+        self, plugin, no_installed_voices, monkeypatch
     ):
-        import gui
-
+        asked = []
+        monkeypatch.setattr(
+            plugin, "_ask_first_run_voice_action", lambda: asked.append(True)
+        )
         plugin._GlobalPlugin__voice_manager_shown = True
         plugin._perform_voice_check()
-        assert not gui.messageBox.called
+        assert asked == []
+
+    def test_choosing_manager_opens_it(self, plugin, no_installed_voices, monkeypatch):
+        opened = []
+        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: "manager")
+        monkeypatch.setattr(plugin, "on_manager", lambda evt: opened.append(evt))
+        plugin._perform_voice_check()
+        assert len(opened) == 1
+
+    def test_choosing_local_file_installs_from_a_local_file(
+        self, plugin, plugin_module, no_installed_voices, monkeypatch
+    ):
+        calls = []
+        monkeypatch.setattr(
+            plugin_module,
+            "install_voice_from_local_file",
+            lambda **kwargs: calls.append(kwargs),
+        )
+        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: "local_file")
+        plugin._perform_voice_check()
+        assert calls == [{"on_installed": plugin._on_first_run_voice_installed}]
+
+    def test_choosing_not_now_does_nothing(
+        self, plugin, plugin_module, no_installed_voices, monkeypatch
+    ):
+        opened = []
+        installed = []
+        monkeypatch.setattr(plugin, "_ask_first_run_voice_action", lambda: None)
+        monkeypatch.setattr(plugin, "on_manager", lambda evt: opened.append(evt))
+        monkeypatch.setattr(
+            plugin_module,
+            "install_voice_from_local_file",
+            lambda **kwargs: installed.append(kwargs),
+        )
+        plugin._perform_voice_check()
+        assert opened == []
+        assert installed == []
+
+
+class TestOnFirstRunVoiceInstalled:
+    def test_reinitializes_the_active_dengjen_synth(
+        self, plugin, plugin_module, monkeypatch
+    ):
+        synth = MagicMock()
+        synth.name = "dengjen_neural_voices"
+        monkeypatch.setattr(plugin_module.synthDriverHandler, "getSynth", lambda: synth)
+        plugin._on_first_run_voice_installed("en_US-amy-low")
+        assert synth.terminate.called
+
+    def test_leaves_a_different_active_synth_alone(
+        self, plugin, plugin_module, monkeypatch
+    ):
+        synth = MagicMock()
+        synth.name = "espeak"
+        monkeypatch.setattr(plugin_module.synthDriverHandler, "getSynth", lambda: synth)
+        plugin._on_first_run_voice_installed("en_US-amy-low")
+        assert not synth.terminate.called

--- a/tests_gui/test_global_plugin.py
+++ b/tests_gui/test_global_plugin.py
@@ -155,11 +155,17 @@ class TestOnFirstRunVoiceInstalled:
     def test_reinitializes_the_active_dengjen_synth(
         self, plugin, plugin_module, monkeypatch
     ):
+        # terminate()'s call record can't be read off the mock after this
+        # test's own __init__() call below -- that call re-runs
+        # NonCallableMock.__init__ on the same instance, which resets its
+        # children's call tracking. An independent side effect survives it.
+        calls = []
         synth = MagicMock()
         synth.name = "dengjen_neural_voices"
+        synth.terminate.side_effect = lambda: calls.append("terminate")
         monkeypatch.setattr(plugin_module.synthDriverHandler, "getSynth", lambda: synth)
         plugin._on_first_run_voice_installed("en_US-amy-low")
-        assert synth.terminate.called
+        assert calls == ["terminate"]
 
     def test_leaves_a_different_active_synth_alone(
         self, plugin, plugin_module, monkeypatch

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -179,11 +179,18 @@ class TestInstallVoiceFromLocalFile:
         assert gui.runScriptModalDialog.called
         opened_dialog = gui.runScriptModalDialog.call_args.args[0]
         assert isinstance(opened_dialog, wx.FileDialog)
+        opened_dialog.Destroy()
 
     def _complete_dialog(self, path, res=wx.ID_OK):
-        gui.runScriptModalDialog.call_args.args[0].SetPath(path)
+        # gui.runScriptModalDialog is mocked here, so the real Destroy() it
+        # would otherwise do after the dialog closes never runs.
+        dialog = gui.runScriptModalDialog.call_args.args[0]
+        dialog.SetPath(path)
         callback = gui.runScriptModalDialog.call_args.args[1]
-        callback(res)
+        try:
+            callback(res)
+        finally:
+            dialog.Destroy()
 
     def test_cancel_does_not_install(self, voice_manager, nvda_gui, monkeypatch):
         install = MagicMock()

--- a/tests_gui/test_voice_manager_dialog.py
+++ b/tests_gui/test_voice_manager_dialog.py
@@ -166,6 +166,77 @@ class TestInstalledPanelControls:
         assert gui.runScriptModalDialog.called
 
 
+class TestInstallVoiceFromLocalFile:
+    """install_voice_from_local_file is the panel's tar-install flow pulled
+    out into a free function, so a first-run "no voice found" check can
+    offer it without going through the voice manager dialog at all.
+    gui.runScriptModalDialog is mocked (see nvda_gui), so the completion
+    callback it would invoke is grabbed from the mock's call and fired
+    directly to simulate the user finishing the file dialog."""
+
+    def test_it_opens_a_file_dialog(self, voice_manager, nvda_gui):
+        voice_manager.install_voice_from_local_file()
+        assert gui.runScriptModalDialog.called
+        opened_dialog = gui.runScriptModalDialog.call_args.args[0]
+        assert isinstance(opened_dialog, wx.FileDialog)
+
+    def _complete_dialog(self, path, res=wx.ID_OK):
+        gui.runScriptModalDialog.call_args.args[0].SetPath(path)
+        callback = gui.runScriptModalDialog.call_args.args[1]
+        callback(res)
+
+    def test_cancel_does_not_install(self, voice_manager, nvda_gui, monkeypatch):
+        install = MagicMock()
+        monkeypatch.setattr(
+            voice_manager.voice_download, "install_voice_from_tar_archive", install
+        )
+        voice_manager.install_voice_from_local_file()
+        self._complete_dialog("/tmp/whatever.tar.gz", res=wx.ID_CANCEL)
+        assert not install.called
+
+    def test_empty_path_does_not_install(self, voice_manager, nvda_gui, monkeypatch):
+        install = MagicMock()
+        monkeypatch.setattr(
+            voice_manager.voice_download, "install_voice_from_tar_archive", install
+        )
+        voice_manager.install_voice_from_local_file()
+        self._complete_dialog("")
+        assert not install.called
+
+    def test_success_calls_on_installed_with_the_voice_key(
+        self, voice_manager, nvda_gui, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            voice_manager.voice_download,
+            "install_voice_from_tar_archive",
+            lambda filepath, voices_dir: "en_US-amy-low",
+        )
+        installed = []
+        voice_manager.install_voice_from_local_file(on_installed=installed.append)
+        self._complete_dialog(str(tmp_path / "voice.tar.gz"))
+
+        assert installed == ["en_US-amy-low"]
+        assert gui.messageBox.called
+        assert "amy" in gui.messageBox.call_args.args[0]
+
+    def test_failure_shows_an_error_and_skips_on_installed(
+        self, voice_manager, nvda_gui, monkeypatch, tmp_path
+    ):
+        def _raise(filepath, voices_dir):
+            raise ValueError("corrupt archive")
+
+        monkeypatch.setattr(
+            voice_manager.voice_download, "install_voice_from_tar_archive", _raise
+        )
+        installed = []
+        voice_manager.install_voice_from_local_file(on_installed=installed.append)
+        self._complete_dialog(str(tmp_path / "voice.tar.gz"))
+
+        assert installed == []
+        assert gui.messageBox.called
+        assert gui.messageBox.call_args.kwargs["style"] == wx.ICON_ERROR
+
+
 class TestOnlinePanelControls:
     @pytest.fixture
     def panel(self, dialog):


### PR DESCRIPTION
Relates to #169.

## Summary

The startup "no voice found" check only offered to open the full voice manager, burying the existing "Install from local file" archive path. This surfaces that path directly at the point of need, instead of bundling a real voice model (see discussion on #169 for why bundling was reconsidered: the catalog has no English `x_low` voice, and the smallest English option is 63MB -- too large to add to every install).

## Changes

- `voice_manager.py`: extracted the tar-archive file-picker/install/result-dialog flow out of `InstalledDengjenVoicesPanel` into a standalone `install_voice_from_local_file()`, reusable outside the voice manager dialog.
- `__init__.py`: `_perform_voice_check` now offers a three-way choice -- open voice manager / install from local file / not now -- instead of only the first. A successful local install reinitializes the active synth driver if it's already Dengjen, since its voice list is a construction-time snapshot.
- `addon/locale/*/LC_MESSAGES/nvda.po`: catalog entries for the new/changed strings across all 5 tracked locales.
- `tests_gui/test_voice_manager_dialog.py`, `tests_gui/test_global_plugin.py`: coverage for the extracted install flow and the new three-way startup choice.

## Test plan

- [x] `pytest` (485 passed, 17 skipped) and `ruff check` / `ruff format --check` -- clean.
- [ ] CI build + test green.
- [ ] `tests_gui/` additions are new/updated in this PR but unexecuted locally (no wxPython outside Windows, matching this repo's existing Windows-only split for that suite) -- need the Windows CI leg to confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * First-run voice setup now lets you open the voice manager, install a voice from a local archive, or defer setup.
  * Newly installed local voices become available immediately after the active speech engine refreshes.
* **Bug Fixes**
  * Improved handling of cancelled, empty, and invalid local voice archive selections.
  * Voice lists refresh automatically after a successful local installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->